### PR TITLE
Use OIDC for Stainless npm publishing

### DIFF
--- a/stainless.yaml
+++ b/stainless.yaml
@@ -29,7 +29,8 @@ targets:
     package_name: "@onkernel/hypeman"
     production_repo: kernel/hypeman-ts
     publish:
-      npm: true
+      npm:
+        auth_method: oidc
 
 # `environments` are a map of the name of the environment (e.g. "sandbox",
 # "production") to the corresponding url to use.


### PR DESCRIPTION
## Summary
- switch the Stainless TypeScript target from `npm: true` to npm OIDC publishing
- configure `stainless.yaml` to use `publish.npm.auth_method: oidc`
- align Hypeman's SDK publishing config with npm trusted publishing

## Test plan
- [ ] verify the Stainless preview workflow runs on this PR
- [ ] after merge, confirm Stainless uses OIDC for the TypeScript npm publish flow
- [ ] confirm the next `@onkernel/hypeman` release publishes successfully without an npm token

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the npm publish authentication mechanism for the TypeScript SDK, which could break release/publish automation if OIDC/trusted publishing isn’t correctly configured in npm/GitHub.
> 
> **Overview**
> Updates `stainless.yaml` to migrate the TypeScript target’s npm publishing config from `publish.npm: true` to an explicit `publish.npm.auth_method: oidc`, enabling npm trusted publishing (OIDC) instead of token-based auth for `@onkernel/hypeman`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0b881f08dddad4417d8d37b2e8c74a99a853fb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->