### PR TITLE
fix: allocate fresh network on start VM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Clean cached binaries
+        run: make clean
+
       - name: Build
         run: make build
      

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: oapi-generate generate-vmm-client generate-wire generate-all dev build test install-tools gen-jwt download-ch-binaries download-ch-spec ensure-ch-binaries build-caddy-binaries build-caddy ensure-caddy-binaries release-prep
+.PHONY: oapi-generate generate-vmm-client generate-wire generate-all dev build test install-tools gen-jwt download-ch-binaries download-ch-spec ensure-ch-binaries build-caddy-binaries build-caddy ensure-caddy-binaries release-prep clean
 
 # Directory where local binaries will be installed
 BIN_DIR ?= $(CURDIR)/bin
@@ -192,10 +192,8 @@ gen-jwt: $(GODOTENV)
 # Clean generated files and binaries
 clean:
 	rm -rf $(BIN_DIR)
-	rm -f lib/oapi/oapi.go
-	rm -f lib/vmm/vmm.go
-	rm -f lib/exec/exec.pb.go
-	rm -f lib/exec/exec_grpc.pb.go
+	rm -rf lib/vmm/binaries/cloud-hypervisor/
+	rm -rf lib/ingress/binaries/
 	rm -f lib/system/exec_agent/exec-agent
 
 # Prepare for release build (called by GoReleaser)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Allocates a fresh network and regenerates the config disk when starting a VM, adds cleanup rollback, and introduces a pre-build clean step in CI with an expanded Makefile clean target.
> 
> - **Backend (instances)**:
>   - `lib/instances/start.go`:
>     - Allocate fresh network via `CreateAllocation`; update stored `IP`/`MAC`.
>     - Add gVisor `cleanup` stack to rollback network on failures.
>     - Regenerate config disk before boot with new network config.
>     - Simplify flow; remove recreate/get allocation logic.
> - **CI**:
>   - `.github/workflows/test.yml`: Add `make clean` step before build.
> - **Build**:
>   - `Makefile`: Add `clean` to phony targets; expand `clean` to remove embedded Cloud Hypervisor and Caddy binaries and `exec-agent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 514591fed9f0caf9118767ad66f0568c631cf6f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->