### PR TITLE
feat: add script to build from source and support binary path with install.sh

### DIFF
--- a/scripts/build-from-source.sh
+++ b/scripts/build-from-source.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Hypeman Build from Source Script
+#
+# Usage:
+#   ./scripts/build-from-source.sh
+#
+# Options (via environment variables:
+#   OUTPUT_DIR   - Full path of directory to place built binaries (optional, default: $(pwd)/bin)
+#
+
+set -e
+
+# Default values
+BINARY_NAME="hypeman-api"
+
+# Colors for output (true color)
+RED='\033[38;2;255;110;110m'
+GREEN='\033[38;2;92;190;83m'
+YELLOW='\033[0;33m'
+PURPLE='\033[38;2;172;134;249m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# =============================================================================
+# Pre-flight checks - verify all requirements before doing anything
+# =============================================================================
+
+# Check for required commands
+command -v go >/dev/null 2>&1 || error "go is required but not installed"
+command -v make >/dev/null 2>&1 || error "make is required but not installed"
+
+# =============================================================================
+# Setup directories
+# =============================================================================
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -z "$OUTPUT_DIR" ]; then
+    OUTPUT_DIR=${SOURCE_DIR}/bin
+fi
+
+# Create output directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+BUILD_LOG="${OUTPUT_DIR}/build.log"
+
+# =============================================================================
+# Build from source
+# =============================================================================
+
+info "Building from source (${SOURCE_DIR})..."
+
+info "Building binaries (this may take a few minutes)..."
+cd "${SOURCE_DIR}"
+
+# Build main binary (includes dependencies) - capture output, show on error
+if ! make build >> "$BUILD_LOG" 2>&1; then
+    echo ""
+    echo -e "${RED}Build failed. Full build log:${NC}"
+    cat "$BUILD_LOG"
+    error "Build failed"
+fi
+cp "bin/hypeman" "${OUTPUT_DIR}/${BINARY_NAME}"
+
+# Build hypeman-token (not included in make build)
+if ! go build -o "${OUTPUT_DIR}/hypeman-token" ./cmd/gen-jwt >> "$BUILD_LOG" 2>&1; then
+    echo ""
+    echo -e "${RED}Build failed. Full build log:${NC}"
+    cat "$BUILD_LOG"
+    error "Failed to build hypeman-token"
+fi
+
+# Copy .env.example for config template
+cp ".env.example" "${OUTPUT_DIR}/.env.example"
+
+info "Build complete"
+info "Binaries are available in: ${OUTPUT_DIR}"

--- a/scripts/build-from-source.sh
+++ b/scripts/build-from-source.sh
@@ -5,11 +5,11 @@
 # Usage:
 #   ./scripts/build-from-source.sh
 #
-# Options (via environment variables:
-#   OUTPUT_DIR   - Full path of directory to place built binaries (optional, default: $(pwd)/bin)
+# Options (via environment variables):
+#   OUTPUT_DIR   - Full path of directory to place built binaries (optional, default: repo's root bin directory)
 #
 
-set -e
+set -euo pipefail
 
 # Default values
 BINARY_NAME="hypeman-api"
@@ -41,14 +41,13 @@ command -v make >/dev/null 2>&1 || error "make is required but not installed"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-if [ -z "$OUTPUT_DIR" ]; then
-    OUTPUT_DIR=${SOURCE_DIR}/bin
-fi
+: "${OUTPUT_DIR:=${SOURCE_DIR}/bin}"
 
 # Create output directory if it doesn't exist
 mkdir -p "$OUTPUT_DIR"
 
 BUILD_LOG="${OUTPUT_DIR}/build.log"
+: > "$BUILD_LOG"
 
 # =============================================================================
 # Build from source

--- a/scripts/build-from-source.sh
+++ b/scripts/build-from-source.sh
@@ -43,6 +43,11 @@ SOURCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 : "${OUTPUT_DIR:=${SOURCE_DIR}/bin}"
 
+# Validate OUTPUT_DIR is an absolute path
+if [[ "$OUTPUT_DIR" != /* ]]; then
+    error "OUTPUT_DIR must be an absolute path (got: ${OUTPUT_DIR})"
+fi
+
 # Create output directory if it doesn't exist
 mkdir -p "$OUTPUT_DIR"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -211,6 +211,11 @@ if [ -n "$BINARY_DIR" ]; then
 
     # Copy binaries to TMP_DIR
     info "Copying binaries from ${BINARY_DIR}..."
+
+    for f in "${BINARY_NAME}" "hypeman-token" ".env.example"; do
+        [ -f "${BINARY_DIR}/${f}" ] || error "File ${f} not found in ${BINARY_DIR}"
+    done
+
     cp "${BINARY_DIR}/${BINARY_NAME}" "${TMP_DIR}/${BINARY_NAME}"
     cp "${BINARY_DIR}/hypeman-token" "${TMP_DIR}/hypeman-token"
     cp "${BINARY_DIR}/.env.example" "${TMP_DIR}/.env.example"


### PR DESCRIPTION
This is used by 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tooling for building and installing Hypeman with more flexible paths.
> 
> - **New `scripts/build-from-source.sh`**: Builds `hypeman-api` and `hypeman-token`, writes logs to `build.log`, validates absolute `OUTPUT_DIR`, and copies `.env.example` to the output dir
> - **Installer enhancements (`scripts/install.sh`)**: Adds `BINARY_DIR` mode to install from prebuilt binaries (with validation and exec perms), makes `BRANCH`, `VERSION`, and `BINARY_DIR` mutually exclusive with checks, and treats `CLI_VERSION=latest` as auto-resolve; keeps build-from-source and release-download paths intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebef7e87aee0761bbc3cc5cd66cf9ec543011758. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->