### PR TITLE
fix: add image-manifest=true to BuildKit cache export for ephemeral VMs

### DIFF
--- a/lib/builds/builder_agent/main.go
+++ b/lib/builds/builder_agent/main.go
@@ -728,11 +728,14 @@ func runBuild(ctx context.Context, config *BuildConfig, logWriter io.Writer) (st
 	}
 
 	// Export cache based on build type
+	// Note: image-manifest=true ensures layer blobs are stored in the registry cache image
+	// rather than as references to external registries (e.g., docker.io). This is critical
+	// for cache hits in ephemeral BuildKit instances that don't have local layer storage.
 	if config.IsAdminBuild {
 		// Admin build: export to global cache
 		if config.GlobalCacheKey != "" {
 			globalCacheRef := fmt.Sprintf("%s/cache/global/%s", registryHost, config.GlobalCacheKey)
-			cacheOpts := "type=registry,ref=" + globalCacheRef + ",mode=max"
+			cacheOpts := "type=registry,ref=" + globalCacheRef + ",mode=max,image-manifest=true,oci-mediatypes=true"
 			if useInsecureFlag {
 				cacheOpts += ",registry.insecure=true"
 			}
@@ -743,7 +746,7 @@ func runBuild(ctx context.Context, config *BuildConfig, logWriter io.Writer) (st
 		// Regular build: export to tenant cache
 		if config.CacheScope != "" {
 			tenantCacheRef := fmt.Sprintf("%s/cache/%s", registryHost, config.CacheScope)
-			cacheOpts := "type=registry,ref=" + tenantCacheRef + ",mode=max"
+			cacheOpts := "type=registry,ref=" + tenantCacheRef + ",mode=max,image-manifest=true,oci-mediatypes=true"
 			if useInsecureFlag {
 				cacheOpts += ",registry.insecure=true"
 			}

--- a/lib/builds/cache.go
+++ b/lib/builds/cache.go
@@ -100,8 +100,10 @@ func (k *CacheKey) ImportCacheArg() string {
 }
 
 // ExportCacheArg returns the BuildKit --export-cache argument
+// Uses image-manifest=true to ensure layer blobs are stored in the cache image
+// rather than as external references, enabling cache hits in ephemeral BuildKit instances.
 func (k *CacheKey) ExportCacheArg() string {
-	return fmt.Sprintf("type=registry,ref=%s,mode=max", k.Reference)
+	return fmt.Sprintf("type=registry,ref=%s,mode=max,image-manifest=true,oci-mediatypes=true", k.Reference)
 }
 
 // normalizeCacheScope normalizes a cache scope to only contain safe characters

--- a/lib/builds/cache_test.go
+++ b/lib/builds/cache_test.go
@@ -103,7 +103,7 @@ func TestCacheKey_Args(t *testing.T) {
 	assert.Equal(t, "type=registry,ref=localhost:8080/cache/tenant/nodejs/abc123", importArg)
 
 	exportArg := key.ExportCacheArg()
-	assert.Equal(t, "type=registry,ref=localhost:8080/cache/tenant/nodejs/abc123,mode=max", exportArg)
+	assert.Equal(t, "type=registry,ref=localhost:8080/cache/tenant/nodejs/abc123,mode=max,image-manifest=true,oci-mediatypes=true", exportArg)
 }
 
 func TestValidateCacheScope(t *testing.T) {

--- a/lib/images/oci_test.go
+++ b/lib/images/oci_test.go
@@ -1,0 +1,190 @@
+package images
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// BuildKit cache config mediatype - this is what BuildKit uses when exporting
+// cache with image-manifest=true
+const buildKitCacheConfigMediaType = "application/vnd.buildkit.cacheconfig.v0"
+
+// TestUnpackLayersFailsOnBuildKitCacheMediatype verifies that hypeman's image
+// unpacker fails when encountering BuildKit cache images. This reproduces the
+// production issue where global cache images exported by BuildKit cannot be
+// pre-pulled by hypeman because they use a non-standard config mediatype.
+//
+// The error occurs because:
+// 1. BuildKit exports cache with --export-cache type=registry,image-manifest=true
+// 2. The exported manifest uses "application/vnd.buildkit.cacheconfig.v0" as config mediatype
+// 3. hypeman's unpackLayers expects "application/vnd.oci.image.config.v1+json"
+// 4. umoci.UnpackRootfs fails with "config blob is not correct mediatype"
+func TestUnpackLayersFailsOnBuildKitCacheMediatype(t *testing.T) {
+	// Create a temp directory for the OCI layout
+	cacheDir := t.TempDir()
+
+	// Create OCI layout structure with BuildKit cache mediatype
+	err := createBuildKitCacheLayout(cacheDir, "test-cache")
+	require.NoError(t, err, "failed to create mock BuildKit cache layout")
+
+	// Create OCI client and try to unpack
+	client, err := newOCIClient(cacheDir)
+	require.NoError(t, err)
+
+	targetDir := t.TempDir()
+	err = client.unpackLayers(context.Background(), "test-cache", targetDir)
+
+	// This should fail with a mediatype error
+	require.Error(t, err, "unpackLayers should fail on BuildKit cache mediatype")
+	assert.Contains(t, err.Error(), "config", "error should mention config")
+
+	t.Logf("Got expected error: %v", err)
+}
+
+// TestExtractMetadataSucceedsOnBuildKitCache verifies that extractOCIMetadata
+// does NOT fail on BuildKit cache images - it's go-containerregistry which is
+// lenient about mediatypes. The failure only happens during unpackLayers when
+// umoci tries to unpack the rootfs.
+func TestExtractMetadataSucceedsOnBuildKitCache(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	err := createBuildKitCacheLayout(cacheDir, "test-cache")
+	require.NoError(t, err)
+
+	client, err := newOCIClient(cacheDir)
+	require.NoError(t, err)
+
+	// This succeeds because go-containerregistry doesn't validate config mediatype
+	// The failure only happens in unpackLayers when umoci validates the config
+	meta, err := client.extractOCIMetadata("test-cache")
+	require.NoError(t, err, "extractOCIMetadata succeeds - go-containerregistry is lenient")
+
+	// But the metadata will be empty/invalid since it's not a real OCI config
+	t.Logf("Got metadata (likely empty): %+v", meta)
+}
+
+// createBuildKitCacheLayout creates an OCI layout that mimics what BuildKit
+// exports when using --export-cache type=registry,image-manifest=true
+//
+// Layout structure:
+// cacheDir/
+//   ├── oci-layout          (OCI layout version marker)
+//   ├── index.json          (points to manifest)
+//   └── blobs/sha256/
+//       ├── <manifest>      (image manifest with buildkit config mediatype)
+//       ├── <config>        (buildkit cache config blob)
+//       └── <layer>         (dummy layer)
+func createBuildKitCacheLayout(cacheDir, layoutTag string) error {
+	// Create directory structure
+	blobsDir := filepath.Join(cacheDir, "blobs", "sha256")
+	if err := os.MkdirAll(blobsDir, 0755); err != nil {
+		return err
+	}
+
+	// 1. Create oci-layout file
+	ociLayout := map[string]string{"imageLayoutVersion": "1.0.0"}
+	ociLayoutBytes, _ := json.Marshal(ociLayout)
+	if err := os.WriteFile(filepath.Join(cacheDir, "oci-layout"), ociLayoutBytes, 0644); err != nil {
+		return err
+	}
+
+	// 2. Create a dummy layer blob (gzipped tar with a single file)
+	// This is a minimal valid gzipped tar
+	layerContent := []byte{
+		0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, // gzip header
+		0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // empty tar
+	}
+	layerDigest := sha256Hash(layerContent)
+	if err := os.WriteFile(filepath.Join(blobsDir, layerDigest), layerContent, 0644); err != nil {
+		return err
+	}
+
+	// 3. Create BuildKit cache config blob
+	// This is what BuildKit puts in the config - NOT a standard OCI config
+	cacheConfig := map[string]interface{}{
+		"layers": []map[string]interface{}{
+			{
+				"blob":      "sha256:" + layerDigest,
+				"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			},
+		},
+	}
+	configBytes, _ := json.Marshal(cacheConfig)
+	configDigest := sha256Hash(configBytes)
+	if err := os.WriteFile(filepath.Join(blobsDir, configDigest), configBytes, 0644); err != nil {
+		return err
+	}
+
+	// 4. Create image manifest with BuildKit's cache config mediatype
+	manifest := map[string]interface{}{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.manifest.v1+json",
+		"config": map[string]interface{}{
+			"mediaType": buildKitCacheConfigMediaType, // This is the problem!
+			"digest":    "sha256:" + configDigest,
+			"size":      len(configBytes),
+		},
+		"layers": []map[string]interface{}{
+			{
+				"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+				"digest":    "sha256:" + layerDigest,
+				"size":      len(layerContent),
+			},
+		},
+	}
+	manifestBytes, _ := json.Marshal(manifest)
+	manifestDigest := sha256Hash(manifestBytes)
+	if err := os.WriteFile(filepath.Join(blobsDir, manifestDigest), manifestBytes, 0644); err != nil {
+		return err
+	}
+
+	// 5. Create index.json pointing to the manifest with our layout tag
+	index := map[string]interface{}{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.index.v1+json",
+		"manifests": []map[string]interface{}{
+			{
+				"mediaType": "application/vnd.oci.image.manifest.v1+json",
+				"digest":    "sha256:" + manifestDigest,
+				"size":      len(manifestBytes),
+				"annotations": map[string]string{
+					"org.opencontainers.image.ref.name": layoutTag,
+				},
+			},
+		},
+	}
+	indexBytes, _ := json.Marshal(index)
+	if err := os.WriteFile(filepath.Join(cacheDir, "index.json"), indexBytes, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// sha256Hash computes the SHA256 hash of data and returns the hex string
+func sha256Hash(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// TestConvertToOCIMediaTypePassesThroughBuildKitType verifies that the
+// mediatype conversion function doesn't handle BuildKit's cache config type,
+// which is the root cause of the unpack failure.
+func TestConvertToOCIMediaTypePassesThroughBuildKitType(t *testing.T) {
+	// Verify that BuildKit's mediatype passes through unchanged
+	result := convertToOCIMediaType(buildKitCacheConfigMediaType)
+	assert.Equal(t, buildKitCacheConfigMediaType, result,
+		"BuildKit cache config mediatype should pass through unchanged (this is the bug)")
+
+	// Standard Docker types should be converted
+	assert.Equal(t, "application/vnd.oci.image.config.v1+json",
+		convertToOCIMediaType("application/vnd.docker.container.image.v1+json"))
+}

--- a/lib/registry/registry.go
+++ b/lib/registry/registry.go
@@ -138,7 +138,15 @@ func (w *responseWrapper) WriteHeader(code int) {
 }
 
 // triggerConversion queues the image for conversion to ext4 disk format.
+// Skips BuildKit cache images (cache/*) since they're not runnable containers.
 func (r *Registry) triggerConversion(repo, reference, dockerDigest string) {
+	// Skip BuildKit cache images - they use a custom mediatype that can't be
+	// unpacked as a standard OCI image. BuildKit imports them directly from
+	// the registry without needing local conversion.
+	if strings.HasPrefix(repo, "cache/") {
+		return
+	}
+
 	imageRef := repo + ":" + reference
 	if strings.HasPrefix(reference, "sha256:") {
 		imageRef = repo + "@" + reference

--- a/lib/registry/registry.go
+++ b/lib/registry/registry.go
@@ -143,7 +143,8 @@ func (r *Registry) triggerConversion(repo, reference, dockerDigest string) {
 	// Skip BuildKit cache images - they use a custom mediatype that can't be
 	// unpacked as a standard OCI image. BuildKit imports them directly from
 	// the registry without needing local conversion.
-	if strings.HasPrefix(repo, "cache/") {
+	// Note: repo may include host prefix (e.g., "10.102.0.1:8083/cache/global/node")
+	if strings.HasPrefix(repo, "cache/") || strings.Contains(repo, "/cache/") {
 		return
 	}
 


### PR DESCRIPTION
## Summary

Fixes two related issues with BuildKit cache handling:

1. **Global cache wasn't providing cache hits** - Without `image-manifest=true`, BuildKit's registry cache stores layer references pointing to external registries rather than copying actual layer blobs
2. **Cache image push was failing** - Hypeman's registry was attempting to convert cache images to ext4 format, but BuildKit uses a custom mediatype (`application/vnd.buildkit.cacheconfig.v0`) that can't be unpacked by standard OCI tools

## Changes

### Fix 1: Enable proper cache blob storage
- `lib/builds/builder_agent/main.go` - Added `image-manifest=true,oci-mediatypes=true` to cache export options
- `lib/builds/cache.go` - Updated `ExportCacheArg()` helper for consistency
- `lib/builds/cache_test.go` - Updated test expectation

### Fix 2: Skip conversion for cache images
- `lib/registry/registry.go` - Skip `triggerConversion()` for `cache/*` repos since they're not runnable containers

### Test coverage
- `lib/images/oci_test.go` - Unit tests documenting the BuildKit cache mediatype limitation

## Root causes

**Issue 1:** Without `image-manifest=true`, BuildKit stores layer references like:
```
sha256:abc123 -> docker.io/library/alpine@sha256:abc123
```
Instead of copying the actual blob. Ephemeral BuildKit instances can't resolve these references.

**Issue 2:** When cache images are pushed, the registry triggers conversion to ext4 format. This calls `umoci.UnpackRootfs` which expects standard OCI config mediatype but BuildKit uses:
```
application/vnd.buildkit.cacheconfig.v0
```
This caused: `config blob is not correct mediatype application/vnd.oci.image.config.v1+json`

## Before (first tenant deployment)

```
#9 [1/3] FROM docker.io/onkernel/python3.11-base:0.1.1@sha256:...
#9 sha256:4831516... 28.23MB / 28.23MB 0.4s   ← Downloaded from Docker Hub
#9 extracting sha256:4831516... 2.1s done
... (many more layer downloads ~7s)
```

## After

```
#9 [1/3] FROM docker.io/onkernel/python3.11-base:0.1.1@sha256:...
#9 DONE 0.0s   ← Cache hit from global cache
```

## Test plan

- [x] Unit tests pass (`go test ./lib/images/... ./lib/registry/... ./lib/builds/...`)
- [x] E2E tested: pushed BuildKit cache image with custom mediatype to local server - no conversion error
- [ ] Rebuild builder image with updated `builder_agent`
- [ ] Re-run global cache population script
- [ ] Deploy to fresh tenant and verify cache hits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches build caching behavior and registry post-push processing; incorrect cache flags or repo matching could reduce cache effectiveness or unintentionally skip conversion for some images.
> 
> **Overview**
> Fixes BuildKit registry cache exports to work reliably in ephemeral builders by adding `image-manifest=true` (and `oci-mediatypes=true`) to cache export args for both global/admin and tenant caches.
> 
> Updates the shared `CacheKey.ExportCacheArg()` helper and its tests accordingly, adds `lib/images/oci_test.go` to document the BuildKit cache config mediatype incompatibility, and changes the registry to **skip ext4 conversion** for pushed `cache/*` images so cache pushes no longer fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1460df94ce38190c69d343fbb5affe9a648371a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->