### PR TITLE
docs: add features section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@
 
 ---
 
+## Features
+
+- **Docker-compatible CLI** — `run`, `exec`, `stop`, `ps`, `logs`, `pull` work like you'd expect
+- **Multiple hypervisors** — Cloud Hypervisor, Firecracker, QEMU on Linux; Virtualization.framework on macOS
+- **Standby & restore** — snapshot a VM to disk and resume it in milliseconds
+- **Built-in ingress** — reverse proxy with TLS termination and subdomain routing
+- **GPU passthrough** — vGPU and VFIO device support
+- **OCI image support** — pull and run standard container images
+- **Remote API** — JWT-authenticated server with a separate CLI client
+
 ## Requirements
 
 ### Linux


### PR DESCRIPTION
my first question was if it allows for resuming vm's

so did a quick code scan to build a basic features list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a high-level feature list; no runtime behavior or APIs are modified.
> 
> **Overview**
> Adds a new **Features** section to `README.md` summarizing Hypeman’s key capabilities (Docker-like CLI, multi-hypervisor support, standby/restore snapshots, ingress/TLS routing, GPU passthrough, OCI images, and a JWT-authenticated remote API).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 440005ed9c7102526aee72ebb9e9d60c106d1a9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->