### PR TITLE
feat(builds): configure local registry as Docker Hub mirror in BuildKit

### DIFF
--- a/lib/builds/builder_agent/main.go
+++ b/lib/builds/builder_agent/main.go
@@ -644,6 +644,14 @@ func setupBuildkitdConfig(config *BuildConfig) error {
 	}
 	// If HTTPS without insecure and without CA, use system CA (no config needed)
 
+	// Configure the local registry as a mirror for Docker Hub.
+	// When BuildKit encounters FROM instructions referencing docker.io images
+	// (e.g., node:20-alpine), it will try the local registry first before
+	// falling back to Docker Hub. This avoids redundant pulls from Docker Hub
+	// when base images have already been mirrored locally.
+	tomlContent.WriteString(fmt.Sprintf("\n[registry.\"docker.io\"]\n"))
+	tomlContent.WriteString(fmt.Sprintf("  mirrors = [\"%s\"]\n", registryHost))
+
 	// Ensure config directory exists
 	buildkitDir := "/home/builder/.config/buildkit"
 	if err := os.MkdirAll(buildkitDir, 0755); err != nil {


### PR DESCRIPTION
## Summary

- Adds `[registry."docker.io"] mirrors = ["{local-registry}"]` to the generated `buildkitd.toml` in the builder agent
- When BuildKit encounters `FROM node:20-alpine` (or any docker.io image), it tries the local registry first, falling back to Docker Hub if not found
- This is a simpler alternative to Dockerfile FROM rewriting — BuildKit handles mirror resolution natively, including multi-stage builds, ARG variables, etc.

## Prerequisites for production testing

Base images need to be available in the local registry for the mirror to provide a hit. This can be done by pulling them into hypeman's registry ahead of time (e.g., via the images API).

## Test plan

- [ ] Deploy to production
- [ ] Run an admin build with `global_cache_key=node` to populate the global cache
- [ ] Pull `node:20-alpine` into the local registry (if not already there)
- [ ] Run a non-admin build using `FROM node:20-alpine` and check builder VM logs — BuildKit should try the local registry first
- [ ] Verify fallback: run a build with an image NOT in the local registry — should still pull from Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)