### PR TITLE
Oci manifest platform mismatch

### DIFF
--- a/lib/images/oci_inspect_test.go
+++ b/lib/images/oci_inspect_test.go
@@ -1,0 +1,43 @@
+package images
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectManifestReturnsPlatformSpecificDigestForMultiArch(t *testing.T) {
+	// alpine:latest is a multi-arch image on Docker Hub; we should resolve the
+	// digest of the platform-specific manifest that we will actually pull.
+	const imageRef = "docker.io/library/alpine:latest"
+
+	client, err := newOCIClient(t.TempDir())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	gotDigest, err := client.inspectManifest(ctx, imageRef)
+	require.NoError(t, err)
+	require.NotEmpty(t, gotDigest)
+
+	ref, err := name.ParseReference(imageRef)
+	require.NoError(t, err)
+
+	img, err := remote.Image(ref,
+		remote.WithContext(ctx),
+		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+		remote.WithPlatform(currentPlatform()))
+	require.NoError(t, err)
+
+	want, err := img.Digest()
+	require.NoError(t, err)
+
+	require.Equal(t, want.String(), gotDigest)
+}
+


### PR DESCRIPTION
Align `inspectManifest` to return platform-specific digests for multi-arch images to prevent cache mismatches.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f5fb93c-9bfa-4dda-8a3d-332b4925b824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f5fb93c-9bfa-4dda-8a3d-332b4925b824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

