### PR TITLE
Add metadata field to instances

### DIFF
--- a/cmd/api/api/instances.go
+++ b/cmd/api/api/instances.go
@@ -111,6 +111,11 @@ func (s *ApiService) CreateInstance(ctx context.Context, request oapi.CreateInst
 		env = *request.Body.Env
 	}
 
+	metadata := make(map[string]string)
+	if request.Body.Metadata != nil {
+		metadata = *request.Body.Metadata
+	}
+
 	// Parse network enabled (default: true)
 	networkEnabled := true
 	if request.Body.Network != nil && request.Body.Network.Enabled != nil {
@@ -216,6 +221,7 @@ func (s *ApiService) CreateInstance(ctx context.Context, request oapi.CreateInst
 		NetworkBandwidthDownload: networkBandwidthDownload,
 		NetworkBandwidthUpload:   networkBandwidthUpload,
 		Env:                      env,
+		Metadata:                 metadata,
 		NetworkEnabled:           networkEnabled,
 		Devices:                  deviceRefs,
 		Volumes:                  volumes,
@@ -664,6 +670,10 @@ func instanceToOAPI(inst instances.Instance) oapi.Instance {
 
 	if len(inst.Env) > 0 {
 		oapiInst.Env = &inst.Env
+	}
+
+	if len(inst.Metadata) > 0 {
+		oapiInst.Metadata = &inst.Metadata
 	}
 
 	// Convert volume attachments

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -192,6 +192,9 @@ func (m *manager) createInstance(
 	if req.Env == nil {
 		req.Env = make(map[string]string)
 	}
+	if req.Metadata == nil {
+		req.Metadata = make(map[string]string)
+	}
 
 	// 7. Determine network based on NetworkEnabled flag
 	networkName := ""
@@ -298,6 +301,7 @@ func (m *manager) createInstance(
 		NetworkBandwidthUpload:   req.NetworkBandwidthUpload,   // Will be set by caller if using resource manager
 		DiskIOBps:                req.DiskIOBps,                // Will be set by caller if using resource manager
 		Env:                      req.Env,
+		Metadata:                 req.Metadata,
 		NetworkEnabled:           req.NetworkEnabled,
 		CreatedAt:                time.Now(),
 		StartedAt:                nil,

--- a/lib/instances/types.go
+++ b/lib/instances/types.go
@@ -46,9 +46,10 @@ type StoredMetadata struct {
 
 	// Configuration
 	Env            map[string]string
-	NetworkEnabled bool   // Whether instance has networking enabled (uses default network)
-	IP             string // Assigned IP address (empty if NetworkEnabled=false)
-	MAC            string // Assigned MAC address (empty if NetworkEnabled=false)
+	Metadata       map[string]string // User-defined key-value metadata
+	NetworkEnabled bool              // Whether instance has networking enabled (uses default network)
+	IP             string            // Assigned IP address (empty if NetworkEnabled=false)
+	MAC            string            // Assigned MAC address (empty if NetworkEnabled=false)
 
 	// Attached volumes
 	Volumes []VolumeAttachment // Volumes attached to this instance
@@ -106,6 +107,7 @@ type CreateInstanceRequest struct {
 	NetworkBandwidthUpload   int64              // Upload rate limit bytes/sec (0 = auto, proportional to CPU)
 	DiskIOBps                int64              // Disk I/O rate limit bytes/sec (0 = auto, proportional to CPU)
 	Env                      map[string]string  // Optional environment variables
+	Metadata                 map[string]string  // Optional user-defined key-value metadata
 	NetworkEnabled           bool               // Whether to enable networking (uses default network)
 	Devices                  []string           // Device IDs or names to attach (GPU passthrough)
 	Volumes                  []VolumeAttachment // Volumes to attach at creation time

--- a/lib/oapi/oapi.go
+++ b/lib/oapi/oapi.go
@@ -246,6 +246,9 @@ type CreateInstanceRequest struct {
 	// Image OCI image reference
 	Image string `json:"image"`
 
+	// Metadata User-defined key-value metadata
+	Metadata *map[string]string `json:"metadata,omitempty"`
+
 	// Name Human-readable name (lowercase letters, digits, and dashes only; cannot start or end with a dash)
 	Name string `json:"name"`
 
@@ -491,6 +494,9 @@ type Instance struct {
 
 	// Image OCI image reference
 	Image string `json:"image"`
+
+	// Metadata User-defined key-value metadata
+	Metadata *map[string]string `json:"metadata,omitempty"`
 
 	// Name Human-readable name
 	Name string `json:"name"`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -144,6 +144,14 @@ components:
           example:
             PORT: "3000"
             NODE_ENV: production
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: User-defined key-value metadata for the instance
+          example:
+            team: backend
+            purpose: staging
         network:
           type: object
           description: Network configuration for the instance
@@ -227,6 +235,11 @@ components:
           additionalProperties:
             type: string
           description: Environment variables
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: User-defined key-value metadata
         network:
           type: object
           description: Network configuration of the instance


### PR DESCRIPTION
## Summary
- Adds optional `metadata` (map of string key-value pairs) to instance creation and response
- Metadata is stored in instance config alongside environment variables and persisted to disk
- Returned in GET /instances and GET /instances/{id} responses
- Changes span domain types, API layer, generated OAPI types, and OpenAPI spec

## Test plan
- [ ] Create instance without metadata — verify no regression
- [ ] Create instance with `metadata: {"team": "backend", "env": "staging"}` — verify stored and returned
- [ ] GET /instances — verify metadata is included in list response
- [ ] GET /instances/{id} — verify metadata is included in detail response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API field and persistence wiring with minimal impact on existing flows; main risk is backwards/forwards compatibility with clients expecting strict schemas.
> 
> **Overview**
> Adds optional `metadata` (string map) to instance creation requests and persists it alongside other instance config.
> 
> Plumbs `metadata` through the API -> domain `CreateInstanceRequest` -> stored instance metadata, and returns it in instance responses when present; updates generated OAPI types and `openapi.yaml` to document the new field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdae3682a18f7989ffc3d0dbedcbcfdcf4f29f94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->