### PR TITLE
Add shared histogram buckets for duration metrics

### DIFF
--- a/lib/builds/metrics.go
+++ b/lib/builds/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	hypotel "github.com/kernel/hypeman/lib/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -22,6 +23,7 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 		"hypeman_build_duration_seconds",
 		metric.WithDescription("Duration of builds in seconds"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.BuildDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err

--- a/lib/egressproxy/metrics.go
+++ b/lib/egressproxy/metrics.go
@@ -3,13 +3,9 @@ package egressproxy
 import (
 	"context"
 
+	hypotel "github.com/kernel/hypeman/lib/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-)
-
-var (
-	controlPlaneDurationBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 5}
-	upstreamDurationBuckets     = []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60}
 )
 
 type metrics struct {
@@ -51,7 +47,7 @@ func newMetrics(meter metric.Meter, svc *Service) (*metrics, error) {
 		"hypeman_egress_proxy_control_plane_duration_seconds",
 		metric.WithDescription("Duration of egress proxy control plane operations"),
 		metric.WithUnit("s"),
-		metric.WithExplicitBucketBoundaries(controlPlaneDurationBuckets...),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err
@@ -69,7 +65,7 @@ func newMetrics(meter metric.Meter, svc *Service) (*metrics, error) {
 		"hypeman_egress_proxy_upstream_duration_seconds",
 		metric.WithDescription("Duration of egress proxy upstream requests"),
 		metric.WithUnit("s"),
-		metric.WithExplicitBucketBoundaries(upstreamDurationBuckets...),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err

--- a/lib/guest/metrics.go
+++ b/lib/guest/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	hypotel "github.com/kernel/hypeman/lib/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -48,6 +49,7 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 		"hypeman_exec_duration_seconds",
 		metric.WithDescription("Exec command duration"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err
@@ -83,6 +85,7 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 		"hypeman_cp_duration_seconds",
 		metric.WithDescription("Copy operation duration"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err

--- a/lib/guestmemory/metrics.go
+++ b/lib/guestmemory/metrics.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kernel/hypeman/lib/hypervisor"
+	hypotel "github.com/kernel/hypeman/lib/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -53,6 +54,7 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 		"hypeman_guestmemory_reconcile_duration_seconds",
 		metric.WithDescription("Guest memory reconcile duration"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err

--- a/lib/images/metrics.go
+++ b/lib/images/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	hypotel "github.com/kernel/hypeman/lib/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -20,6 +21,7 @@ func newMetrics(meter metric.Meter, m *manager) (*Metrics, error) {
 		"hypeman_images_build_duration_seconds",
 		metric.WithDescription("Time to build an image"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.BuildDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err

--- a/lib/instances/metrics.go
+++ b/lib/instances/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kernel/hypeman/lib/hypervisor"
 	mw "github.com/kernel/hypeman/lib/middleware"
+	hypotel "github.com/kernel/hypeman/lib/otel"
 	snapshotstore "github.com/kernel/hypeman/lib/snapshot"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -86,6 +87,7 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 		"hypeman_instances_create_duration_seconds",
 		metric.WithDescription("Time to create an instance"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err
@@ -95,6 +97,7 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 		"hypeman_instances_restore_duration_seconds",
 		metric.WithDescription("Time to restore an instance from standby"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err
@@ -104,6 +107,7 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 		"hypeman_instances_standby_duration_seconds",
 		metric.WithDescription("Time to put an instance in standby"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err
@@ -113,6 +117,7 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 		"hypeman_instances_stop_duration_seconds",
 		metric.WithDescription("Time to stop an instance"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err
@@ -122,6 +127,7 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 		"hypeman_instances_start_duration_seconds",
 		metric.WithDescription("Time to start an instance"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err
@@ -131,6 +137,7 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 		"hypeman_instances_time_to_running_seconds",
 		metric.WithDescription("Time from boot start until an instance reaches Running"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err
@@ -156,6 +163,7 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 		"hypeman_snapshot_compression_duration_seconds",
 		metric.WithDescription("Time to asynchronously compress snapshot memory"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err
@@ -198,6 +206,7 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 		"hypeman_snapshot_restore_memory_prepare_duration_seconds",
 		metric.WithDescription("Time to prepare snapshot memory before restore"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err

--- a/lib/middleware/otel.go
+++ b/lib/middleware/otel.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/kernel/hypeman/lib/logger"
+	hypotel "github.com/kernel/hypeman/lib/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -36,6 +37,7 @@ func NewHTTPMetrics(meter metric.Meter) (*HTTPMetrics, error) {
 		"hypeman_http_request_duration_seconds",
 		metric.WithDescription("HTTP request duration in seconds"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err

--- a/lib/otel/buckets.go
+++ b/lib/otel/buckets.go
@@ -1,0 +1,25 @@
+package otel
+
+var commonDurationHistogramBuckets = []float64{
+	0.001, 0.0025, 0.005, 0.010, 0.025, 0.050, 0.075,
+	0.100, 0.150, 0.200, 0.300, 0.500, 0.750,
+	1, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10,
+	20, 30, 45, 60, 90, 120,
+}
+
+var buildDurationHistogramBuckets = []float64{
+	0.100, 0.250, 0.500, 1, 2.5, 5, 10,
+	20, 30, 45, 60, 90, 120, 180, 300, 600, 900, 1800,
+}
+
+// CommonDurationHistogramBuckets returns the standard duration bucket set for
+// Hypeman duration histograms.
+func CommonDurationHistogramBuckets() []float64 {
+	return append([]float64(nil), commonDurationHistogramBuckets...)
+}
+
+// BuildDurationHistogramBuckets returns the slower-moving duration bucket set
+// used for build-style operations.
+func BuildDurationHistogramBuckets() []float64 {
+	return append([]float64(nil), buildDurationHistogramBuckets...)
+}

--- a/lib/vmm/metrics.go
+++ b/lib/vmm/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	hypotel "github.com/kernel/hypeman/lib/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -34,6 +35,7 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 		"hypeman_vmm_api_duration_seconds",
 		metric.WithDescription("Cloud Hypervisor API call duration"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err

--- a/lib/volumes/metrics.go
+++ b/lib/volumes/metrics.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 	"time"
 
+	hypotel "github.com/kernel/hypeman/lib/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -21,6 +22,7 @@ func newVolumeMetrics(meter metric.Meter, m *manager) (*Metrics, error) {
 		"hypeman_volumes_create_duration_seconds",
 		metric.WithDescription("Time to create a volume"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- add a shared default duration bucket set for Hypeman duration histograms
- apply the shared buckets across HTTP, instance lifecycle, guest ops, guest memory, volumes, VMM, and egress proxy histograms
- use a slower build-specific bucket set for build and image build duration histograms

## Testing
- go test -run '^$' ./lib/middleware ./lib/builds ./lib/otel
- go test -run '^$' ./lib/images ./lib/guest ./lib/volumes ./lib/vmm ./lib/guestmemory ./lib/egressproxy
- go test ./lib/instances -run 'TestSnapshotCompressionMetrics_RecordAndObserve|TestInstanceOldestInStateMetric_ObserveOldestAgePerState|TestInstanceTimeToRunningMetric_RecordWhenBootMarkersPersisted|TestLifecycleDurationMetrics_RecordCompressionLabels'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes histogram bucket boundaries for multiple exported duration metrics, which can affect Prometheus/OTel time series, dashboards, and alert thresholds even though runtime behavior is otherwise unchanged.
> 
> **Overview**
> Introduces shared OpenTelemetry duration histogram bucket helpers in `lib/otel/buckets.go`, including a common bucket set and a slower build-specific set.
> 
> Updates duration histograms across builds/images, HTTP middleware, instances lifecycle/snapshot operations, guest ops, guest memory, volumes, VMM, and egress proxy to use these shared bucket boundaries (removing egress-proxy’s local bucket definitions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efd62564daf1e5bdd9d6772b3d8595efeff77924. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->