### PR TITLE
Remove CLI section from stainless.yaml

### DIFF
--- a/stainless.yaml
+++ b/stainless.yaml
@@ -24,17 +24,6 @@ targets:
     production_repo: kernel/hypeman-go
     options:
       enable_v2: true
-  cli:
-    edition: cli.2025-10-08
-    binary_name: hypeman
-    production_repo: kernel/hypeman-cli
-    options:
-      go_sdk_package: github.com/kernel/hypeman-go
-    publish:
-      homebrew:
-        tap_repo: kernel/homebrew-tap
-        homepage: https://github.com/kernel/hypeman
-        description: orchestrate cloud-hypervisor VMs
   typescript:
     edition: typescript.2025-10-10
     package_name: "@onkernel/hypeman"


### PR DESCRIPTION
Removed CLI configuration from stainless.yaml.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that stops generating/publishing the CLI via Stainless; minimal runtime risk but may affect release automation if the CLI target was relied on.
> 
> **Overview**
> Removes the `cli` target from `stainless.yaml`, including its binary name, publish settings (Homebrew tap metadata), and dependency on the Go SDK package.
> 
> As a result, Stainless generation/publishing is now configured only for the Go and TypeScript targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6929afa0b3d325b17a82cf91dd9a688c4e8a8129. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->