### PR TITLE
Add Discord link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 <p align="center">
   <strong>Run containerized workloads in VMs, powered by <a href="https://github.com/cloud-hypervisor/cloud-hypervisor">Cloud Hypervisor</a>.</strong>
+ <img alt="GitHub License" src="https://img.shields.io/github/license/onkernel/hypeman">
+  <a href="https://discord.gg/FBrveQRcud"><img src="https://img.shields.io/discord/1342243238748225556?logo=discord&logoColor=white&color=7289DA" alt="Discord"></a>
 </p>
 
 ---


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add GitHub License and Discord badges to the README header.
> 
> - **Docs**:
>   - Update `README.md` header to include badges: `GitHub License` and `Discord` invite link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a76e5576234335392ca594b17369f1f6467ca3ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->