### PR TITLE
fix(exec): add vsock timeout and fix init script for Debian images

### DIFF
--- a/cmd/api/api/api_test.go
+++ b/cmd/api/api/api_test.go
@@ -6,14 +6,17 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/onkernel/hypeman/cmd/api/config"
 	"github.com/onkernel/hypeman/lib/images"
 	"github.com/onkernel/hypeman/lib/instances"
 	"github.com/onkernel/hypeman/lib/network"
+	"github.com/onkernel/hypeman/lib/oapi"
 	"github.com/onkernel/hypeman/lib/paths"
 	"github.com/onkernel/hypeman/lib/system"
 	"github.com/onkernel/hypeman/lib/volumes"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestService creates an ApiService for testing with automatic cleanup
@@ -51,23 +54,23 @@ func newTestService(t *testing.T) *ApiService {
 func cleanupOrphanedProcesses(t *testing.T, dataDir string) {
 	p := paths.New(dataDir)
 	guestsDir := p.GuestsDir()
-	
+
 	entries, err := os.ReadDir(guestsDir)
 	if err != nil {
 		return // No guests directory
 	}
-	
+
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		
+
 		metaPath := p.InstanceMetadata(entry.Name())
 		data, err := os.ReadFile(metaPath)
 		if err != nil {
 			continue
 		}
-		
+
 		// Parse just the CHPID field
 		var meta struct {
 			CHPID *int `json:"CHPID"`
@@ -75,11 +78,11 @@ func cleanupOrphanedProcesses(t *testing.T, dataDir string) {
 		if err := json.Unmarshal(data, &meta); err != nil {
 			continue
 		}
-		
+
 		// If metadata has a PID, try to kill it
 		if meta.CHPID != nil {
 			pid := *meta.CHPID
-			
+
 			// Check if process exists
 			if err := syscall.Kill(pid, 0); err == nil {
 				t.Logf("Cleaning up orphaned Cloud Hypervisor process: PID %d", pid)
@@ -91,4 +94,47 @@ func cleanupOrphanedProcesses(t *testing.T, dataDir string) {
 
 func ctx() context.Context {
 	return context.Background()
+}
+
+// createAndWaitForImage creates an image and waits for it to be ready.
+// Returns the image name on success, or fails the test on error/timeout.
+func createAndWaitForImage(t *testing.T, svc *ApiService, imageName string, timeout time.Duration) string {
+	t.Helper()
+
+	t.Logf("Creating image %s...", imageName)
+	imgResp, err := svc.CreateImage(ctx(), oapi.CreateImageRequestObject{
+		Body: &oapi.CreateImageRequest{
+			Name: imageName,
+		},
+	})
+	require.NoError(t, err)
+
+	imgCreated, ok := imgResp.(oapi.CreateImage202JSONResponse)
+	require.True(t, ok, "expected 202 response for image creation")
+
+	t.Log("Waiting for image to be ready...")
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		imgResp, err := svc.GetImage(ctx(), oapi.GetImageRequestObject{
+			Name: imageName,
+		})
+		require.NoError(t, err)
+
+		img, ok := imgResp.(oapi.GetImage200JSONResponse)
+		if ok {
+			switch img.Status {
+			case "ready":
+				t.Log("Image is ready")
+				return imgCreated.Name
+			case "failed":
+				t.Fatalf("Image build failed: %v", img.Error)
+			default:
+				t.Logf("Image status: %s", img.Status)
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	t.Fatalf("Timeout waiting for image %s to be ready", imageName)
+	return ""
 }


### PR DESCRIPTION
## Problem

The `hypeman exec` command would hang indefinitely when connecting to an instance. Two separate issues were discovered:

### Issue 1: No timeout on vsock connection

In `lib/exec/client.go`, the vsock dialer had no timeout on `net.Dial` or the handshake `ReadString`. If exec-agent wasn't running (or vsock wasn't working), the connection would block forever.

### Issue 2: exec-agent never started (discovered via logs)

Running `./hypeman logs <instance>` on a Debian 12 instance revealed the real problem:

```
+ chroot /overlay/newroot ip link set lo up
chroot: can't execute 'ip': No such file or directory
[    0.732925] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00007f00
```

The init script was failing because:
1. **Network config used container's `ip` command** - Debian 12 minimal images don't have `iproute2` installed, so `chroot ... ip` failed
2. **Init exited after app exited** - When bash (the entrypoint) exited immediately (not interactive), the init script exited, causing a kernel panic before exec-agent could start

## Solution

### Fix 1: Add timeout to vsock connection (`lib/exec/client.go`)

- Add 5-second timeout on vsock Unix socket dial
- Add 5-second deadline on Cloud Hypervisor vsock handshake
- Create `bufferedConn` wrapper to prevent data loss from `bufio.Reader`
- Improve error message to suggest checking if exec-agent is running

### Fix 2: Fix init script (`lib/system/init_script.go`)

- **Use initrd's `ip` command** - Run network commands from initrd (which has busybox) instead of chroot, since network interfaces are shared
- **Keep init alive with `wait`** - After the app exits, call `wait` to block on all background jobs (exec-agent runs forever)

---

## ⚠️ Open Question: VM behavior when main app exits

The `wait` fix keeps init alive so exec-agent continues running, but this changes the VM lifecycle behavior:

| Behavior | Pros | Cons |
|----------|------|------|
| **Exit when app exits** (old) | Matches Docker semantics (container stops when PID 1 exits) | Kills exec-agent, can't exec into crashed app to debug |
| **Stay alive** (current fix) | Can exec into VM after app crash to debug; exit code still visible in `hypeman logs` | VM doesn't auto-terminate, may be unexpected |

**Current behavior:** VM stays alive, exit code logged to console. Users can see `overlay-init: app exited with code X` in `hypeman logs`.

**Question for reviewers:** Is this the right default? Should we add a flag to control this behavior?

---

## Testing

```bash
# Start the server
make dev

# In another terminal, create a Debian 12 instance
./hypeman run --name test-debian debian:12

# Test exec
./hypeman exec test-debian -- echo 'hello from guest'
./hypeman exec test-debian -- uname -a
./hypeman exec test-debian -- cat /etc/os-release

# Interactive shell
./hypeman exec -it test-debian
```

### Before fix:
```
./hypeman exec test-debian -- echo hello
# Hangs forever (or times out after 5s with first fix only)
```

### After fix:
```
./hypeman exec test-debian -- echo hello
hello
```