### PR TITLE
Fix hanging on exec for missing command

### DIFF
--- a/cmd/api/api/exec.go
+++ b/cmd/api/api/exec.go
@@ -138,7 +138,11 @@ func (s *ApiService) ExecHandler(w http.ResponseWriter, r *http.Request) {
 			"duration_ms", duration.Milliseconds(),
 		)
 		// Send error message over WebSocket before closing
-		ws.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("Error: %v", err)))
+		// Use BinaryMessage so the CLI writes it to stdout (it ignores TextMessage for output)
+		// Use \r\n so it displays properly when client terminal is in raw mode
+		ws.WriteMessage(websocket.BinaryMessage, []byte(fmt.Sprintf("Error: %v\r\n", err)))
+		// Send exit code 127 (command not found - standard Unix convention)
+		ws.WriteMessage(websocket.TextMessage, []byte(`{"exitCode":127}`))
 		return
 	}
 
@@ -199,4 +203,3 @@ func (w *wsReadWriter) Write(p []byte) (n int, err error) {
 	}
 	return len(p), nil
 }
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents hangs when a command is missing by sending binary error output and a JSON exitCode=127 over WebSocket, improving client close handling, and adding regression tests.
> 
> - **Exec API (`cmd/api/api/exec.go`)**:
>   - On exec error, write binary error output with `\r\n` and send JSON `{"exitCode":127}` via text message.
>   - Clarify message types/comments; keep stdout binary streaming via `wsReadWriter`.
> - **CLI (`cmd/exec/main.go`)**:
>   - In interactive mode, treat unexpected WebSocket closes as errors; normal closes default to exit code 0.
>   - Non-interactive path: minor close-handling tidy-up; continues to parse `{"exitCode":...}` messages.
> - **Tests (`lib/instances/exec_test.go`)**:
>   - Add regression tests ensuring non-existent commands fail quickly (TTY and non-TTY) without hanging and report "executable file not found".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a93f85438559a34377d70a28017562be92b6bb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->