### PR TITLE
Pin oapi generator version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,14 @@ $(BIN_DIR):
 
 # Local binary paths
 OAPI_CODEGEN ?= $(BIN_DIR)/oapi-codegen
+OAPI_CODEGEN_VERSION ?= v2.5.1
 AIR ?= $(BIN_DIR)/air
 WIRE ?= $(BIN_DIR)/wire
 XCADDY ?= $(BIN_DIR)/xcaddy
 
 # Install oapi-codegen
 $(OAPI_CODEGEN): | $(BIN_DIR)
-	GOBIN=$(BIN_DIR) go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+	GOBIN=$(BIN_DIR) go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@$(OAPI_CODEGEN_VERSION)
 
 # Install air for hot reload
 $(AIR): | $(BIN_DIR)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: build tooling change only, affecting how `oapi-codegen` is installed (version drift prevention) but not runtime logic.
> 
> **Overview**
> Pins OpenAPI code generation tooling by adding `OAPI_CODEGEN_VERSION` and switching `make install-tools` to install `oapi-codegen` at that fixed version instead of `@latest`, improving reproducibility of generated code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae207c26891fae379936ba517bec9d2005c706c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->