### PR TITLE
Update kernel link

### DIFF
--- a/lib/system/versions.go
+++ b/lib/system/versions.go
@@ -8,7 +8,7 @@ type KernelVersion string
 const (
 	// Kernel versions from Kernel linux build
 	Kernel_202511182 KernelVersion = "ch-6.12.8-kernel-1-202511182"
-	Kernel_20251211  KernelVersion = "ch-6.12.8-kernel-2-20251211"
+	Kernel_20251211  KernelVersion = "ch-6.12.8-kernel-1.1-20251211"
 )
 
 var (
@@ -30,8 +30,8 @@ var KernelDownloadURLs = map[KernelVersion]map[string]string{
 		"aarch64": "https://github.com/onkernel/linux/releases/download/ch-6.12.8-kernel-1-202511182/Image-arm64",
 	},
 	Kernel_20251211: {
-		"x86_64":  "https://github.com/onkernel/linux/releases/download/ch-6.12.8-kernel-2-20251211/vmlinux-x86_64",
-		"aarch64": "https://github.com/onkernel/linux/releases/download/ch-6.12.8-kernel-2-20251211/Image-arm64",
+		"x86_64":  "https://github.com/onkernel/linux/releases/download/ch-6.12.8-kernel-1.1-20251211/vmlinux-x86_64",
+		"aarch64": "https://github.com/onkernel/linux/releases/download/ch-6.12.8-kernel-1.1-20251211/Image-arm64",
 	},
 	// Add future versions here
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `Kernel_20251211` version string and its x86_64/arm64 download URLs to the `-kernel-1.1-20251211` build.
> 
> - **System kernels (`lib/system/versions.go`)**:
>   - Update `Kernel_20251211` from `ch-6.12.8-kernel-2-20251211` to `ch-6.12.8-kernel-1.1-20251211`.
>   - Update `KernelDownloadURLs[Kernel_20251211]` for `x86_64` and `aarch64` to the matching `-kernel-1.1-20251211` artifacts.
>   - `DefaultKernelVersion` remains `Kernel_20251211`; supported versions unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 857ff07bd8045ba4fcc7ab8d229dfccbacf647eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->