### PR TITLE
Fix tc class EEXIST error during TAP device creation

### DIFF
--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -705,8 +705,11 @@ func (m *manager) addVMClass(bridgeName, tapName string, rateBps, ceilBps int64)
 	}
 	ceilStr := formatTcRate(ceilBps)
 
-	// 1. Add HTB class for this VM
-	cmd := exec.Command("tc", "class", "add", "dev", bridgeName, "parent", htbRootClassID,
+	// 1. Add or update HTB class for this VM
+	// Use "replace" instead of "add" for idempotency — if the class already exists
+	// (e.g., orphaned from a previous failed cleanup, or a 16-bit hash collision on
+	// restore), "replace" updates it in place instead of failing with EEXIST.
+	cmd := exec.Command("tc", "class", "replace", "dev", bridgeName, "parent", htbRootClassID,
 		"classid", fullClassID, "htb", "rate", rateStr, "ceil", ceilStr, "prio", "1")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},


### PR DESCRIPTION
## Summary

Fixes the `failed to create instance` error caused by:
```
allocate network: create TAP device: apply upload rate limit: tc class add vm: exit status 2 (output: RTNETLINK answers: File exists)
```

**Root cause:** `addVMClass` uses `tc class add` which fails with `EEXIST` when a class with the same ID already exists on the bridge. This happens because:

1. **Orphaned tc classes from failed cleanup.** `removeVMClass` (called during TAP teardown) is entirely best-effort — filter, qdisc, and class deletions all silently swallow errors. If the filter deletion fails (fragile string parsing of `tc filter show` output), `tc class del` also fails silently because the class still has references. The TAP device gets deleted, but the tc class persists as an orphan. On the next allocation that maps to the same class ID, `tc class add` hits the orphan and fails.

2. **16-bit hash collision risk.** `deriveClassID` hashes TAP names via FNV-1a truncated to 16 bits (65,536 possible IDs). By birthday paradox, collision probability reaches ~50% at 256 concurrent TAPs per host. Two different live instances can map to the same class ID.

3. **Restore/re-creation paths.** `createTAPDevice` checks for an existing TAP (and deletes it if found), but does not check for an existing tc class independently. When the TAP is gone but the class persists, the idempotency check is bypassed. `CleanupOrphanedClasses` handles this but only runs at `Initialize()` time, not before each allocation.

**Fix:** Change `tc class add` to `tc class replace` in `addVMClass`. This is the idempotent equivalent — creates the class if missing, updates it in place if it already exists. No behavioral change for the happy path; eliminates the EEXIST failure on all three root cause paths.

One-line change in `lib/network/bridge_linux.go`.