### PR TITLE
Add to stainless config new API endpoints

### DIFF
--- a/stainless.yaml
+++ b/stainless.yaml
@@ -135,6 +135,32 @@ resources:
       get: get /ingresses/{id}
       delete: delete /ingresses/{id}
 
+  resources:
+    models:
+      resources: "#/components/schemas/Resources"
+      resource_status: "#/components/schemas/ResourceStatus"
+      resource_allocation: "#/components/schemas/ResourceAllocation"
+      disk_breakdown: "#/components/schemas/DiskBreakdown"
+      gpu_resource_status: "#/components/schemas/GPUResourceStatus"
+      gpu_profile: "#/components/schemas/GPUProfile"
+      passthrough_device: "#/components/schemas/PassthroughDevice"
+    methods:
+      get: get /resources
+
+  builds:
+    models:
+      build: "#/components/schemas/Build"
+      build_status: "#/components/schemas/BuildStatus"
+      build_policy: "#/components/schemas/BuildPolicy"
+      build_provenance: "#/components/schemas/BuildProvenance"
+      build_event: "#/components/schemas/BuildEvent"
+    methods:
+      list: get /builds
+      create: post /builds
+      get: get /builds/{id}
+      cancel: delete /builds/{id}
+      events: get /builds/{id}/events
+
 settings:
   # All generated integration tests that hit the prism mock http server are marked
   # as skipped. Removing this setting or setting it to false enables tests, but


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands API surface in `stainless.yaml`.
> 
> - **New `resources` resource**: models (`Resources`, `ResourceStatus`, `ResourceAllocation`, `DiskBreakdown`, `GPUResourceStatus`, `GPUProfile`, `PassthroughDevice`) and `get /resources`.
> - **New `builds` resource**: models (`Build`, `BuildStatus`, `BuildPolicy`, `BuildProvenance`, `BuildEvent`) and endpoints `get /builds`, `post /builds`, `get /builds/{id}`, `delete /builds/{id}` (cancel), `get /builds/{id}/events`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e70b139e68e731f452a049ea5c367b391d421048. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->