### PR TITLE
feat: add arm64/aarch64 multi-arch support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/golang/protobuf v1.5.4
 	github.com/google/go-containerregistry v0.20.6
 	github.com/google/wire v0.7.0
 	github.com/gorilla/websocket v1.5.3
@@ -42,7 +43,6 @@ require (
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.38.0
 	google.golang.org/grpc v1.77.0
-	google.golang.org/protobuf v1.36.10
 	gvisor.dev/gvisor v0.0.0-20251125014920-fc40e232ff54
 )
 
@@ -112,6 +112,7 @@ require (
 	golang.org/x/tools v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251022142026-3a174f9686a8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251022142026-3a174f9686a8 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.2 // indirect

--- a/lib/system/versions.go
+++ b/lib/system/versions.go
@@ -74,5 +74,8 @@ func GetArch() string {
 	if arch == "amd64" {
 		return "x86_64"
 	}
+	if arch == "arm64" {
+		return "aarch64"
+	}
 	return arch
 }

--- a/lib/vmm/binaries.go
+++ b/lib/vmm/binaries.go
@@ -30,6 +30,8 @@ func ExtractBinary(p *paths.Paths, version CHVersion) (string, error) {
 	arch := runtime.GOARCH
 	if arch == "amd64" {
 		arch = "x86_64"
+	} else if arch == "arm64" {
+		arch = "aarch64"
 	}
 
 	embeddedPath := fmt.Sprintf("binaries/cloud-hypervisor/%s/%s/cloud-hypervisor", version, arch)


### PR DESCRIPTION
## Summary

Add support for arm64 architecture to enable running hypeman on ARM-based systems.

## Changes

- **`lib/system/versions.go`**: Map `arm64` to `aarch64` in `GetArch()` for kernel/binary paths
- **`lib/vmm/binaries.go`**: Map `arm64` to `aarch64` in cloud-hypervisor binary extraction  
- **`lib/images/oci.go`**: Add platform-specific OCI image pulling with `remote.WithPlatform()` to correctly pull the right architecture for multi-arch container images
- **`go.mod`**: Add `golang/protobuf` dependency for gRPC compatibility

## Testing

- Tested on arm64 ubuntu vm running via UTM on mac os


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables running on ARM by aligning architecture naming and ensuring OCI pulls resolve to the host platform.
> 
> - Map `arm64` → `aarch64` in `system.GetArch()` and `vmm.ExtractBinary()` for kernel and Cloud Hypervisor binary paths
> - Add platform-aware OCI operations in `lib/images/oci.go` via `remote.WithPlatform()` and `currentPlatform()`; `inspectManifest` now returns the host-specific manifest digest
> - Add `github.com/golang/protobuf v1.5.4` and adjust protobuf deps in `go.mod`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c85a3c2f696fd1857b81451e8b1f47fe536f300. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->