### PR TITLE
Update stainless config: fork, instance stats

### DIFF
--- a/stainless.yaml
+++ b/stainless.yaml
@@ -78,6 +78,7 @@ resources:
       delete: delete /instances/{id}
       standby: post /instances/{id}/standby
       restore: post /instances/{id}/restore
+      fork: post /instances/{id}/fork
       start: post /instances/{id}/start
       stop: post /instances/{id}/stop
       logs: get /instances/{id}/logs

--- a/stainless.yaml
+++ b/stainless.yaml
@@ -71,6 +71,7 @@ resources:
       port_mapping: "#/components/schemas/PortMapping"
       instance: "#/components/schemas/Instance"
       path_info: "#/components/schemas/PathInfo"
+      instance_stats: "#/components/schemas/InstanceStats"
     methods:
       list: get /instances
       create: post /instances
@@ -83,6 +84,7 @@ resources:
       stop: post /instances/{id}/stop
       logs: get /instances/{id}/logs
       stat: get /instances/{id}/stat
+      stats: get /instances/{id}/stats
     # Subresources define resources that are nested within another for more powerful
     # logical groupings, e.g. `cards.payments`.
     subresources:


### PR DESCRIPTION
Summary
- document the missing `fork` resource for instance operations in `stainless.yaml`

Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds new generated SDK surface area (new endpoints/types) without altering runtime behavior.
> 
> **Overview**
> Adds missing instance functionality to the Stainless config by exposing `POST /instances/{id}/fork` and `GET /instances/{id}/stats`, and registering the `InstanceStats` model under `instances` for codegen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 360ef45d08687695cb28d9377d366073920f546e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->