### PR TITLE
Add heartbeats to StreamBuildEvents wait-for-log-file loop

### DIFF
--- a/lib/builds/manager.go
+++ b/lib/builds/manager.go
@@ -1127,7 +1127,11 @@ func (m *manager) StreamBuildEvents(ctx context.Context, id string, follow bool)
 			if !follow || isComplete {
 				return
 			}
-			// Wait for log file to appear, or for build to complete
+			// Wait for log file to appear, or for build to complete.
+			// Send heartbeats while waiting so SSE connections survive
+			// infrastructure idle timeouts (e.g. load balancer 60s timeout).
+			waitHeartbeat := time.NewTicker(15 * time.Second)
+			defer waitHeartbeat.Stop()
 			for {
 				select {
 				case <-ctx.Done():
@@ -1138,11 +1142,16 @@ func (m *manager) StreamBuildEvents(ctx context.Context, id string, follow bool)
 					case <-ctx.Done():
 						return
 					}
-					// Check if build completed
 					if event.Status == StatusReady || event.Status == StatusFailed || event.Status == StatusCancelled {
 						return
 					}
-					// Non-terminal status event - keep waiting for log file
+					continue
+				case <-waitHeartbeat.C:
+					select {
+					case out <- BuildEvent{Type: EventTypeHeartbeat, Timestamp: time.Now()}:
+					case <-ctx.Done():
+						return
+					}
 					continue
 				case <-time.After(500 * time.Millisecond):
 					if _, err := os.Stat(logPath); err == nil {
@@ -1152,6 +1161,7 @@ func (m *manager) StreamBuildEvents(ctx context.Context, id string, follow bool)
 				}
 				break
 			}
+			waitHeartbeat.Stop()
 		}
 
 		// Build tail command args


### PR DESCRIPTION
## Summary
- Adds a 15-second heartbeat ticker to the `StreamBuildEvents` wait-for-log-file loop
- When a build is queued behind others, the SSE stream previously sent no events while waiting for the log file to appear. Infrastructure proxies (e.g. Railway) terminate idle SSE connections after ~60 seconds, causing the Kernel API to report "build timed out" even though the build hasn't started yet.
- The heartbeat keeps the connection alive through the queue wait. The existing 30-second heartbeat in the main streaming loop already handles the active-build case.

## Context
During a bulk migration of Unikraft deployments to Hypeman, builds queued behind others consistently timed out after exactly 60 seconds. Root cause: the SSE stream was idle during the queue wait, triggering an infrastructure idle timeout.

## Test plan
- [ ] Deploy to a staging Hypeman host
- [ ] Submit multiple builds concurrently (more than `max_concurrent_source_builds`) to force queuing
- [ ] Verify that queued builds receive heartbeat events and complete successfully instead of timing out

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to `StreamBuildEvents` that only adds periodic heartbeat events during the pre-log wait; main behavioral risk is extra event traffic or unexpected client handling of `heartbeat` events.
> 
> **Overview**
> Prevents idle timeouts for queued builds by emitting `heartbeat` events while `StreamBuildEvents` is waiting for the build log file to appear.
> 
> This adds a 15s ticker in the wait-for-log-file loop (before `tail` starts) so SSE clients keep receiving events until logs begin streaming or the build reaches a terminal status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bffcd3e7116ac567d13f44dbdd9d353eb6000345. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->