### PR TITLE
fix: increase ext4 filesystem overhead from 20% to 50%

### DIFF
--- a/lib/images/disk.go
+++ b/lib/images/disk.go
@@ -116,8 +116,10 @@ func convertToExt4(rootfsDir, diskPath string) (int64, error) {
 		return 0, fmt.Errorf("calculate dir size: %w", err)
 	}
 
-	// Add 20% overhead for filesystem metadata, minimum 10MB
-	diskSizeBytes := sizeBytes + (sizeBytes / 5)
+	// Add 50% overhead for filesystem metadata, minimum 10MB
+	// ext4 needs significant overhead for superblock, group descriptors, inode tables, etc.
+	// 20% was insufficient for small filesystems with many files (like tzdata)
+	diskSizeBytes := sizeBytes + (sizeBytes / 2)
 	const minSize = 10 * 1024 * 1024 // 10MB
 	if diskSizeBytes < minSize {
 		diskSizeBytes = minSize


### PR DESCRIPTION
## Summary

- Increases ext4 filesystem overhead from 20% to 50% when converting OCI images to disk format
- Fixes `mkfs.ext4: Could not allocate block in ext2 filesystem` error for images with many small files

## Problem

When building and running images with many small files (like Alpine + tzdata), the image conversion to ext4 was failing:

```
Creating filesystem with 2702 4k blocks and 2704 inodes
Could not allocate block in ext2 filesystem while writing file "GMT-2"
```

The 20% overhead was insufficient for ext4 metadata (superblock, group descriptors, inode tables, directory entries), especially for small filesystems with many files.

## Solution

Increased the overhead from 20% (`sizeBytes / 5`) to 50% (`sizeBytes / 2`).

| Metric | Before (20%) | After (50%) |
|--------|--------------|-------------|
| Example: 8.80 MB rootfs | 10.56 MB disk | 13.20 MB disk |
| Result | ❌ mkfs.ext4 failed | ✅ Success |

## Test plan

- [x] Built Alpine + tzdata image via `hypeman build`
- [x] Successfully pulled and converted image to ext4
- [x] Successfully ran instance with the image

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts ext4 image sizing to avoid mkfs failures on rootfs with many small files.
> 
> - In `convertToExt4`, increase overhead from `sizeBytes/5` to `sizeBytes/2` (retain 10MB minimum) when computing `diskSizeBytes`
> - Add clarifying comments about ext4 metadata overhead and small-files failure cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5493085b46307a2d54f6275192f7648f7bf3d714. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->