### PR TITLE
Qemu capabilities

### DIFF
--- a/lib/hypervisor/qemu/qemu.go
+++ b/lib/hypervisor/qemu/qemu.go
@@ -3,6 +3,8 @@ package qemu
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/digitalocean/go-qemu/qemu"
@@ -36,8 +38,8 @@ var _ hypervisor.Hypervisor = (*QEMU)(nil)
 // Capabilities returns the features supported by QEMU.
 func (q *QEMU) Capabilities() hypervisor.Capabilities {
 	return hypervisor.Capabilities{
-		SupportsSnapshot:       false, // Not implemented in first pass
-		SupportsHotplugMemory:  false, // Not implemented in first pass
+		SupportsSnapshot:       true,  // Uses QMP migrate file:// for snapshot
+		SupportsHotplugMemory:  false, // Not implemented - balloon not configured
 		SupportsPause:          true,
 		SupportsVsock:          true,
 		SupportsGPUPassthrough: true,
@@ -119,10 +121,39 @@ func (q *QEMU) Resume(ctx context.Context) error {
 	return nil
 }
 
-// Snapshot creates a VM snapshot.
-// Not implemented in first pass.
+// Snapshot creates a VM snapshot using QEMU's migrate-to-file mechanism.
+// The VM state is saved to destPath/memory file.
+// The VM config is copied to destPath for restore (QEMU requires exact arg match).
 func (q *QEMU) Snapshot(ctx context.Context, destPath string) error {
-	return fmt.Errorf("snapshot not supported by QEMU implementation")
+	// QEMU uses migrate to file for snapshots
+	// The file URI must be absolute path
+	uri := "file://" + destPath + "/memory"
+	if err := q.client.Migrate(uri); err != nil {
+		Remove(q.socketPath)
+		return fmt.Errorf("migrate: %w", err)
+	}
+
+	// Wait for migration to complete
+	if err := q.client.WaitMigration(ctx, 30*time.Second); err != nil {
+		Remove(q.socketPath)
+		return fmt.Errorf("wait migration: %w", err)
+	}
+
+	// Copy VM config from instance dir to snapshot dir
+	// QEMU restore requires exact same command-line args as when snapshot was taken
+	instanceDir := filepath.Dir(q.socketPath)
+	srcConfig := filepath.Join(instanceDir, vmConfigFile)
+	dstConfig := filepath.Join(destPath, vmConfigFile)
+
+	configData, err := os.ReadFile(srcConfig)
+	if err != nil {
+		return fmt.Errorf("read vm config for snapshot: %w", err)
+	}
+	if err := os.WriteFile(dstConfig, configData, 0644); err != nil {
+		return fmt.Errorf("write vm config to snapshot: %w", err)
+	}
+
+	return nil
 }
 
 // ResizeMemory changes the VM's memory allocation.

--- a/lib/hypervisor/qemu/qemu.go
+++ b/lib/hypervisor/qemu/qemu.go
@@ -126,8 +126,9 @@ func (q *QEMU) Resume(ctx context.Context) error {
 // The VM config is copied to destPath for restore (QEMU requires exact arg match).
 func (q *QEMU) Snapshot(ctx context.Context, destPath string) error {
 	// QEMU uses migrate to file for snapshots
-	// The file URI must be absolute path
-	uri := "file://" + destPath + "/memory"
+	// The "file:" protocol is deprecated in QEMU 7.2+, use "exec:cat > path" instead
+	memoryFile := destPath + "/memory"
+	uri := "exec:cat > " + memoryFile
 	if err := q.client.Migrate(uri); err != nil {
 		Remove(q.socketPath)
 		return fmt.Errorf("migrate: %w", err)

--- a/lib/hypervisor/qemu/qemu.go
+++ b/lib/hypervisor/qemu/qemu.go
@@ -135,7 +135,7 @@ func (q *QEMU) Snapshot(ctx context.Context, destPath string) error {
 	}
 
 	// Wait for migration to complete
-	if err := q.client.WaitMigration(ctx, 30*time.Second); err != nil {
+	if err := q.client.WaitMigration(ctx, migrationTimeout); err != nil {
 		Remove(q.socketPath)
 		return fmt.Errorf("wait migration: %w", err)
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds end-to-end QEMU standby/restore support and refines process/QMP handling, plus observability improvements.
> 
> - **QEMU snapshot/restore**: Enables `Standby`/`Restore` using QMP migrate-to-file; saves `qemu-config.json` on start and loads it for restore; starts QEMU with `-incoming exec:cat < memory` and waits for VM readiness
> - **QMP client utilities**: New wait helpers (`WaitMigration`, `WaitVMReady`), `Migrate`, and tuned timeouts/polling; exposes status and raw commands
> - **Process startup refactor**: Shared `startQEMUProcess` with socket readiness checks, log redirection, cleanup handling, and debug timings; constants for dial/wait intervals
> - **Capabilities**: `SupportsSnapshot` now true for QEMU
> - **Integration tests**: Adds `TestQEMUStandbyAndRestore` covering snapshot/restore path; extends QEMU E2E helpers
> - **Instance flows**: Standby/restore paths add tracing spans, clearer logs, network recreate/release, and deletion of snapshots post-restore
> - **Cloud Hypervisor**: Restore path gains timing/debug logs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c998b6491d0d4a1218c774ede4053136f4ea7e93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->