### PR TITLE
Check local image store before remote resolve in CreateImage

### DIFF
--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -115,6 +115,13 @@ func (m *manager) CreateImage(ctx context.Context, req CreateImageRequest) (*Ima
 		return nil, fmt.Errorf("%w: %s", ErrInvalidName, err.Error())
 	}
 
+	// Check if the image already exists locally (e.g. build images pushed to
+	// the local registry). This avoids a remote registry call for images that
+	// were created via ImportLocalImage.
+	if img, err := m.GetImage(ctx, req.Name); err == nil {
+		return img, nil
+	}
+
 	// Resolve to get digest (validates existence)
 	// Add a 2-second timeout to ensure fast failure on rate limits or errors
 	resolveCtx, cancel := context.WithTimeout(ctx, 2*time.Second)


### PR DESCRIPTION
## Summary
- `CreateImage` always tried `normalized.Resolve()` which calls `remote.Image()` against a remote OCI registry
- This fails for locally-built images like `builds/<id>:latest` from app deployments — they only exist in the local store (pushed to local registry, imported via `ImportLocalImage`)
- Fix: call `GetImage` first to check the local store. If found, return immediately without remote resolve
- This is the hypeman-side fix for [kernel#1443](https://github.com/kernel/kernel/pull/1443) / [kernel#1449](https://github.com/kernel/kernel/pull/1449)

## Test plan
- [ ] Deploy an app, invoke it — image should be found locally and invocation succeeds
- [ ] Pull a remote image via `CreateImage` — remote resolve still works as fallback


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a local fast-path lookup in `CreateImage` and falls back to the existing remote resolve behavior, with minimal impact limited to image creation flow.
> 
> **Overview**
> `CreateImage` now first calls `GetImage` to return an existing locally-stored image (including locally-built/imported images) instead of always attempting a remote registry `Resolve`.
> 
> If the image isn’t found locally, the existing remote resolve + build/queue logic remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d375c36192d2de12c2efe708ccbc02065691502a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->