### PR TITLE
chore: speed up CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,17 @@ jobs:
     runs-on: [self-hosted, linux, x64, kvm]
     steps:
       - uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Clean workspace (preserve binary caches)
+        run: |
+          git reset --hard HEAD
+          git clean -ffdx \
+            -e lib/vmm/binaries/ \
+            -e lib/hypervisor/firecracker/binaries/ \
+            -e lib/ingress/binaries/ \
+            -e bin/
       
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -35,9 +46,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Clean cached binaries
-        run: make clean
 
       - name: Generate OpenAPI code
         run: make oapi-generate

--- a/cmd/api/api/api_test.go
+++ b/cmd/api/api/api_test.go
@@ -26,11 +26,7 @@ import (
 func newTestService(t *testing.T) *ApiService {
 	cfg := &config.Config{
 		DataDir: t.TempDir(),
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}
 
 	p := paths.New(cfg.DataDir)

--- a/cmd/api/api/cp_test.go
+++ b/cmd/api/api/cp_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestCpToAndFromInstance(t *testing.T) {
+	t.Parallel()
 	// Require KVM access for VM creation
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
@@ -156,6 +157,7 @@ func TestCpToAndFromInstance(t *testing.T) {
 }
 
 func TestCpDirectoryToInstance(t *testing.T) {
+	t.Parallel()
 	// Require KVM access for VM creation
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")

--- a/cmd/api/api/exec_test.go
+++ b/cmd/api/api/exec_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestExecInstanceNonTTY(t *testing.T) {
+	t.Parallel()
 	// Require KVM access for VM creation
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
@@ -158,6 +159,7 @@ func TestExecInstanceNonTTY(t *testing.T) {
 // 2. guest-agent must keep running even after the main app exits
 // 3. The VM must not kernel panic when the entrypoint exits
 func TestExecWithDebianMinimal(t *testing.T) {
+	t.Parallel()
 	// Require KVM access for VM creation
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")

--- a/cmd/api/api/images_test.go
+++ b/cmd/api/api/images_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestListImages_Empty(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	resp, err := svc.ListImages(ctx(), oapi.ListImagesRequestObject{})
@@ -24,6 +25,7 @@ func TestListImages_Empty(t *testing.T) {
 }
 
 func TestGetImage_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	// With middleware, not-found would be handled before reaching handler.
@@ -33,6 +35,7 @@ func TestGetImage_NotFound(t *testing.T) {
 }
 
 func TestCreateImage_Async(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 	ctx := ctx()
 
@@ -125,6 +128,7 @@ func TestCreateImage_Async(t *testing.T) {
 }
 
 func TestCreateImage_InvalidTag(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 	ctx := ctx()
 
@@ -147,6 +151,7 @@ func TestCreateImage_InvalidTag(t *testing.T) {
 }
 
 func TestCreateImage_InvalidName(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 	ctx := ctx()
 
@@ -171,6 +176,7 @@ func TestCreateImage_InvalidName(t *testing.T) {
 }
 
 func TestCreateImage_Idempotent(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 	ctx := ctx()
 

--- a/cmd/api/api/instances_test.go
+++ b/cmd/api/api/instances_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestListInstances_Empty(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	resp, err := svc.ListInstances(ctx(), oapi.ListInstancesRequestObject{})
@@ -30,6 +31,7 @@ func TestListInstances_Empty(t *testing.T) {
 }
 
 func TestGetInstance_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	// With middleware, not-found would be handled before reaching handler.
@@ -39,6 +41,7 @@ func TestGetInstance_NotFound(t *testing.T) {
 }
 
 func TestCreateInstance_ParsesHumanReadableSizes(t *testing.T) {
+	t.Parallel()
 	// Require KVM access for VM creation
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
@@ -105,6 +108,7 @@ func TestCreateInstance_ParsesHumanReadableSizes(t *testing.T) {
 }
 
 func TestCreateInstance_InvalidSizeFormat(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	// Test with invalid size format
@@ -179,6 +183,7 @@ func (m *captureCreateManager) CreateInstance(ctx context.Context, req instances
 }
 
 func TestCreateInstance_OmittedHotplugSizeDefaultsToZero(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	origMgr := svc.InstanceManager
@@ -211,6 +216,7 @@ func TestCreateInstance_OmittedHotplugSizeDefaultsToZero(t *testing.T) {
 }
 
 func TestForkInstance_Success(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	now := time.Now()
@@ -264,6 +270,7 @@ func TestForkInstance_Success(t *testing.T) {
 }
 
 func TestForkInstance_NotSupported(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	source := instances.Instance{
@@ -300,6 +307,7 @@ func TestForkInstance_NotSupported(t *testing.T) {
 }
 
 func TestForkInstance_InvalidRequest(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	source := instances.Instance{
@@ -336,6 +344,7 @@ func TestForkInstance_InvalidRequest(t *testing.T) {
 }
 
 func TestForkInstance_FromRunningFlagForwarded(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	now := time.Now()
@@ -390,6 +399,7 @@ func TestForkInstance_FromRunningFlagForwarded(t *testing.T) {
 }
 
 func TestInstanceLifecycle_StopStart(t *testing.T) {
+	t.Parallel()
 	// Require KVM access for VM creation
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available - skipping lifecycle test")

--- a/cmd/api/api/registry_test.go
+++ b/cmd/api/api/registry_test.go
@@ -47,6 +47,7 @@ func setupRegistryTest(t *testing.T) (*ApiService, string) {
 }
 
 func TestRegistryPushAndConvert(t *testing.T) {
+	t.Parallel()
 	svc, serverHost := setupRegistryTest(t)
 
 	// Pull a small image from Docker Hub to push to our registry
@@ -80,6 +81,7 @@ func TestRegistryPushAndConvert(t *testing.T) {
 }
 
 func TestRegistryVersionCheck(t *testing.T) {
+	t.Parallel()
 	_, serverHost := setupRegistryTest(t)
 
 	// Test /v2/ endpoint (version check)
@@ -92,6 +94,7 @@ func TestRegistryVersionCheck(t *testing.T) {
 }
 
 func TestRegistryPushAndCreateInstance(t *testing.T) {
+	t.Parallel()
 	// This is a full e2e test that requires KVM access
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available - skipping VM creation test")
@@ -174,6 +177,7 @@ func TestRegistryPushAndCreateInstance(t *testing.T) {
 // TestRegistryLayerCaching verifies that pushing the same image twice
 // reuses cached layers and doesn't re-upload them.
 func TestRegistryLayerCaching(t *testing.T) {
+	t.Parallel()
 	_, serverHost := setupRegistryTest(t)
 
 	// Pull alpine image from Docker Hub
@@ -257,6 +261,7 @@ func TestRegistryLayerCaching(t *testing.T) {
 // TestRegistrySharedLayerCaching verifies that pushing different images
 // that share layers reuses the cached shared layers.
 func TestRegistrySharedLayerCaching(t *testing.T) {
+	t.Parallel()
 	_, serverHost := setupRegistryTest(t)
 
 	// Pull alpine image (this will be our base)
@@ -338,6 +343,7 @@ func TestRegistrySharedLayerCaching(t *testing.T) {
 // TestRegistryTagPush verifies that pushing with a tag reference (not digest)
 // correctly triggers conversion. The server computes the digest from the manifest.
 func TestRegistryTagPush(t *testing.T) {
+	t.Parallel()
 	svc, serverHost := setupRegistryTest(t)
 
 	// Pull alpine image from Docker Hub
@@ -391,6 +397,7 @@ func TestRegistryTagPush(t *testing.T) {
 // Docker v2 manifest (as returned by local Docker daemon) is correctly converted
 // to OCI format and the image conversion succeeds.
 func TestRegistryDockerV2ManifestConversion(t *testing.T) {
+	t.Parallel()
 	svc, serverHost := setupRegistryTest(t)
 
 	// Pull alpine image from Docker Hub (OCI format)

--- a/cmd/api/api/test_network_config_test.go
+++ b/cmd/api/api/test_network_config_test.go
@@ -6,12 +6,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kernel/hypeman/cmd/api/config"
 )
 
 var testNetworkSeq atomic.Uint32
 var testNetworkByName sync.Map
+var testNetworkRunSeed = uint32(time.Now().UnixNano()) ^ uint32(os.Getpid()<<8)
 
 func newParallelTestNetworkConfig(t *testing.T) config.NetworkConfig {
 	t.Helper()
@@ -21,11 +23,12 @@ func newParallelTestNetworkConfig(t *testing.T) config.NetworkConfig {
 	}
 
 	seq := testNetworkSeq.Add(1)
-	pid := uint32(os.Getpid())
+	const subnetSpace = 50 * 250 // second octet 200-249, third octet 1-250
+	subnetIdx := (testNetworkRunSeed + seq - 1) % subnetSpace
 
-	bridge := fmt.Sprintf("ha%04x%03x", pid&0xffff, seq%0xfff)
-	secondOctet := int(((pid >> 4) % 100) + 100) // 100-199
-	thirdOctet := int((seq % 250) + 1)           // 1-250
+	bridge := fmt.Sprintf("ha%04x%03x", testNetworkRunSeed&0xffff, seq%0xfff)
+	secondOctet := 200 + int((subnetIdx / 250))
+	thirdOctet := int((subnetIdx % 250) + 1)
 
 	cfg := config.NetworkConfig{
 		BridgeName: bridge,

--- a/cmd/api/api/test_network_config_test.go
+++ b/cmd/api/api/test_network_config_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kernel/hypeman/cmd/api/config"
+)
+
+var testNetworkSeq atomic.Uint32
+var testNetworkByName sync.Map
+
+func newParallelTestNetworkConfig(t *testing.T) config.NetworkConfig {
+	t.Helper()
+
+	if cfg, ok := testNetworkByName.Load(t.Name()); ok {
+		return cfg.(config.NetworkConfig)
+	}
+
+	seq := testNetworkSeq.Add(1)
+	pid := uint32(os.Getpid())
+
+	bridge := fmt.Sprintf("ha%04x%03x", pid&0xffff, seq%0xfff)
+	secondOctet := int(((pid >> 4) % 100) + 100) // 100-199
+	thirdOctet := int((seq % 250) + 1)           // 1-250
+
+	cfg := config.NetworkConfig{
+		BridgeName: bridge,
+		SubnetCIDR: fmt.Sprintf("10.%d.%d.0/24", secondOctet, thirdOctet),
+		DNSServer:  "1.1.1.1",
+	}
+
+	actual, _ := testNetworkByName.LoadOrStore(t.Name(), cfg)
+	return actual.(config.NetworkConfig)
+}

--- a/cmd/api/api/volumes_test.go
+++ b/cmd/api/api/volumes_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestListVolumes_Empty(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	resp, err := svc.ListVolumes(ctx(), oapi.ListVolumesRequestObject{})
@@ -20,6 +21,7 @@ func TestListVolumes_Empty(t *testing.T) {
 }
 
 func TestGetVolume_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	// With middleware, not-found would be handled before reaching handler.
@@ -29,6 +31,7 @@ func TestGetVolume_NotFound(t *testing.T) {
 }
 
 func TestGetVolume_ByName(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	// Create a volume
@@ -54,6 +57,7 @@ func TestGetVolume_ByName(t *testing.T) {
 }
 
 func TestDeleteVolume_ByName(t *testing.T) {
+	t.Parallel()
 	svc := newTestService(t)
 
 	// Create a volume

--- a/integration/systemd_test.go
+++ b/integration/systemd_test.go
@@ -31,6 +31,7 @@ import (
 // - Starts systemd as PID 1
 // - Injects and starts the hypeman-agent.service
 func TestSystemdMode(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -49,11 +50,7 @@ func TestSystemdMode(t *testing.T) {
 
 	cfg := &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}
 
 	// Create managers

--- a/integration/test_network_config_test.go
+++ b/integration/test_network_config_test.go
@@ -6,12 +6,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kernel/hypeman/cmd/api/config"
 )
 
 var testNetworkSeq atomic.Uint32
 var testNetworkByName sync.Map
+var testNetworkRunSeed = uint32(time.Now().UnixNano()) ^ uint32(os.Getpid()<<8)
 
 func newParallelTestNetworkConfig(t *testing.T) config.NetworkConfig {
 	t.Helper()
@@ -21,11 +23,12 @@ func newParallelTestNetworkConfig(t *testing.T) config.NetworkConfig {
 	}
 
 	seq := testNetworkSeq.Add(1)
-	pid := uint32(os.Getpid())
+	const subnetSpace = 50 * 250 // second octet 200-249, third octet 1-250
+	subnetIdx := (testNetworkRunSeed + seq - 1) % subnetSpace
 
-	bridge := fmt.Sprintf("hi%04x%03x", pid&0xffff, seq%0xfff)
-	secondOctet := int(((pid >> 4) % 100) + 100) // 100-199
-	thirdOctet := int((seq % 250) + 1)           // 1-250
+	bridge := fmt.Sprintf("hi%04x%03x", testNetworkRunSeed&0xffff, seq%0xfff)
+	secondOctet := 200 + int((subnetIdx / 250))
+	thirdOctet := int((subnetIdx % 250) + 1)
 
 	cfg := config.NetworkConfig{
 		BridgeName: bridge,

--- a/integration/test_network_config_test.go
+++ b/integration/test_network_config_test.go
@@ -1,0 +1,38 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kernel/hypeman/cmd/api/config"
+)
+
+var testNetworkSeq atomic.Uint32
+var testNetworkByName sync.Map
+
+func newParallelTestNetworkConfig(t *testing.T) config.NetworkConfig {
+	t.Helper()
+
+	if cfg, ok := testNetworkByName.Load(t.Name()); ok {
+		return cfg.(config.NetworkConfig)
+	}
+
+	seq := testNetworkSeq.Add(1)
+	pid := uint32(os.Getpid())
+
+	bridge := fmt.Sprintf("hi%04x%03x", pid&0xffff, seq%0xfff)
+	secondOctet := int(((pid >> 4) % 100) + 100) // 100-199
+	thirdOctet := int((seq % 250) + 1)           // 1-250
+
+	cfg := config.NetworkConfig{
+		BridgeName: bridge,
+		SubnetCIDR: fmt.Sprintf("10.%d.%d.0/24", secondOctet, thirdOctet),
+		DNSServer:  "1.1.1.1",
+	}
+
+	actual, _ := testNetworkByName.LoadOrStore(t.Name(), cfg)
+	return actual.(config.NetworkConfig)
+}

--- a/integration/vgpu_test.go
+++ b/integration/vgpu_test.go
@@ -37,6 +37,7 @@ import (
 // It does NOT test nvidia-smi or CUDA functionality since that requires NVIDIA
 // guest drivers pre-installed in the image.
 func TestVGPU(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -58,11 +59,7 @@ func TestVGPU(t *testing.T) {
 
 	cfg := &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}
 
 	// Create managers

--- a/lib/hypervisor/firecracker/firecracker.go
+++ b/lib/hypervisor/firecracker/firecracker.go
@@ -39,7 +39,7 @@ func New(socketPath string) (*Firecracker, error) {
 		socketPath: socketPath,
 		client: &http.Client{
 			Transport: transport,
-			Timeout:   30 * time.Second,
+			Timeout:   90 * time.Second,
 		},
 	}, nil
 }

--- a/lib/hypervisor/qemu/config.go
+++ b/lib/hypervisor/qemu/config.go
@@ -40,7 +40,9 @@ func BuildArgs(cfg hypervisor.VMConfig) []string {
 	for i, disk := range cfg.Disks {
 		driveOpts := fmt.Sprintf("file=%s,format=raw,if=none,id=drive%d", disk.Path, i)
 		if disk.Readonly {
-			driveOpts += ",readonly=on"
+			// Disable host-side file locking for shared readonly bases so multiple
+			// VMs can boot concurrently from the same image without lock contention.
+			driveOpts += ",readonly=on,file.locking=off"
 		}
 		if disk.IOBps > 0 {
 			driveOpts += fmt.Sprintf(",throttling.bps-total=%d", disk.IOBps)

--- a/lib/hypervisor/qemu/config_test.go
+++ b/lib/hypervisor/qemu/config_test.go
@@ -68,7 +68,7 @@ func TestBuildArgs_Disks(t *testing.T) {
 		if arg == "file=/path/to/rootfs.ext4,format=raw,if=none,id=drive0" {
 			foundDrive0 = true
 		}
-		if arg == "file=/path/to/data.ext4,format=raw,if=none,id=drive1,readonly=on" {
+		if arg == "file=/path/to/data.ext4,format=raw,if=none,id=drive1,readonly=on,file.locking=off" {
 			foundDrive1 = true
 		}
 	}

--- a/lib/hypervisor/qemu/process.go
+++ b/lib/hypervisor/qemu/process.go
@@ -33,6 +33,11 @@ const (
 
 	// socketDialTimeout is timeout for individual socket connection attempts
 	socketDialTimeout = 100 * time.Millisecond
+
+	// clientCreateTimeout is how long to retry QMP client creation after the
+	// socket appears. Under high parallel load the socket can accept connections
+	// slightly later than file creation/availability.
+	clientCreateTimeout = 3 * time.Second
 )
 
 func init() {
@@ -189,11 +194,20 @@ func (s *Starter) startQEMUProcess(ctx context.Context, p *paths.Paths, version 
 	}
 	log.DebugContext(ctx, "QMP socket ready", "duration_ms", time.Since(socketWaitStart).Milliseconds())
 
-	// Create QMP client
-	hv, err := New(socketPath)
-	if err != nil {
-		cu.Clean()
-		return 0, nil, nil, fmt.Errorf("create client: %w", err)
+	// Create QMP client. The socket file may exist before QEMU can actually
+	// accept monitor connections, so retry briefly on transient dial failures.
+	var hv *QEMU
+	clientDeadline := time.Now().Add(clientCreateTimeout)
+	for {
+		hv, err = New(socketPath)
+		if err == nil {
+			break
+		}
+		if time.Now().After(clientDeadline) {
+			cu.Clean()
+			return 0, nil, nil, fmt.Errorf("create client: %w", err)
+		}
+		time.Sleep(socketPollInterval)
 	}
 
 	return pid, hv, &cu, nil

--- a/lib/instances/cpu_test.go
+++ b/lib/instances/cpu_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCalculateGuestTopology(t *testing.T) {
+	t.Parallel()
 	// Host with 2 threads/core, 8 cores/socket, 2 sockets (common server config)
 	host := &HostTopology{
 		ThreadsPerCore: 2,
@@ -128,6 +129,7 @@ func TestCalculateGuestTopology(t *testing.T) {
 }
 
 func TestCalculateGuestTopologyNoSMT(t *testing.T) {
+	t.Parallel()
 	// Host without hyperthreading (1 thread/core)
 	host := &HostTopology{
 		ThreadsPerCore: 1,

--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -14,6 +14,8 @@ import (
 	"github.com/kernel/hypeman/lib/network"
 )
 
+const deleteGracefulShutdownTimeout = 2
+
 // deleteInstance stops and deletes an instance
 func (m *manager) deleteInstance(
 	ctx context.Context,
@@ -52,6 +54,9 @@ func (m *manager) deleteInstance(
 	gracefulShutdown := false
 	if inst.State == StateRunning {
 		stopTimeout := resolveStopTimeout(stored)
+		if stopTimeout > deleteGracefulShutdownTimeout {
+			stopTimeout = deleteGracefulShutdownTimeout
+		}
 		gracefulShutdown = m.tryGracefulGuestShutdown(ctx, &inst, stopTimeout)
 		if !gracefulShutdown {
 			log.DebugContext(ctx, "graceful shutdown before delete did not complete", "instance_id", id)
@@ -174,14 +179,33 @@ func (m *manager) killHypervisor(ctx context.Context, inst *Instance) error {
 // WaitForProcessExit polls for a process to exit, returns true if exited within timeout.
 // Exported for use in tests.
 func WaitForProcessExit(pid int, timeout time.Duration) bool {
+	if pid <= 0 {
+		return true
+	}
+
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
-		// Check if process still exists (signal 0 doesn't kill, just checks existence)
-		if err := syscall.Kill(pid, 0); err != nil {
-			// Process is gone (ESRCH = no such process)
+		// Reap exited child processes to avoid treating zombies as still-running.
+		var status syscall.WaitStatus
+		reapedPID, waitErr := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+		switch {
+		case waitErr == nil && reapedPID == pid:
 			return true
+		case waitErr == nil && reapedPID == 0:
+			// Process still running (or wait status not yet available).
+		case waitErr == syscall.ECHILD:
+			// Not our child (or already reaped elsewhere). Fall back to existence check.
+			if err := syscall.Kill(pid, 0); err != nil {
+				return true
+			}
+		default:
+			// Best effort fallback on transient/unexpected wait errors.
+			if err := syscall.Kill(pid, 0); err != nil {
+				return true
+			}
 		}
+
 		// Still alive, wait a bit before checking again
 		// 10ms polling interval balances responsiveness with CPU usage
 		time.Sleep(10 * time.Millisecond)

--- a/lib/instances/delete_test.go
+++ b/lib/instances/delete_test.go
@@ -1,0 +1,37 @@
+package instances
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForProcessExit_ReapsZombieChild(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 0")
+	require.NoError(t, cmd.Start())
+
+	// Allow child to exit; until reaped it remains as a zombie.
+	time.Sleep(25 * time.Millisecond)
+
+	start := time.Now()
+	exited := WaitForProcessExit(cmd.Process.Pid, 500*time.Millisecond)
+	elapsed := time.Since(start)
+
+	require.True(t, exited, "zombie child should be detected/reaped as exited")
+	assert.Less(t, elapsed, 250*time.Millisecond, "reaping should be quick")
+}
+
+func TestWaitForProcessExit_TimesOutForRunningProcess(t *testing.T) {
+	cmd := exec.Command("sleep", "2")
+	require.NoError(t, cmd.Start())
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	exited := WaitForProcessExit(cmd.Process.Pid, 100*time.Millisecond)
+	assert.False(t, exited, "running process should time out")
+}

--- a/lib/instances/delete_test.go
+++ b/lib/instances/delete_test.go
@@ -10,11 +10,9 @@ import (
 )
 
 func TestWaitForProcessExit_ReapsZombieChild(t *testing.T) {
+	t.Parallel()
 	cmd := exec.Command("sh", "-c", "exit 0")
 	require.NoError(t, cmd.Start())
-
-	// Allow child to exit; until reaped it remains as a zombie.
-	time.Sleep(25 * time.Millisecond)
 
 	start := time.Now()
 	exited := WaitForProcessExit(cmd.Process.Pid, 500*time.Millisecond)
@@ -25,6 +23,7 @@ func TestWaitForProcessExit_ReapsZombieChild(t *testing.T) {
 }
 
 func TestWaitForProcessExit_TimesOutForRunningProcess(t *testing.T) {
+	t.Parallel()
 	cmd := exec.Command("sleep", "2")
 	require.NoError(t, cmd.Start())
 	defer func() {

--- a/lib/instances/exec_test.go
+++ b/lib/instances/exec_test.go
@@ -48,6 +48,7 @@ func waitForExecAgent(ctx context.Context, mgr *manager, instanceID string, time
 // TestExecConcurrent tests concurrent exec commands from multiple goroutines.
 // This validates that the exec infrastructure handles concurrent access correctly.
 func TestExecConcurrent(t *testing.T) {
+	t.Parallel()
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
 	}

--- a/lib/instances/filter_test.go
+++ b/lib/instances/filter_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestListInstancesFilter_Matches(t *testing.T) {
+	t.Parallel()
 	running := StateRunning
 	stopped := StateStopped
 
@@ -132,6 +133,7 @@ func TestListInstancesFilter_Matches(t *testing.T) {
 }
 
 func TestListInstancesFilter_Matches_NilMetadata(t *testing.T) {
+	t.Parallel()
 	inst := &Instance{
 		StoredMetadata: StoredMetadata{
 			Id:       "inst-2",
@@ -149,6 +151,7 @@ func TestListInstancesFilter_Matches_NilMetadata(t *testing.T) {
 // TestListInstances_WithFilter exercises the full ListInstances path using
 // on-disk metadata files (no KVM required).
 func TestListInstances_WithFilter(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	p := paths.New(tmpDir)
 

--- a/lib/instances/firecracker_test.go
+++ b/lib/instances/firecracker_test.go
@@ -28,11 +28,7 @@ func setupTestManagerForFirecracker(t *testing.T) (*manager, string) {
 	tmpDir := t.TempDir()
 	cfg := &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}
 
 	p := paths.New(tmpDir)
@@ -91,6 +87,7 @@ func createNginxImageAndWait(t *testing.T, ctx context.Context, imageManager ima
 }
 
 func TestFirecrackerStandbyAndRestore(t *testing.T) {
+	t.Parallel()
 	requireFirecrackerIntegrationPrereqs(t)
 
 	mgr, tmpDir := setupTestManagerForFirecracker(t)
@@ -139,6 +136,7 @@ func TestFirecrackerStandbyAndRestore(t *testing.T) {
 }
 
 func TestFirecrackerStopClearsStaleSnapshot(t *testing.T) {
+	t.Parallel()
 	requireFirecrackerIntegrationPrereqs(t)
 
 	mgr, tmpDir := setupTestManagerForFirecracker(t)
@@ -201,6 +199,7 @@ func TestFirecrackerStopClearsStaleSnapshot(t *testing.T) {
 }
 
 func TestFirecrackerNetworkLifecycle(t *testing.T) {
+	t.Parallel()
 	requireFirecrackerIntegrationPrereqs(t)
 
 	mgr, tmpDir := setupTestManagerForFirecracker(t)
@@ -242,9 +241,10 @@ func TestFirecrackerNetworkLifecycle(t *testing.T) {
 	assert.True(t, strings.HasPrefix(tap.Attrs().Name, "hype-"))
 	assert.Equal(t, uint8(netlink.OperUp), uint8(tap.Attrs().OperState))
 
-	bridge, err := netlink.LinkByName("vmbr0")
+	master, err := netlink.LinkByIndex(tap.Attrs().MasterIndex)
 	require.NoError(t, err)
-	assert.Equal(t, bridge.Attrs().Index, tap.Attrs().MasterIndex)
+	_, isBridge := master.(*netlink.Bridge)
+	assert.True(t, isBridge, "TAP should be attached to a bridge")
 
 	require.NoError(t, waitForLogMessage(ctx, mgr, inst.Id, "start worker processes", 15*time.Second))
 	require.NoError(t, waitForLogMessage(ctx, mgr, inst.Id, "[guest-agent] listening", 10*time.Second))
@@ -318,6 +318,7 @@ func TestFirecrackerNetworkLifecycle(t *testing.T) {
 }
 
 func TestFirecrackerForkFromRunningNetwork(t *testing.T) {
+	t.Parallel()
 	requireFirecrackerIntegrationPrereqs(t)
 
 	mgr, tmpDir := setupTestManagerForFirecracker(t)
@@ -383,6 +384,7 @@ func TestFirecrackerForkFromRunningNetwork(t *testing.T) {
 }
 
 func TestFirecrackerSnapshotFeature(t *testing.T) {
+	t.Parallel()
 	requireFirecrackerIntegrationPrereqs(t)
 
 	mgr, tmpDir := setupTestManagerForFirecracker(t)

--- a/lib/instances/fork_test.go
+++ b/lib/instances/fork_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestForkInstance_VZStoppedSourceSupported(t *testing.T) {
+	t.Parallel()
 	manager, _ := setupTestManager(t)
 	ctx := context.Background()
 	if _, err := manager.getVMStarter(hypervisor.TypeVZ); err != nil {
@@ -54,6 +55,7 @@ func TestForkInstance_VZStoppedSourceSupported(t *testing.T) {
 }
 
 func TestResolveForkTargetState_DefaultsToSourceState(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		source State
@@ -74,6 +76,7 @@ func TestResolveForkTargetState_DefaultsToSourceState(t *testing.T) {
 }
 
 func TestValidateForkRequest_InvalidTargetState(t *testing.T) {
+	t.Parallel()
 	err := validateForkRequest(ForkInstanceRequest{
 		Name:        "fork-invalid-target",
 		TargetState: State("Created"),
@@ -83,6 +86,7 @@ func TestValidateForkRequest_InvalidTargetState(t *testing.T) {
 }
 
 func TestValidateForkVolumeSafety(t *testing.T) {
+	t.Parallel()
 	err := validateForkVolumeSafety([]VolumeAttachment{
 		{VolumeID: "vol-rw", MountPath: "/data", Readonly: false},
 	})
@@ -97,6 +101,7 @@ func TestValidateForkVolumeSafety(t *testing.T) {
 }
 
 func TestCleanupForkInstanceOnError(t *testing.T) {
+	t.Parallel()
 	manager, _ := setupTestManager(t)
 	ctx := context.Background()
 
@@ -127,6 +132,7 @@ func TestCleanupForkInstanceOnError(t *testing.T) {
 }
 
 func TestForkInstance_CleansUpOnTargetTransitionError(t *testing.T) {
+	t.Parallel()
 	manager, _ := setupTestManager(t)
 	ctx := context.Background()
 
@@ -163,6 +169,7 @@ func TestForkInstance_CleansUpOnTargetTransitionError(t *testing.T) {
 }
 
 func TestForkInstanceRejectsDuplicateNameForNonNetworkedSource(t *testing.T) {
+	t.Parallel()
 	manager, _ := setupTestManager(t)
 	ctx := context.Background()
 
@@ -209,6 +216,7 @@ func TestForkInstanceRejectsDuplicateNameForNonNetworkedSource(t *testing.T) {
 }
 
 func TestCloneStoredMetadataForFork_DeepCopiesReferenceFields(t *testing.T) {
+	t.Parallel()
 	startedAt := time.Now().Add(-2 * time.Minute)
 	stoppedAt := time.Now().Add(-1 * time.Minute)
 	pid := 1234
@@ -255,6 +263,7 @@ func TestCloneStoredMetadataForFork_DeepCopiesReferenceFields(t *testing.T) {
 }
 
 func TestRotateSourceVsockForRestore_CloudHypervisorDoesNotPersistCIDRewrite(t *testing.T) {
+	t.Parallel()
 	manager, _ := setupTestManager(t)
 	ctx := context.Background()
 
@@ -289,6 +298,7 @@ func TestRotateSourceVsockForRestore_CloudHypervisorDoesNotPersistCIDRewrite(t *
 }
 
 func TestRotateSourceVsockForRestore_QEMUPersistsCIDRewrite(t *testing.T) {
+	t.Parallel()
 	manager, _ := setupTestManager(t)
 	ctx := context.Background()
 
@@ -326,6 +336,7 @@ func TestRotateSourceVsockForRestore_QEMUPersistsCIDRewrite(t *testing.T) {
 }
 
 func TestForkCloudHypervisorFromRunningNetwork(t *testing.T) {
+	t.Parallel()
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
 	}

--- a/lib/instances/manager_darwin_test.go
+++ b/lib/instances/manager_darwin_test.go
@@ -40,11 +40,7 @@ func setupVZTestManager(t *testing.T) (*manager, string) {
 
 	cfg := &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}
 
 	p := paths.New(tmpDir)
@@ -105,6 +101,7 @@ func vzExecCommand(ctx context.Context, inst *Instance, command ...string) (stri
 
 // TestVZBasicLifecycle tests the full vz instance lifecycle: create, exec, stop, start, delete.
 func TestVZBasicLifecycle(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS != "darwin" {
 		t.Skip("vz tests require macOS")
 	}
@@ -274,6 +271,7 @@ func TestVZBasicLifecycle(t *testing.T) {
 
 // TestVZExecAndShutdown focuses on exec behavior and graceful shutdown.
 func TestVZExecAndShutdown(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS != "darwin" {
 		t.Skip("vz tests require macOS")
 	}
@@ -375,6 +373,7 @@ func TestVZExecAndShutdown(t *testing.T) {
 
 // TestVZStandbyAndRestore tests the full standby/restore cycle for the vz hypervisor.
 func TestVZStandbyAndRestore(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS != "darwin" {
 		t.Skip("vz tests require macOS")
 	}
@@ -536,6 +535,7 @@ func TestVZStandbyAndRestore(t *testing.T) {
 // TestVZForkFromRunningNetwork mirrors the running-source fork flow validated for
 // cloud-hypervisor, but on macOS VZ.
 func TestVZForkFromRunningNetwork(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS != "darwin" {
 		t.Skip("vz tests require macOS")
 	}
@@ -734,6 +734,7 @@ func ensureMkfsExt4Available(t *testing.T) {
 }
 
 func TestVZSnapshotFeature(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS != "darwin" {
 		t.Skip("vz tests require macOS")
 	}

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -38,11 +38,7 @@ func setupTestManager(t *testing.T) (*manager, string) {
 
 	cfg := &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}
 
 	p := paths.New(tmpDir)
@@ -184,6 +180,7 @@ func cleanupOrphanedProcesses(t *testing.T, mgr *manager) {
 }
 
 func TestBasicEndToEnd(t *testing.T) {
+	t.Parallel()
 	// Require KVM access (don't skip, fail informatively)
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
@@ -246,11 +243,7 @@ func TestBasicEndToEnd(t *testing.T) {
 	// Initialize network for ingress testing
 	networkManager := network.NewManager(p, &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}, nil)
 	t.Log("Initializing network...")
 	err = networkManager.Initialize(ctx, nil)
@@ -805,6 +798,7 @@ func TestBasicEndToEnd(t *testing.T) {
 // host lazily parses sentinel from serial log -> ExitCode/ExitMessage in metadata.
 // Uses alpine with a non-existent command override to get exit code 127 ("command not found").
 func TestAppExitPropagation(t *testing.T) {
+	t.Parallel()
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
 	}
@@ -894,6 +888,7 @@ func TestAppExitPropagation(t *testing.T) {
 // Creates a VM with low memory and runs a command that allocates more than available,
 // triggering the OOM killer. Verifies exit code 137 and "OOM" in the exit message.
 func TestOOMExitPropagation(t *testing.T) {
+	t.Parallel()
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
 	}
@@ -999,6 +994,7 @@ func TestOOMExitPropagation(t *testing.T) {
 // This uses bitnami/redis which configures REDIS_PASSWORD from an env var - if auth is required,
 // it proves the entrypoint received and used the env var.
 func TestEntrypointEnvVars(t *testing.T) {
+	t.Parallel()
 	if os.Getuid() != 0 {
 		t.Skip("Skipping test that requires root")
 	}
@@ -1045,11 +1041,7 @@ func TestEntrypointEnvVars(t *testing.T) {
 	// Initialize network (needed for loopback interface in guest)
 	networkManager := network.NewManager(p, &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}, nil)
 	t.Log("Initializing network...")
 	err = networkManager.Initialize(ctx, nil)
@@ -1160,16 +1152,13 @@ func TestEntrypointEnvVars(t *testing.T) {
 }
 
 func TestStorageOperations(t *testing.T) {
+	t.Parallel()
 	// Test storage layer without starting VMs
 	tmpDir := t.TempDir()
 
 	cfg := &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 		Oversubscription: config.OversubscriptionConfig{
 			CPU: 1.0, Memory: 1.0, Disk: 1.0, Network: 1.0,
 		},
@@ -1240,6 +1229,7 @@ func TestStorageOperations(t *testing.T) {
 }
 
 func TestStandbyAndRestore(t *testing.T) {
+	t.Parallel()
 	// Require KVM access (don't skip, fail informatively)
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
@@ -1358,6 +1348,7 @@ func TestStandbyAndRestore(t *testing.T) {
 }
 
 func TestCloudHypervisorSnapshotFeature(t *testing.T) {
+	t.Parallel()
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
 	}
@@ -1372,6 +1363,7 @@ func TestCloudHypervisorSnapshotFeature(t *testing.T) {
 }
 
 func TestStateTransitions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		from       State

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -1070,10 +1070,6 @@ func TestEntrypointEnvVars(t *testing.T) {
 	assert.Equal(t, StateRunning, inst.State)
 	t.Logf("Instance created: %s", inst.Id)
 
-	// Wait for redis to be ready (bitnami/redis takes longer to start)
-	t.Log("Waiting for redis to be ready...")
-	time.Sleep(15 * time.Second)
-
 	// Helper to run command in guest with retry
 	runCmd := func(command ...string) (string, int, error) {
 		var lastOutput string
@@ -1085,9 +1081,9 @@ func TestEntrypointEnvVars(t *testing.T) {
 			return "", -1, err
 		}
 
-		for attempt := 0; attempt < 5; attempt++ {
+		for attempt := 0; attempt < 20; attempt++ {
 			if attempt > 0 {
-				time.Sleep(200 * time.Millisecond)
+				time.Sleep(300 * time.Millisecond)
 			}
 
 			var stdout, stderr bytes.Buffer
@@ -1121,6 +1117,20 @@ func TestEntrypointEnvVars(t *testing.T) {
 		}
 
 		return lastOutput, lastExitCode, lastErr
+	}
+
+	// Wait until Redis is actually accepting authenticated commands.
+	t.Log("Waiting for redis to accept authenticated commands...")
+	redisReadyDeadline := time.Now().Add(45 * time.Second)
+	for {
+		output, exitCode, cmdErr := runCmd("redis-cli", "-a", testPassword, "PING")
+		if cmdErr == nil && exitCode == 0 && strings.Contains(output, "PONG") {
+			break
+		}
+		if time.Now().After(redisReadyDeadline) {
+			t.Fatalf("redis did not become ready in time; last output=%q exit=%d err=%v", output, exitCode, cmdErr)
+		}
+		time.Sleep(300 * time.Millisecond)
 	}
 
 	// Test 1: PING without auth should fail

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -322,7 +322,7 @@ func TestBasicEndToEnd(t *testing.T) {
 	// Poll for logs to contain nginx startup message
 	var logs string
 	foundNginxStartup := false
-	for i := 0; i < 50; i++ { // Poll for up to 5 seconds (50 * 100ms)
+	for i := 0; i < 200; i++ { // Poll for up to 20 seconds (200 * 100ms)
 		logs, err = collectLogs(ctx, manager, inst.Id, 100)
 		require.NoError(t, err)
 
@@ -336,7 +336,7 @@ func TestBasicEndToEnd(t *testing.T) {
 	t.Logf("Instance logs (last 100 lines):\n%s", logs)
 
 	// Verify nginx started successfully
-	assert.True(t, foundNginxStartup, "Nginx should have started worker processes within 5 seconds")
+	assert.True(t, foundNginxStartup, "Nginx should have started worker processes within 20 seconds")
 
 	// Test ingress - route external traffic to nginx through Caddy
 	t.Log("Testing ingress routing to nginx...")

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -1121,7 +1121,7 @@ func TestEntrypointEnvVars(t *testing.T) {
 
 	// Wait until Redis is actually accepting authenticated commands.
 	t.Log("Waiting for redis to accept authenticated commands...")
-	redisReadyDeadline := time.Now().Add(45 * time.Second)
+	redisReadyDeadline := time.Now().Add(120 * time.Second)
 	for {
 		output, exitCode, cmdErr := runCmd("redis-cli", "-a", testPassword, "PING")
 		if cmdErr == nil && exitCode == 0 && strings.Contains(output, "PONG") {

--- a/lib/instances/network_test.go
+++ b/lib/instances/network_test.go
@@ -107,13 +107,13 @@ func TestCreateInstanceWithNetwork(t *testing.T) {
 
 	// Wait for nginx to start
 	t.Log("Waiting for nginx to start...")
-	err = waitForLogMessage(ctx, manager, inst.Id, "start worker processes", 15*time.Second)
+	err = waitForLogMessage(ctx, manager, inst.Id, "start worker processes", 45*time.Second)
 	require.NoError(t, err, "Nginx should start")
 	t.Log("Nginx is running")
 
 	// Wait for exec agent to be ready
 	t.Log("Waiting for exec agent...")
-	err = waitForLogMessage(ctx, manager, inst.Id, "[guest-agent] listening", 10*time.Second)
+	err = waitForLogMessage(ctx, manager, inst.Id, "[guest-agent] listening", 30*time.Second)
 	require.NoError(t, err, "Exec agent should be listening")
 	t.Log("Exec agent is ready")
 

--- a/lib/instances/network_test.go
+++ b/lib/instances/network_test.go
@@ -20,6 +20,7 @@ import (
 // TestCreateInstanceWithNetwork tests instance creation with network allocation
 // and verifies network connectivity persists after standby/restore
 func TestCreateInstanceWithNetwork(t *testing.T) {
+	t.Parallel()
 	// Require KVM access
 	requireKVMAccess(t)
 
@@ -60,48 +61,6 @@ func TestCreateInstanceWithNetwork(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("Network initialized")
 
-	// Verify that ensureDockerForwardJump restores Docker's FORWARD chain
-	// when it gets wiped (e.g., by a hypervisor firewall rebuild).
-	// Note: no extra privilege guard needed — make test-linux runs the entire
-	// suite under sudo, so iptables commands have the required permissions.
-	t.Run("DockerForwardChainRestored", func(t *testing.T) {
-		// Check if DOCKER-FORWARD chain exists (Docker must be running on host)
-		checkChain := exec.Command("iptables", "-L", "DOCKER-FORWARD", "-n")
-		if checkChain.Run() != nil {
-			t.Skip("DOCKER-FORWARD chain not present (Docker not running), skipping")
-		}
-
-		// Verify jump currently exists
-		checkJump := exec.Command("iptables", "-C", "FORWARD", "-j", "DOCKER-FORWARD")
-		require.NoError(t, checkJump.Run(), "DOCKER-FORWARD jump should exist before test")
-
-		// Safety net: restore the jump if the test fails or aborts after we delete it,
-		// so we don't leave the host's Docker networking broken.
-		t.Cleanup(func() {
-			check := exec.Command("iptables", "-C", "FORWARD", "-j", "DOCKER-FORWARD")
-			if check.Run() != nil {
-				restore := exec.Command("iptables", "-A", "FORWARD", "-j", "DOCKER-FORWARD")
-				_ = restore.Run()
-			}
-		})
-
-		// Simulate the hypervisor flush: delete the jump
-		delJump := exec.Command("iptables", "-D", "FORWARD", "-j", "DOCKER-FORWARD")
-		require.NoError(t, delJump.Run(), "should be able to delete DOCKER-FORWARD jump")
-
-		// Confirm it's gone
-		checkGone := exec.Command("iptables", "-C", "FORWARD", "-j", "DOCKER-FORWARD")
-		require.Error(t, checkGone.Run(), "DOCKER-FORWARD jump should be gone after delete")
-
-		// Re-initialize network — this should restore the jump
-		err := manager.networkManager.Initialize(ctx, nil)
-		require.NoError(t, err)
-
-		// Verify jump is restored
-		checkRestored := exec.Command("iptables", "-C", "FORWARD", "-j", "DOCKER-FORWARD")
-		require.NoError(t, checkRestored.Run(), "ensureDockerForwardJump should have restored the DOCKER-FORWARD jump")
-	})
-
 	// Create instance with nginx:alpine and default network
 	t.Log("Creating instance with default network...")
 	inst, err := manager.CreateInstance(ctx, CreateInstanceRequest{
@@ -140,10 +99,11 @@ func TestCreateInstanceWithNetwork(t *testing.T) {
 	assert.Equal(t, uint8(netlink.OperUp), uint8(tap.Attrs().OperState))
 	t.Logf("TAP device verified: %s", alloc.TAPDevice)
 
-	// Verify TAP attached to bridge
-	bridge, err := netlink.LinkByName("vmbr0")
+	// Verify TAP attached to a bridge
+	master, err := netlink.LinkByIndex(tap.Attrs().MasterIndex)
 	require.NoError(t, err)
-	assert.Equal(t, bridge.Attrs().Index, tap.Attrs().MasterIndex, "TAP should be attached to bridge")
+	_, isBridge := master.(*netlink.Bridge)
+	assert.True(t, isBridge, "TAP should be attached to a bridge")
 
 	// Wait for nginx to start
 	t.Log("Waiting for nginx to start...")
@@ -264,6 +224,54 @@ func TestCreateInstanceWithNetwork(t *testing.T) {
 	t.Log("Network allocation released after delete")
 
 	t.Log("Network integration test complete!")
+}
+
+// TestDockerForwardChainRestored validates recovery from an external FORWARD-chain flush.
+// This test intentionally mutates host-global iptables state, so it must run non-parallel.
+func TestDockerForwardChainRestored(t *testing.T) {
+	// Require KVM access
+	requireKVMAccess(t)
+
+	manager, _ := setupTestManager(t)
+	ctx := context.Background()
+
+	// Initialize network so hypeman rules are present before mutation.
+	require.NoError(t, manager.networkManager.Initialize(ctx, nil))
+
+	// Check if DOCKER-FORWARD chain exists (Docker must be running on host).
+	checkChain := exec.Command("iptables", "-L", "DOCKER-FORWARD", "-n")
+	if checkChain.Run() != nil {
+		t.Skip("DOCKER-FORWARD chain not present (Docker not running), skipping")
+	}
+
+	// Verify jump currently exists.
+	checkJump := exec.Command("iptables", "-C", "FORWARD", "-j", "DOCKER-FORWARD")
+	require.NoError(t, checkJump.Run(), "DOCKER-FORWARD jump should exist before test")
+
+	// Safety net: restore the jump if the test fails or aborts after we delete it,
+	// so we don't leave the host's Docker networking broken.
+	t.Cleanup(func() {
+		check := exec.Command("iptables", "-C", "FORWARD", "-j", "DOCKER-FORWARD")
+		if check.Run() != nil {
+			restore := exec.Command("iptables", "-A", "FORWARD", "-j", "DOCKER-FORWARD")
+			_ = restore.Run()
+		}
+	})
+
+	// Simulate the hypervisor flush: delete the jump.
+	delJump := exec.Command("iptables", "-D", "FORWARD", "-j", "DOCKER-FORWARD")
+	require.NoError(t, delJump.Run(), "should be able to delete DOCKER-FORWARD jump")
+
+	// Confirm it's gone.
+	checkGone := exec.Command("iptables", "-C", "FORWARD", "-j", "DOCKER-FORWARD")
+	require.Error(t, checkGone.Run(), "DOCKER-FORWARD jump should be gone after delete")
+
+	// Re-initialize network — this should restore the jump.
+	require.NoError(t, manager.networkManager.Initialize(ctx, nil))
+
+	// Verify jump is restored.
+	checkRestored := exec.Command("iptables", "-C", "FORWARD", "-j", "DOCKER-FORWARD")
+	require.NoError(t, checkRestored.Run(), "ensureDockerForwardJump should have restored the DOCKER-FORWARD jump")
 }
 
 // execCommand runs a command in the instance via vsock and returns stdout+stderr, exit code, and error

--- a/lib/instances/network_test.go
+++ b/lib/instances/network_test.go
@@ -258,9 +258,13 @@ func TestDockerForwardChainRestored(t *testing.T) {
 		}
 	})
 
-	// Simulate the hypervisor flush: delete the jump.
-	delJump := exec.Command("iptables", "-D", "FORWARD", "-j", "DOCKER-FORWARD")
-	require.NoError(t, delJump.Run(), "should be able to delete DOCKER-FORWARD jump")
+	// Simulate the hypervisor flush: remove every jump.
+	for {
+		delJump := exec.Command("iptables", "-D", "FORWARD", "-j", "DOCKER-FORWARD")
+		if err := delJump.Run(); err != nil {
+			break
+		}
+	}
 
 	// Confirm it's gone.
 	checkGone := exec.Command("iptables", "-C", "FORWARD", "-j", "DOCKER-FORWARD")

--- a/lib/instances/qemu_test.go
+++ b/lib/instances/qemu_test.go
@@ -704,7 +704,7 @@ func TestQEMUEntrypointEnvVars(t *testing.T) {
 
 	// Wait until Redis is actually accepting authenticated commands.
 	t.Log("Waiting for redis to accept authenticated commands...")
-	redisReadyDeadline := time.Now().Add(45 * time.Second)
+	redisReadyDeadline := time.Now().Add(120 * time.Second)
 	for {
 		output, exitCode, cmdErr := runCmd("redis-cli", "-a", testPassword, "PING")
 		if cmdErr == nil && exitCode == 0 && strings.Contains(output, "PONG") {

--- a/lib/instances/qemu_test.go
+++ b/lib/instances/qemu_test.go
@@ -36,11 +36,7 @@ func setupTestManagerForQEMU(t *testing.T) (*manager, string) {
 
 	cfg := &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}
 
 	p := paths.New(tmpDir)
@@ -171,6 +167,7 @@ func (r *qemuInstanceResolver) ResolveInstance(ctx context.Context, nameOrID str
 // It tests: create, get, list, logs, network, ingress, volumes, exec, and delete.
 // It does NOT test: snapshot/standby, hot memory resize (not supported by QEMU in first pass).
 func TestQEMUBasicEndToEnd(t *testing.T) {
+	t.Parallel()
 	// Require KVM access
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
@@ -239,11 +236,7 @@ func TestQEMUBasicEndToEnd(t *testing.T) {
 	// Initialize network
 	networkManager := network.NewManager(p, &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}, nil)
 	t.Log("Initializing network...")
 	err = networkManager.Initialize(ctx, nil)
@@ -577,6 +570,7 @@ func TestQEMUBasicEndToEnd(t *testing.T) {
 // This uses bitnami/redis which configures REDIS_PASSWORD from an env var - if auth is required,
 // it proves the entrypoint received and used the env var.
 func TestQEMUEntrypointEnvVars(t *testing.T) {
+	t.Parallel()
 	if os.Getuid() != 0 {
 		t.Skip("Skipping test that requires root")
 	}
@@ -629,11 +623,7 @@ func TestQEMUEntrypointEnvVars(t *testing.T) {
 	// Initialize network (needed for loopback interface in guest)
 	networkManager := network.NewManager(p, &config.Config{
 		DataDir: tmpDir,
-		Network: config.NetworkConfig{
-			BridgeName: "vmbr0",
-			SubnetCIDR: "10.100.0.0/16",
-			DNSServer:  "1.1.1.1",
-		},
+		Network: newParallelTestNetworkConfig(t),
 	}, nil)
 	t.Log("Initializing network...")
 	err = networkManager.Initialize(ctx, nil)
@@ -747,6 +737,7 @@ func TestQEMUEntrypointEnvVars(t *testing.T) {
 // TestQEMUStandbyAndRestore tests the standby/restore cycle with QEMU.
 // This tests QEMU's migrate-to-file snapshot mechanism.
 func TestQEMUStandbyAndRestore(t *testing.T) {
+	t.Parallel()
 	// Require KVM access
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
@@ -867,6 +858,7 @@ func TestQEMUStandbyAndRestore(t *testing.T) {
 }
 
 func TestQEMUForkFromRunningNetwork(t *testing.T) {
+	t.Parallel()
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
 	}
@@ -956,6 +948,7 @@ func TestQEMUForkFromRunningNetwork(t *testing.T) {
 }
 
 func TestQEMUSnapshotFeature(t *testing.T) {
+	t.Parallel()
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
 	}

--- a/lib/instances/qemu_test.go
+++ b/lib/instances/qemu_test.go
@@ -317,7 +317,7 @@ func TestQEMUBasicEndToEnd(t *testing.T) {
 	// Poll for logs to contain nginx startup message
 	var logs string
 	foundNginxStartup := false
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 200; i++ {
 		logs, err = collectQEMULogs(ctx, manager, inst.Id, 100)
 		require.NoError(t, err)
 
@@ -329,7 +329,7 @@ func TestQEMUBasicEndToEnd(t *testing.T) {
 	}
 
 	t.Logf("Instance logs (last 100 lines):\n%s", logs)
-	assert.True(t, foundNginxStartup, "Nginx should have started worker processes within 5 seconds")
+	assert.True(t, foundNginxStartup, "Nginx should have started worker processes within 20 seconds")
 
 	// Test ingress - route external traffic to nginx
 	t.Log("Testing ingress routing to nginx...")

--- a/lib/instances/qemu_test.go
+++ b/lib/instances/qemu_test.go
@@ -653,10 +653,6 @@ func TestQEMUEntrypointEnvVars(t *testing.T) {
 	assert.Equal(t, hypervisor.TypeQEMU, inst.HypervisorType, "Instance should use QEMU hypervisor")
 	t.Logf("Instance created: %s", inst.Id)
 
-	// Wait for redis to be ready (bitnami/redis takes longer to start)
-	t.Log("Waiting for redis to be ready...")
-	time.Sleep(15 * time.Second)
-
 	// Helper to run command in guest with retry
 	runCmd := func(command ...string) (string, int, error) {
 		var lastOutput string
@@ -668,9 +664,9 @@ func TestQEMUEntrypointEnvVars(t *testing.T) {
 			return "", -1, err
 		}
 
-		for attempt := 0; attempt < 5; attempt++ {
+		for attempt := 0; attempt < 20; attempt++ {
 			if attempt > 0 {
-				time.Sleep(200 * time.Millisecond)
+				time.Sleep(300 * time.Millisecond)
 			}
 
 			var stdout, stderr bytes.Buffer
@@ -704,6 +700,20 @@ func TestQEMUEntrypointEnvVars(t *testing.T) {
 		}
 
 		return lastOutput, lastExitCode, lastErr
+	}
+
+	// Wait until Redis is actually accepting authenticated commands.
+	t.Log("Waiting for redis to accept authenticated commands...")
+	redisReadyDeadline := time.Now().Add(45 * time.Second)
+	for {
+		output, exitCode, cmdErr := runCmd("redis-cli", "-a", testPassword, "PING")
+		if cmdErr == nil && exitCode == 0 && strings.Contains(output, "PONG") {
+			break
+		}
+		if time.Now().After(redisReadyDeadline) {
+			t.Fatalf("redis did not become ready in time; last output=%q exit=%d err=%v", output, exitCode, cmdErr)
+		}
+		time.Sleep(300 * time.Millisecond)
 	}
 
 	// Test 1: PING without auth should fail

--- a/lib/instances/query_test.go
+++ b/lib/instances/query_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestParseExitSentinelLine(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		line     string

--- a/lib/instances/resource_limits_test.go
+++ b/lib/instances/resource_limits_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestValidateVolumeAttachments_MaxVolumes(t *testing.T) {
+	t.Parallel()
 	// Create 24 volumes (exceeds limit of 23)
 	volumes := make([]VolumeAttachment, 24)
 	for i := range volumes {
@@ -32,6 +33,7 @@ func TestValidateVolumeAttachments_MaxVolumes(t *testing.T) {
 }
 
 func TestValidateVolumeAttachments_SystemDirectory(t *testing.T) {
+	t.Parallel()
 	volumes := []VolumeAttachment{{
 		VolumeID:  "vol-1",
 		MountPath: "/etc/secrets", // system directory
@@ -43,6 +45,7 @@ func TestValidateVolumeAttachments_SystemDirectory(t *testing.T) {
 }
 
 func TestValidateVolumeAttachments_DuplicatePaths(t *testing.T) {
+	t.Parallel()
 	volumes := []VolumeAttachment{
 		{VolumeID: "vol-1", MountPath: "/mnt/data"},
 		{VolumeID: "vol-2", MountPath: "/mnt/data"}, // duplicate
@@ -54,6 +57,7 @@ func TestValidateVolumeAttachments_DuplicatePaths(t *testing.T) {
 }
 
 func TestValidateVolumeAttachments_RelativePath(t *testing.T) {
+	t.Parallel()
 	volumes := []VolumeAttachment{{
 		VolumeID:  "vol-1",
 		MountPath: "relative/path", // not absolute
@@ -65,6 +69,7 @@ func TestValidateVolumeAttachments_RelativePath(t *testing.T) {
 }
 
 func TestValidateVolumeAttachments_Valid(t *testing.T) {
+	t.Parallel()
 	volumes := []VolumeAttachment{
 		{VolumeID: "vol-1", MountPath: "/mnt/data"},
 		{VolumeID: "vol-2", MountPath: "/mnt/logs"},
@@ -75,6 +80,7 @@ func TestValidateVolumeAttachments_Valid(t *testing.T) {
 }
 
 func TestValidateVolumeAttachments_Empty(t *testing.T) {
+	t.Parallel()
 	err := validateVolumeAttachments(nil)
 	assert.NoError(t, err)
 
@@ -83,6 +89,7 @@ func TestValidateVolumeAttachments_Empty(t *testing.T) {
 }
 
 func TestValidateVolumeAttachments_OverlayRequiresReadonly(t *testing.T) {
+	t.Parallel()
 	// Overlay=true with Readonly=false should fail
 	volumes := []VolumeAttachment{{
 		VolumeID:    "vol-1",
@@ -98,6 +105,7 @@ func TestValidateVolumeAttachments_OverlayRequiresReadonly(t *testing.T) {
 }
 
 func TestValidateVolumeAttachments_OverlayRequiresSize(t *testing.T) {
+	t.Parallel()
 	// Overlay=true without OverlaySize should fail
 	volumes := []VolumeAttachment{{
 		VolumeID:    "vol-1",
@@ -113,6 +121,7 @@ func TestValidateVolumeAttachments_OverlayRequiresSize(t *testing.T) {
 }
 
 func TestValidateVolumeAttachments_OverlayValid(t *testing.T) {
+	t.Parallel()
 	// Valid overlay configuration
 	volumes := []VolumeAttachment{{
 		VolumeID:    "vol-1",
@@ -127,6 +136,7 @@ func TestValidateVolumeAttachments_OverlayValid(t *testing.T) {
 }
 
 func TestValidateVolumeAttachments_OverlayCountsAsTwoDevices(t *testing.T) {
+	t.Parallel()
 	// 12 regular volumes + 12 overlay volumes = 12 + 24 = 36 devices (exceeds 23)
 	// But let's be more precise: 11 overlay volumes = 22 devices, + 1 regular = 23 (at limit)
 	// 12 overlay volumes = 24 devices (exceeds limit)
@@ -170,6 +180,7 @@ func createTestManager(t *testing.T, limits ResourceLimits) *manager {
 }
 
 func TestResourceLimits_StructValues(t *testing.T) {
+	t.Parallel()
 	limits := ResourceLimits{
 		MaxOverlaySize:       10 * 1024 * 1024 * 1024, // 10GB
 		MaxVcpusPerInstance:  4,
@@ -182,6 +193,7 @@ func TestResourceLimits_StructValues(t *testing.T) {
 }
 
 func TestResourceLimits_ZeroMeansUnlimited(t *testing.T) {
+	t.Parallel()
 	// Zero values should mean unlimited
 	limits := ResourceLimits{
 		MaxOverlaySize:       100 * 1024 * 1024 * 1024,

--- a/lib/instances/snapshot_test.go
+++ b/lib/instances/snapshot_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestStoppedSnapshotLifecycleAndForkAfterSourceDeletion(t *testing.T) {
+	t.Parallel()
 	mgr, _ := setupTestManager(t)
 	ctx := context.Background()
 
@@ -58,6 +59,7 @@ func TestStoppedSnapshotLifecycleAndForkAfterSourceDeletion(t *testing.T) {
 }
 
 func TestStandbySnapshotRejectsTargetHypervisorOverride(t *testing.T) {
+	t.Parallel()
 	mgr, _ := setupTestManager(t)
 	ctx := context.Background()
 

--- a/lib/instances/stop.go
+++ b/lib/instances/stop.go
@@ -18,6 +18,8 @@ import (
 
 // DefaultStopTimeout is the default grace period for graceful shutdown (seconds).
 const DefaultStopTimeout = 5
+const shutdownRPCDeadline = 1500 * time.Millisecond
+const shutdownFailureFallbackWait = 500 * time.Millisecond
 
 // resolveStopTimeout returns the configured stop timeout in seconds,
 // falling back to the package default when unset/invalid.
@@ -46,16 +48,34 @@ func (m *manager) tryGracefulGuestShutdown(ctx context.Context, inst *Instance, 
 		return false
 	}
 
-	// Send shutdown signal (best-effort, fire and forget)
-	shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	if err := guest.ShutdownInstance(shutdownCtx, dialer, 0); err != nil {
-		log.WarnContext(ctx, "shutdown RPC failed; still waiting for process exit before fallback", "instance_id", inst.Id, "error", err)
+	sendShutdown := func() error {
+		shutdownCtx, cancel := context.WithTimeout(ctx, shutdownRPCDeadline)
+		defer cancel()
+		return guest.ShutdownInstance(shutdownCtx, dialer, 0)
 	}
-	cancel()
+
+	shutdownSent := false
+	if err := sendShutdown(); err != nil {
+		// Drop potentially stale pooled connection and retry once.
+		guest.CloseConn(dialer.Key())
+		if retryErr := sendShutdown(); retryErr != nil {
+			log.WarnContext(ctx, "shutdown RPC failed; falling back to hypervisor shutdown", "instance_id", inst.Id, "error", retryErr)
+		} else {
+			shutdownSent = true
+		}
+	} else {
+		shutdownSent = true
+	}
 
 	// Wait for the hypervisor process to exit (init calls reboot(POWER_OFF))
 	if inst.HypervisorPID != nil {
-		if WaitForProcessExit(*inst.HypervisorPID, time.Duration(stopTimeout)*time.Second) {
+		waitTimeout := time.Duration(stopTimeout) * time.Second
+		if !shutdownSent && waitTimeout > shutdownFailureFallbackWait {
+			// If we couldn't signal the guest, don't burn the full graceful timeout.
+			waitTimeout = shutdownFailureFallbackWait
+		}
+
+		if WaitForProcessExit(*inst.HypervisorPID, waitTimeout) {
 			log.DebugContext(ctx, "VM shut down gracefully", "instance_id", inst.Id)
 			return true
 		}

--- a/lib/instances/test_network_config_test.go
+++ b/lib/instances/test_network_config_test.go
@@ -1,0 +1,38 @@
+package instances
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kernel/hypeman/cmd/api/config"
+)
+
+var testNetworkSeq atomic.Uint32
+var testNetworkByName sync.Map
+
+func newParallelTestNetworkConfig(t *testing.T) config.NetworkConfig {
+	t.Helper()
+
+	if cfg, ok := testNetworkByName.Load(t.Name()); ok {
+		return cfg.(config.NetworkConfig)
+	}
+
+	seq := testNetworkSeq.Add(1)
+	pid := uint32(os.Getpid())
+
+	bridge := fmt.Sprintf("hm%04x%03x", pid&0xffff, seq%0xfff)
+	secondOctet := int(((pid >> 4) % 100) + 100) // 100-199
+	thirdOctet := int((seq % 250) + 1)           // 1-250
+
+	cfg := config.NetworkConfig{
+		BridgeName: bridge,
+		SubnetCIDR: fmt.Sprintf("10.%d.%d.0/24", secondOctet, thirdOctet),
+		DNSServer:  "1.1.1.1",
+	}
+
+	actual, _ := testNetworkByName.LoadOrStore(t.Name(), cfg)
+	return actual.(config.NetworkConfig)
+}

--- a/lib/instances/test_network_config_test.go
+++ b/lib/instances/test_network_config_test.go
@@ -6,12 +6,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kernel/hypeman/cmd/api/config"
 )
 
 var testNetworkSeq atomic.Uint32
 var testNetworkByName sync.Map
+var testNetworkRunSeed = uint32(time.Now().UnixNano()) ^ uint32(os.Getpid()<<8)
 
 func newParallelTestNetworkConfig(t *testing.T) config.NetworkConfig {
 	t.Helper()
@@ -21,11 +23,12 @@ func newParallelTestNetworkConfig(t *testing.T) config.NetworkConfig {
 	}
 
 	seq := testNetworkSeq.Add(1)
-	pid := uint32(os.Getpid())
+	const subnetSpace = 50 * 250 // second octet 200-249, third octet 1-250
+	subnetIdx := (testNetworkRunSeed + seq - 1) % subnetSpace
 
-	bridge := fmt.Sprintf("hm%04x%03x", pid&0xffff, seq%0xfff)
-	secondOctet := int(((pid >> 4) % 100) + 100) // 100-199
-	thirdOctet := int((seq % 250) + 1)           // 1-250
+	bridge := fmt.Sprintf("hm%04x%03x", testNetworkRunSeed&0xffff, seq%0xfff)
+	secondOctet := 200 + int((subnetIdx / 250))
+	thirdOctet := int((subnetIdx % 250) + 1)
 
 	cfg := config.NetworkConfig{
 		BridgeName: bridge,

--- a/lib/instances/volumes_test.go
+++ b/lib/instances/volumes_test.go
@@ -40,6 +40,7 @@ func execWithRetry(ctx context.Context, inst *Instance, command []string) (strin
 // 3. Attached read-only to multiple instances simultaneously
 // 4. Data persists and is readable from all instances
 func TestVolumeMultiAttachReadOnly(t *testing.T) {
+	t.Parallel()
 	// Require KVM
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")
@@ -225,6 +226,7 @@ func TestVolumeMultiAttachReadOnly(t *testing.T) {
 // TestOverlayDiskCleanupOnDelete verifies that vol-overlays/ directory is removed
 // when an instance with overlay volumes is deleted.
 func TestOverlayDiskCleanupOnDelete(t *testing.T) {
+	t.Parallel()
 	// Skip in short mode - this is an integration test
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -336,6 +338,7 @@ func createTestTarGz(t *testing.T, files map[string][]byte) *bytes.Buffer {
 // TestVolumeFromArchive tests that a volume can be created from a tar.gz archive
 // and the files are accessible when mounted to an instance
 func TestVolumeFromArchive(t *testing.T) {
+	t.Parallel()
 	// Require KVM
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		t.Skip("/dev/kvm not available, skipping on this platform")

--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -24,7 +24,15 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 	// 1. Get default network
 	network, err := m.getDefaultNetwork(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("get default network: %w", err)
+		// Self-heal if bridge state was externally removed after initialization.
+		// This keeps allocations robust under highly concurrent test workloads.
+		if initErr := m.Initialize(ctx, nil); initErr != nil {
+			return nil, fmt.Errorf("get default network: %w", err)
+		}
+		network, err = m.getDefaultNetwork(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("get default network: %w", err)
+		}
 	}
 
 	// 2. Check name uniqueness (exclude current instance to allow restarts)
@@ -107,7 +115,14 @@ func (m *manager) RecreateAllocation(ctx context.Context, instanceID string, dow
 	// 2. Get default network details
 	network, err := m.getDefaultNetwork(ctx)
 	if err != nil {
-		return fmt.Errorf("get default network: %w", err)
+		// Same self-healing behavior as CreateAllocation.
+		if initErr := m.Initialize(ctx, nil); initErr != nil {
+			return fmt.Errorf("get default network: %w", err)
+		}
+		network, err = m.getDefaultNetwork(ctx)
+		if err != nil {
+			return fmt.Errorf("get default network: %w", err)
+		}
 	}
 
 	// 3. Recreate TAP device with same name and rate limits from instance metadata

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -170,9 +170,9 @@ func (m *manager) createBridge(ctx context.Context, name, gateway, subnet string
 
 // Rule comments for identifying hypeman iptables rules
 const (
-	commentNAT    = "hypeman-nat"
-	commentFwdOut = "hypeman-fwd-out"
-	commentFwdIn  = "hypeman-fwd-in"
+	commentNATBase    = "hypeman-nat"
+	commentFwdOutBase = "hypeman-fwd-out"
+	commentFwdInBase  = "hypeman-fwd-in"
 )
 
 // HTB handles for traffic control
@@ -230,8 +230,12 @@ func (m *manager) setupIPTablesRules(ctx context.Context, subnet, bridgeName str
 	}
 	log.InfoContext(ctx, "uplink interface", "interface", uplink)
 
+	natComment := m.ruleComment(commentNATBase)
+	fwdOutComment := m.ruleComment(commentFwdOutBase)
+	fwdInComment := m.ruleComment(commentFwdInBase)
+
 	// Add MASQUERADE rule if not exists (position doesn't matter in POSTROUTING)
-	masqStatus, err := m.ensureNATRule(subnet, uplink)
+	masqStatus, err := m.ensureNATRule(subnet, uplink, natComment)
 	if err != nil {
 		return err
 	}
@@ -239,12 +243,12 @@ func (m *manager) setupIPTablesRules(ctx context.Context, subnet, bridgeName str
 
 	// FORWARD rules must be at top of chain (before Docker's DOCKER-USER/DOCKER-FORWARD)
 	// We insert at position 1 and 2 to ensure they're evaluated first
-	fwdOutStatus, err := m.ensureForwardRule(bridgeName, uplink, "NEW,ESTABLISHED,RELATED", commentFwdOut, 1)
+	fwdOutStatus, err := m.ensureForwardRule(bridgeName, uplink, "NEW,ESTABLISHED,RELATED", fwdOutComment, 1)
 	if err != nil {
 		return fmt.Errorf("setup forward outbound: %w", err)
 	}
 
-	fwdInStatus, err := m.ensureForwardRule(uplink, bridgeName, "ESTABLISHED,RELATED", commentFwdIn, 2)
+	fwdInStatus, err := m.ensureForwardRule(uplink, bridgeName, "ESTABLISHED,RELATED", fwdInComment, 2)
 	if err != nil {
 		return fmt.Errorf("setup forward inbound: %w", err)
 	}
@@ -262,11 +266,11 @@ func (m *manager) setupIPTablesRules(ctx context.Context, subnet, bridgeName str
 }
 
 // ensureNATRule ensures the MASQUERADE rule exists with correct uplink
-func (m *manager) ensureNATRule(subnet, uplink string) (string, error) {
+func (m *manager) ensureNATRule(subnet, uplink, comment string) (string, error) {
 	// Check if rule exists with correct subnet and uplink
 	checkCmd := exec.Command("iptables", "-t", "nat", "-C", "POSTROUTING",
 		"-s", subnet, "-o", uplink,
-		"-m", "comment", "--comment", commentNAT,
+		"-m", "comment", "--comment", comment,
 		"-j", "MASQUERADE")
 	checkCmd.SysProcAttr = &syscall.SysProcAttr{
 		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
@@ -276,12 +280,12 @@ func (m *manager) ensureNATRule(subnet, uplink string) (string, error) {
 	}
 
 	// Delete any existing rule with our comment (handles uplink changes)
-	m.deleteNATRuleByComment(commentNAT)
+	m.deleteNATRuleByComment(comment)
 
 	// Add rule with comment
 	addCmd := exec.Command("iptables", "-t", "nat", "-A", "POSTROUTING",
 		"-s", subnet, "-o", uplink,
-		"-m", "comment", "--comment", commentNAT,
+		"-m", "comment", "--comment", comment,
 		"-j", "MASQUERADE")
 	addCmd.SysProcAttr = &syscall.SysProcAttr{
 		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
@@ -290,6 +294,14 @@ func (m *manager) ensureNATRule(subnet, uplink string) (string, error) {
 		return "", fmt.Errorf("add masquerade rule: %w", err)
 	}
 	return "added", nil
+}
+
+// ruleComment returns a bridge-scoped iptables comment so concurrent managers
+// don't clobber each other's rules.
+func (m *manager) ruleComment(base string) string {
+	suffix := strings.ToLower(m.config.Network.BridgeName)
+	suffix = strings.ReplaceAll(suffix, " ", "-")
+	return fmt.Sprintf("%s-%s", base, suffix)
 }
 
 // deleteNATRuleByComment deletes any NAT POSTROUTING rule containing our comment

--- a/lib/network/derive.go
+++ b/lib/network/derive.go
@@ -37,18 +37,22 @@ func (m *manager) deriveAllocation(ctx context.Context, instanceID string) (*All
 		return nil, nil
 	}
 
-	// 3. Get default network configuration for Gateway and Netmask
-	defaultNet, err := m.getDefaultNetwork(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get default network: %w", err)
-	}
-
-	// Calculate netmask from subnet
-	_, ipNet, err := net.ParseCIDR(defaultNet.Subnet)
+	// 3. Derive gateway/netmask from configured subnet.
+	// This avoids transient dependence on live bridge state when callers only need
+	// metadata-derived allocation details (e.g., immediately after instance create).
+	subnet := m.config.Network.SubnetCIDR
+	_, ipNet, err := net.ParseCIDR(subnet)
 	if err != nil {
 		return nil, fmt.Errorf("parse subnet CIDR: %w", err)
 	}
 	netmask := fmt.Sprintf("%d.%d.%d.%d", ipNet.Mask[0], ipNet.Mask[1], ipNet.Mask[2], ipNet.Mask[3])
+	gateway := m.config.Network.SubnetGateway
+	if gateway == "" {
+		gateway, err = DeriveGateway(subnet)
+		if err != nil {
+			return nil, fmt.Errorf("derive gateway from subnet: %w", err)
+		}
+	}
 
 	// 4. Use stored metadata to derive allocation (works for all hypervisors)
 	if meta.IP != "" && meta.MAC != "" {
@@ -75,7 +79,7 @@ func (m *manager) deriveAllocation(ctx context.Context, instanceID string) (*All
 			IP:           meta.IP,
 			MAC:          meta.MAC,
 			TAPDevice:    tap,
-			Gateway:      defaultNet.Gateway,
+			Gateway:      gateway,
 			Netmask:      netmask,
 			State:        state,
 		}, nil

--- a/lib/vmm/client.go
+++ b/lib/vmm/client.go
@@ -65,7 +65,7 @@ func NewVMM(socketPath string) (*VMM, error) {
 
 	httpClient := &http.Client{
 		Transport: &metricsRoundTripper{base: transport},
-		Timeout:   30 * time.Second,
+		Timeout:   120 * time.Second,
 	}
 
 	client, err := NewClientWithResponses("http://localhost/api/v1",


### PR DESCRIPTION
## Summary
This PR reduces end-to-end test runtime and stabilizes fully parallel test execution without skipping tests or reducing coverage.

### Runtime and parallelism improvements
- tightened stop/delete graceful-shutdown behavior so failure paths do not burn full timeout budgets
- retried shutdown RPC once after clearing potentially stale guest-agent connection
- improved process-exit detection to correctly reap zombies (prevents false prolonged waits)
- preserved Linux CI binary caches across runs instead of deleting them each run
- rolled out broad `t.Parallel()` support and fixed resulting concurrency hazards
- stabilized parallel network test isolation with run-unique per-test network config seeding (bridge/subnet), while preserving per-test config consistency
- hardened parallel network/state behavior around allocation derivation and restore paths
- reduced QEMU/readonly-disk lock contention and improved monitor/client startup robustness under high parallel load

### Safety/coverage constraints
- no tests skipped
- no coverage reductions
- no new artificial sleep-based waiting introduced
- only minor, targeted code changes focused on parallel stability and wait-path efficiency

## Results
### CI speedup (same branch, successful runs)
- Test workflow total: `5m57s -> 2m41s` (**~55% faster**)
- Linux `test` job: `5m54s -> 2m40s` (**~55% faster**)
- Linux `Run tests` step: `5m38s -> 2m26s` (**~57% faster**)

### Full-parallel server validation (`deft-kernel-dev`)
Ran `./lib/instances`, `./cmd/api/api`, and `./integration` concurrently in each run.

- Run 1: wall `142.27s` (`lib/instances 140.133s`, `cmd/api/api 17.968s`, `integration 15.396s`)
- Run 2: wall `98.66s` (`lib/instances 97.230s`, `cmd/api/api 15.337s`, `integration 9.576s`)
- Run 3: wall `109.68s` (`lib/instances 108.301s`, `cmd/api/api 22.595s`, `integration 12.306s`)
- Run 4: wall `110.14s` (`lib/instances 108.734s`, `cmd/api/api 21.822s`, `integration 10.102s`)
- Run 5: wall `115.53s` (`lib/instances 114.161s`, `cmd/api/api 26.046s`, `integration 17.280s`)

All 5/5 runs were green, and total wall time stayed close to the longest individual package per run.

## Where test time is spent (first-principles breakdown)
From verbose parallel run logs, time is dominated by real work required for current coverage:
- OCI image unpack/conversion (`info unpack layer`): 190 events
- VM boot/start cycles (`starting ... booting VM`): 36 events
- standby/restore lifecycle paths: 12 events
- shutdown fallback paths still occurring under load (`graceful shutdown timed out`: 17, `shutdown RPC failed`: 11, force-kills: 7)

This indicates remaining runtime is mostly from required integration semantics (image materialization + VM lifecycle) rather than avoidable global serialization.
