### PR TITLE
fix: wire DockerSocket config into build manager

### DIFF
--- a/lib/providers/providers.go
+++ b/lib/providers/providers.go
@@ -289,6 +289,7 @@ func ProvideBuildManager(p *paths.Paths, cfg *config.Config, instanceManager ins
 		RegistryCACert:      registryCACert,
 		DefaultTimeout:      cfg.Build.Timeout,
 		RegistrySecret:      cfg.JwtSecret, // Use same secret for registry tokens
+		DockerSocket:        cfg.Build.DockerSocket,
 	}
 
 	// Configure secret provider (use NoOpSecretProvider as fallback to avoid nil panics)


### PR DESCRIPTION
## Summary

`cfg.Build.DockerSocket` was defined in the app config struct and parsed from `config.yaml`, but never passed through to `builds.Config` in `lib/providers/providers.go`. This meant the `docker_socket` value (e.g. Colima's `~/.colima/default/docker.sock`) was silently ignored and the build manager always fell back to the hardcoded `/var/run/docker.sock`, breaking `make dev-darwin` on machines using Colima or other non-default Docker socket paths.

## Change

One-line fix in `lib/providers/providers.go` — adds `DockerSocket: cfg.Build.DockerSocket` to the `builds.Config` initialization.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config plumbing change: it only adds a missing field mapping so the build manager can use a non-default Docker socket path; no behavioral changes elsewhere unless `Build.DockerSocket` is set.
> 
> **Overview**
> Wires `cfg.Build.DockerSocket` through `ProvideBuildManager` into `builds.Config`, so the build system can use a configured Docker socket path instead of implicitly relying on the default socket.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 848d7e43324e4cc61ffa6ac76fa8ef31011c4fe2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->