### PR TITLE
chore: hypeman integration test flakes

### DIFF
--- a/cmd/api/api/instances_test.go
+++ b/cmd/api/api/instances_test.go
@@ -64,7 +64,7 @@ func TestCreateInstance_AutoPullImage(t *testing.T) {
 	createReq := oapi.CreateInstanceRequestObject{
 		Body: &oapi.CreateInstanceRequest{
 			Name:  "test-auto-pull",
-				Image: apiTestImageRef(t, "docker.io/library/alpine:latest"),
+			Image: apiTestImageRef(t, "docker.io/library/alpine:latest"),
 			Network: &struct {
 				BandwidthDownload *string                                  `json:"bandwidth_download,omitempty"`
 				BandwidthUpload   *string                                  `json:"bandwidth_upload,omitempty"`

--- a/cmd/api/api/instances_test.go
+++ b/cmd/api/api/instances_test.go
@@ -50,8 +50,8 @@ func TestCreateInstance_AutoPullImage(t *testing.T) {
 
 	// NOTE: intentionally NOT calling createAndWaitForImage here.
 	// The auto-pull logic in CreateInstance should handle pulling the image.
-	// The auto-pull has a 5s timeout — alpine:latest is small enough to
-	// complete within that window.
+	// Use the test registry mirror when configured so this covers auto-pull
+	// orchestration without depending on live Docker Hub auth latency.
 
 	// Ensure system files (kernel and initramfs) are available
 	t.Log("Ensuring system files (kernel and initramfs)...")
@@ -64,7 +64,7 @@ func TestCreateInstance_AutoPullImage(t *testing.T) {
 	createReq := oapi.CreateInstanceRequestObject{
 		Body: &oapi.CreateInstanceRequest{
 			Name:  "test-auto-pull",
-			Image: "docker.io/library/alpine:latest",
+				Image: apiTestImageRef(t, "docker.io/library/alpine:latest"),
 			Network: &struct {
 				BandwidthDownload *string                                  `json:"bandwidth_download,omitempty"`
 				BandwidthUpload   *string                                  `json:"bandwidth_upload,omitempty"`

--- a/lib/builds/manager_test.go
+++ b/lib/builds/manager_test.go
@@ -509,7 +509,7 @@ func TestGetBuild_Found(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, created.ID, build.ID)
-	assert.Equal(t, StatusQueued, build.Status)
+	assert.Contains(t, []string{StatusQueued, StatusBuilding}, build.Status)
 }
 
 func TestGetBuild_NotFound(t *testing.T) {

--- a/lib/instances/exec_test.go
+++ b/lib/instances/exec_test.go
@@ -34,7 +34,9 @@ func waitForExecAgent(ctx context.Context, mgr *manager, instanceID string, time
 		}
 
 		lastState = inst.State
-		if inst.State != StateRunning {
+		// Boot-marker hydration can lag behind a healthy guest-agent, leaving the
+		// instance in Initializing even though exec is already available.
+		if inst.State != StateRunning && inst.State != StateInitializing {
 			time.Sleep(500 * time.Millisecond)
 			continue
 		}

--- a/lib/instances/qemu_test.go
+++ b/lib/instances/qemu_test.go
@@ -928,8 +928,12 @@ func TestQEMUForkFromRunningNetwork(t *testing.T) {
 		Hypervisor:     hypervisor.TypeQEMU,
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = manager.DeleteInstance(context.Background(), source.Id) })
-	source, err = waitForInstanceState(ctx, manager, source.Id, StateRunning, 20*time.Second)
+	sourceID := source.Id
+	t.Cleanup(func() { _ = manager.DeleteInstance(context.Background(), sourceID) })
+	// QEMU is the slowest Linux hypervisor under full-suite load on Deft. Give
+	// the host-side Running transition more headroom so we don't fail while the
+	// VM is still legitimately completing boot marker hydration.
+	source, err = waitForInstanceState(ctx, manager, sourceID, StateRunning, 45*time.Second)
 	require.NoError(t, err)
 	require.NoError(t, waitForQEMUReady(ctx, source.SocketPath, 10*time.Second))
 
@@ -954,7 +958,7 @@ func TestQEMUForkFromRunningNetwork(t *testing.T) {
 	sourceAfterFork, err := manager.GetInstance(ctx, source.Id)
 	require.NoError(t, err)
 	if sourceAfterFork.State != StateRunning {
-		sourceAfterFork, err = waitForInstanceState(ctx, manager, source.Id, StateRunning, 20*time.Second)
+		sourceAfterFork, err = waitForInstanceState(ctx, manager, source.Id, StateRunning, 45*time.Second)
 		require.NoError(t, err)
 	}
 	require.Equal(t, StateRunning, sourceAfterFork.State)
@@ -964,7 +968,7 @@ func TestQEMUForkFromRunningNetwork(t *testing.T) {
 	forked, err = manager.RestoreInstance(ctx, forkedID)
 	require.NoError(t, err)
 	require.Contains(t, []State{StateInitializing, StateRunning}, forked.State)
-	forked, err = waitForInstanceState(ctx, manager, forkedID, StateRunning, 20*time.Second)
+	forked, err = waitForInstanceState(ctx, manager, forkedID, StateRunning, 45*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, StateRunning, forked.State)
 	require.NoError(t, waitForQEMUReady(ctx, forked.SocketPath, 10*time.Second))

--- a/lib/instances/standby.go
+++ b/lib/instances/standby.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kernel/hypeman/lib/guest"
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/logger"
 	"github.com/kernel/hypeman/lib/network"
@@ -171,6 +172,11 @@ func (m *manager) standbyInstance(
 		for _, match := range matches {
 			_ = os.Remove(match)
 		}
+	}
+	// Standby/restore keeps the same vsock identity, so any pooled guest-agent
+	// gRPC connection now points at a dead VM and must be recreated on restore.
+	if dialer, err := hypervisor.NewVsockDialer(inst.HypervisorType, inst.VsockSocket, inst.VsockCID); err == nil {
+		guest.CloseConn(dialer.Key())
 	}
 
 	// 9. Release network allocation (delete TAP device)

--- a/lib/instances/volumes_test.go
+++ b/lib/instances/volumes_test.go
@@ -108,7 +108,9 @@ func TestVolumeMultiAttachReadOnly(t *testing.T) {
 	t.Logf("Writer instance created: %s", writerInst.Id)
 
 	// Wait for exec-agent
-	err = waitForExecAgent(ctx, manager, writerInst.Id, 15*time.Second)
+	// Volume-backed boots can take noticeably longer under full-suite Deft load,
+	// especially once multiple readers are attaching the same backing disk.
+	err = waitForExecAgent(ctx, manager, writerInst.Id, 30*time.Second)
 	require.NoError(t, err, "exec-agent should be ready")
 
 	// Write test file, sync, and verify in one command to ensure data persistence
@@ -173,10 +175,10 @@ func TestVolumeMultiAttachReadOnly(t *testing.T) {
 	assert.Len(t, vol.Attachments, 2, "Volume should have 2 attachments")
 
 	// Wait for exec-agent on both readers
-	err = waitForExecAgent(ctx, manager, reader1.Id, 15*time.Second)
+	err = waitForExecAgent(ctx, manager, reader1.Id, 30*time.Second)
 	require.NoError(t, err, "reader-1 exec-agent should be ready")
 
-	err = waitForExecAgent(ctx, manager, reader2.Id, 15*time.Second)
+	err = waitForExecAgent(ctx, manager, reader2.Id, 30*time.Second)
 	require.NoError(t, err, "reader-2 exec-agent should be ready")
 
 	// Verify data is readable from reader-1
@@ -415,7 +417,9 @@ func TestVolumeFromArchive(t *testing.T) {
 	t.Logf("Instance created: %s", inst.Id)
 
 	// Wait for exec-agent
-	err = waitForExecAgent(ctx, manager, inst.Id, 15*time.Second)
+	// Archive hydration adds another boot-time variable, so keep the exec-agent
+	// readiness budget aligned with the other volume-backed integration tests.
+	err = waitForExecAgent(ctx, manager, inst.Id, 30*time.Second)
 	require.NoError(t, err, "exec-agent should be ready")
 
 	// Verify files from archive are present

--- a/lib/vmm/client.go
+++ b/lib/vmm/client.go
@@ -2,12 +2,14 @@ package vmm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -21,6 +23,11 @@ import (
 )
 
 const cloudHypervisorSocketReadyTimeout = 10 * time.Second
+
+const (
+	cloudHypervisorStartRetryDelay    = 100 * time.Millisecond
+	cloudHypervisorStartRetryAttempts = 20
+)
 
 // VMM wraps the generated Cloud Hypervisor client (API v0.3.0)
 type VMM struct {
@@ -136,14 +143,6 @@ func StartProcessWithArgs(ctx context.Context, p *paths.Paths, version CHVersion
 	args := []string{"--api-socket", socketPath}
 	args = append(args, extraArgs...)
 
-	// Use Command (not CommandContext) so process survives parent context cancellation
-	cmd := exec.Command(binaryPath, args...)
-
-	// Daemonize: detach from parent process group
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true, // Create new process group
-	}
-
 	// Redirect stdout/stderr to combined VMM log file (process won't block on I/O)
 	instanceDir := filepath.Dir(socketPath)
 	logsDir := filepath.Join(instanceDir, "logs")
@@ -165,11 +164,24 @@ func StartProcessWithArgs(ctx context.Context, p *paths.Paths, version CHVersion
 	defer vmmLogFile.Close()
 
 	// Both stdout and stderr go to the same file
-	cmd.Stdout = vmmLogFile
-	cmd.Stderr = vmmLogFile
+	var cmd *exec.Cmd
+	for attempt := 1; attempt <= cloudHypervisorStartRetryAttempts; attempt++ {
+		// Use Command (not CommandContext) so process survives parent context cancellation.
+		cmd = exec.Command(binaryPath, args...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Setpgid: true, // Create new process group
+		}
+		cmd.Stdout = vmmLogFile
+		cmd.Stderr = vmmLogFile
 
-	if err := cmd.Start(); err != nil {
-		return 0, fmt.Errorf("start cloud-hypervisor: %w", err)
+		err := cmd.Start()
+		if err == nil {
+			break
+		}
+		if !isTextFileBusyError(err) || attempt == cloudHypervisorStartRetryAttempts {
+			return 0, fmt.Errorf("start cloud-hypervisor: %w", err)
+		}
+		time.Sleep(cloudHypervisorStartRetryDelay)
 	}
 
 	pid := cmd.Process.Pid
@@ -189,6 +201,10 @@ func StartProcessWithArgs(ctx context.Context, p *paths.Paths, version CHVersion
 	}
 
 	return pid, nil
+}
+
+func isTextFileBusyError(err error) bool {
+	return errors.Is(err, syscall.ETXTBSY) || strings.Contains(strings.ToLower(err.Error()), "text file busy")
 }
 
 // isSocketInUse checks if a Unix socket is actively being used

--- a/skills/test-agent/agents/test-agent/NOTES.md
+++ b/skills/test-agent/agents/test-agent/NOTES.md
@@ -287,3 +287,28 @@
   - `go test -count=20 -v -tags containers_image_openpgp -run '^TestCloudHypervisorStandbyRestoreCompressionScenarios$' -timeout=90m ./lib/instances`
   - result: pass, package time `740.546s`
 - I also started a fresh-cache full-suite Deft verification run after this fix, but it was intentionally interrupted before completion when switching to commit/push.
+
+## 2026-03-25 - Follow-up CI flakes after `771018f`
+
+### Flake signatures
+- `cmd/api/api/TestCreateInstance_AutoPullImage`
+  - auto-pull failed while fetching Docker Hub auth token:
+    - `resolve manifest: fetch manifest: Get "https://auth.docker.io/token?...": context deadline exceeded`
+- `lib/builds/TestGetBuild_Found`
+  - expected `queued`, got `building`
+
+### Root causes
+- `TestCreateInstance_AutoPullImage` still used the raw Docker Hub ref instead of the API test registry mirror helper, so it depended on live Docker Hub auth latency even though CI had prewarm + local registry configured.
+- `TestGetBuild_Found` asserted the build must still be `queued`, but the queue worker can legitimately transition it to `building` before the test reads it back.
+
+### Fixes
+- `cmd/api/api/instances_test.go`
+  - switched the auto-pull image ref to `apiTestImageRef(t, "docker.io/library/alpine:latest")`
+- `lib/builds/manager_test.go`
+  - relaxed the status assertion to accept either `queued` or `building`
+
+### Validation on `deft-kernel-dev`
+- `go test -count=10 -v -tags containers_image_openpgp -run '^TestCreateInstance_AutoPullImage$' -timeout=45m ./cmd/api/api`
+  - pass, package time `28.484s`
+- `go test -count=50 -run '^TestGetBuild_Found$' ./lib/builds`
+  - pass

--- a/skills/test-agent/agents/test-agent/NOTES.md
+++ b/skills/test-agent/agents/test-agent/NOTES.md
@@ -264,3 +264,26 @@
 ### Verification note
 - One intermediate Deft rerun failed before tests because the remote scratch workspace had stray untracked files at repo-root `lib/` (`client.go`, `exec_test.go`, `qemu_test.go`) that created a mixed-package directory.
 - After removing those remote-only artifacts, the same fresh-cache full-suite gate passed twice.
+
+## 2026-03-25 - Follow-up flake: CH compression standby/restore exec reset
+
+### Flake signature
+- `TestCloudHypervisorStandbyRestoreCompressionScenarios`
+  - failure while writing a guest marker before standby:
+    - `receive response (stdout=0, stderr=0): rpc error: code = DeadlineExceeded desc = stream terminated by RST_STREAM with error code: CANCEL`
+
+### Root cause
+- Standby/restore keeps the same guest-agent vsock identity for Cloud Hypervisor (`ch:<vsock-socket-path>`), and guest gRPC connections are pooled by that key.
+- `standbyInstance` did not evict the pooled guest-agent connection when the VM transitioned to `Standby`, so post-restore execs could briefly reuse a connection tied to the dead pre-standby VM.
+- That stale-connection reuse is consistent with the observed one-shot gRPC stream reset in `writeGuestMarker`.
+
+### Fix
+- `lib/instances/standby.go`
+  - after shutting down the hypervisor and cleaning stale vsock sockets, explicitly remove the pooled guest-agent connection with `guest.CloseConn(dialer.Key())`
+  - this forces restore-time execs to establish a fresh gRPC connection against the resumed VM
+
+### Validation on `deft-kernel-dev`
+- Targeted stress:
+  - `go test -count=20 -v -tags containers_image_openpgp -run '^TestCloudHypervisorStandbyRestoreCompressionScenarios$' -timeout=90m ./lib/instances`
+  - result: pass, package time `740.546s`
+- I also started a fresh-cache full-suite Deft verification run after this fix, but it was intentionally interrupted before completion when switching to commit/push.

--- a/skills/test-agent/agents/test-agent/NOTES.md
+++ b/skills/test-agent/agents/test-agent/NOTES.md
@@ -211,3 +211,56 @@
 - One environmental contributor on `deft-kernel-dev`:
   - `lz4` and `zstd` are not installed, so snapshot compression tests fall back to the Go implementation, which likely inflates compression-scenario timings.
 - I did not make a test-quality code change in this pass because I did not find a low-risk redundancy or speed improvement that was clearly justified after the no-cache runs came back clean.
+
+## 2026-03-25 - `hypeman` flake round on `~/hm4943`
+
+### Reported flake signatures
+- `TestVolumeMultiAttachReadOnly`
+  - `exec-agent not ready for instance ... within 15s (last state: Initializing)`
+- `TestVolumeFromArchive`
+  - `exec-agent not ready for instance ... within 15s (last state: Initializing)`
+
+### Additional flakes reproduced during Deft full-suite verification
+- `TestQEMUForkFromRunningNetwork`
+  - source/fork instance did not reach `Running` within 20s on a busy Deft host
+  - cleanup also risked a nil-pointer panic because the cleanup closure captured `source.Id` after `source` could be reassigned on failure
+- `TestCreateInstance_AutoPullImage`
+  - `start cloud-hypervisor: ... text file busy`
+
+### Root causes
+- Volume-backed integration tests still used a 15s exec-agent readiness budget even though guest-agent/vsock readiness can lag while the instance remains in `Initializing` under full-suite host contention.
+- `waitForExecAgent` previously refused to probe until the manager reported `Running`, even though exec could already be reachable while boot-marker hydration was still catching up.
+- QEMU running-fork tests had a too-tight 20s host-side `Running` budget for full-suite contention.
+- Cloud Hypervisor startup could race a freshly extracted binary and hit transient `ETXTBSY`.
+
+### Fixes
+- `lib/instances/exec_test.go`
+  - allowed `waitForExecAgent` to probe while instance state is either `Initializing` or `Running`
+- `lib/instances/volumes_test.go`
+  - widened exec-agent waits from 15s to 30s for:
+    - writer in `TestVolumeMultiAttachReadOnly`
+    - both readers in `TestVolumeMultiAttachReadOnly`
+    - archive-backed instance in `TestVolumeFromArchive`
+- `lib/instances/qemu_test.go`
+  - captured `sourceID` before `t.Cleanup(...)`
+  - widened three `waitForInstanceState(..., StateRunning, ...)` calls from 20s to 45s in `TestQEMUForkFromRunningNetwork`
+- `lib/vmm/client.go`
+  - added bounded retry-on-`ETXTBSY` / `"text file busy"` when starting Cloud Hypervisor
+
+### Validation on `deft-kernel-dev`
+- Targeted volume stress:
+  - `go test -count=20 -v -tags containers_image_openpgp -run '^(TestVolumeMultiAttachReadOnly|TestVolumeFromArchive)$' -timeout=60m ./lib/instances`
+  - result: pass, package time `169.911s`
+- Targeted QEMU fork verification:
+  - `go test -count=4 -v -tags containers_image_openpgp -run '^TestQEMUForkFromRunningNetwork$' -timeout=45m ./lib/instances`
+  - result: pass, package time `57.699s`
+- Targeted API verification for CH startup retry:
+  - `go test -count=10 -v -tags containers_image_openpgp -run '^TestCreateInstance_AutoPullImage$' -timeout=45m ./cmd/api/api`
+  - result: pass, package time `34.761s`
+- Fresh-cache full-suite verification (`go mod download`, `make oapi-generate`, `make build`, `go run ./cmd/test-prewarm`, `go test -count=1 -tags containers_image_openpgp -timeout=20m ./...`)
+  - Run 1: `215s` (pass)
+  - Run 2: `212s` (pass)
+
+### Verification note
+- One intermediate Deft rerun failed before tests because the remote scratch workspace had stray untracked files at repo-root `lib/` (`client.go`, `exec_test.go`, `qemu_test.go`) that created a mixed-package directory.
+- After removing those remote-only artifacts, the same fresh-cache full-suite gate passed twice.


### PR DESCRIPTION
## Summary
- allow `waitForExecAgent` to probe while instances are still `Initializing`
- widen the volume integration test exec-agent budgets and the QEMU running-fork readiness budget
- retry Cloud Hypervisor startup on transient `text file busy` failures
- record the investigation and validation details in the test-agent notes

## Flakes addressed
- `TestVolumeMultiAttachReadOnly`: `exec-agent not ready ... within 15s (last state: Initializing)`
- `TestVolumeFromArchive`: `exec-agent not ready ... within 15s (last state: Initializing)`
- `TestQEMUForkFromRunningNetwork`: did not reach `Running` within 20s under Deft full-suite load
- `TestCreateInstance_AutoPullImage`: transient Cloud Hypervisor `text file busy` startup failure

## Validation
- `go test -count=20 -v -tags containers_image_openpgp -run '^(TestVolumeMultiAttachReadOnly|TestVolumeFromArchive)$' -timeout=60m ./lib/instances`
- `go test -count=4 -v -tags containers_image_openpgp -run '^TestQEMUForkFromRunningNetwork$' -timeout=45m ./lib/instances`
- `go test -count=10 -v -tags containers_image_openpgp -run '^TestCreateInstance_AutoPullImage$' -timeout=45m ./cmd/api/api`
- fresh-cache full-suite verification on `deft-kernel-dev`:
  - run 1: pass in 215s
  - run 2: pass in 212s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM lifecycle code (`standbyInstance`) and Cloud Hypervisor process startup (`StartProcessWithArgs`), so a mistake could impact standby/restore reliability or VMM boot behavior, though changes are bounded and targeted at transient flake conditions.
> 
> **Overview**
> Reduces integration test flakiness under CI/host contention by relaxing readiness assumptions: `waitForExecAgent` now probes while instances are still `Initializing`, volume-backed exec-agent waits are increased (15s→30s), and QEMU running-fork state waits are widened (20s→45s) with safer cleanup ID capture.
> 
> Hardens Cloud Hypervisor startup by adding a bounded retry loop when `cloud-hypervisor` fails to `exec` with transient `ETXTBSY`/"text file busy", and makes standby/restore more reliable by explicitly evicting pooled guest-agent gRPC connections on standby.
> 
> Updates tests to avoid live Docker Hub dependencies (`apiTestImageRef`) and relaxes a build status assertion to accept an immediate transition from `queued` to `building`; adds investigation/validation notes in `skills/test-agent/agents/test-agent/NOTES.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52aa4dc86f98e1ddd412b80bcc68eda5f98497f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->