### PR TITLE
Update kernel to include network capabilities

### DIFF
--- a/lib/system/versions.go
+++ b/lib/system/versions.go
@@ -8,15 +8,17 @@ type KernelVersion string
 const (
 	// Kernel versions from Kernel linux build
 	Kernel_202511182 KernelVersion = "ch-6.12.8-kernel-1-202511182"
+	Kernel_20251211  KernelVersion = "ch-6.12.8-kernel-2-20251211"
 )
 
 var (
 	// DefaultKernelVersion is the kernel version used for new instances
-	DefaultKernelVersion = Kernel_202511182
+	DefaultKernelVersion = Kernel_20251211
 
 	// SupportedKernelVersions lists all supported kernel versions
 	SupportedKernelVersions = []KernelVersion{
 		Kernel_202511182,
+		Kernel_20251211,
 		// Add future versions here
 	}
 )
@@ -26,6 +28,10 @@ var KernelDownloadURLs = map[KernelVersion]map[string]string{
 	Kernel_202511182: {
 		"x86_64":  "https://github.com/onkernel/linux/releases/download/ch-6.12.8-kernel-1-202511182/vmlinux-x86_64",
 		"aarch64": "https://github.com/onkernel/linux/releases/download/ch-6.12.8-kernel-1-202511182/Image-arm64",
+	},
+	Kernel_20251211: {
+		"x86_64":  "https://github.com/onkernel/linux/releases/download/ch-6.12.8-kernel-2-20251211/vmlinux-x86_64",
+		"aarch64": "https://github.com/onkernel/linux/releases/download/ch-6.12.8-kernel-2-20251211/Image-arm64",
 	},
 	// Add future versions here
 }
@@ -38,4 +44,3 @@ func GetArch() string {
 	}
 	return arch
 }
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add new kernel version `20251211`, make it the default, and provide its download URLs.
> 
> - **Kernel versions (`lib/system/versions.go`)**:
>   - Add `Kernel_20251211` and its download URLs for `x86_64` and `aarch64`.
>   - Set `DefaultKernelVersion` to `Kernel_20251211`.
>   - Include `Kernel_20251211` in `SupportedKernelVersions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d61a7542ae43563ee903129ecebf8a663efc4744. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->