### PR TITLE
Propagate saveClassID error and clear stale classid files

### DIFF
--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -66,8 +66,13 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 	m.recordTAPOperation(ctx, "create")
 
 	// Persist assigned tc class ID so removal uses the correct ID after collisions.
+	// Clear any stale file when no rate limiting was applied.
 	if classID != "" {
-		m.saveClassID(req.InstanceID, classID)
+		if err := m.saveClassID(req.InstanceID, classID); err != nil {
+			return nil, fmt.Errorf("save class ID: %w", err)
+		}
+	} else {
+		m.clearClassID(req.InstanceID)
 	}
 
 	log.InfoContext(ctx, "allocated network",
@@ -128,8 +133,13 @@ func (m *manager) RecreateAllocation(ctx context.Context, instanceID string, dow
 	m.recordTAPOperation(ctx, "create")
 
 	// Persist assigned tc class ID so removal uses the correct ID after collisions.
+	// Clear any stale file when no rate limiting was applied.
 	if classID != "" {
-		m.saveClassID(instanceID, classID)
+		if err := m.saveClassID(instanceID, classID); err != nil {
+			return fmt.Errorf("save class ID: %w", err)
+		}
+	} else {
+		m.clearClassID(instanceID)
 	}
 
 	log.InfoContext(ctx, "recreated network for restore",
@@ -309,9 +319,13 @@ func generateMAC() (string, error) {
 }
 
 // saveClassID persists the tc class ID for an instance so it survives restarts.
-func (m *manager) saveClassID(instanceID, classID string) {
-	path := m.paths.InstanceDir(instanceID)
-	_ = os.WriteFile(path+"/classid", []byte(classID), 0644)
+func (m *manager) saveClassID(instanceID, classID string) error {
+	return os.WriteFile(m.paths.InstanceDir(instanceID)+"/classid", []byte(classID), 0644)
+}
+
+// clearClassID removes any persisted tc class ID for an instance.
+func (m *manager) clearClassID(instanceID string) {
+	_ = os.Remove(m.paths.InstanceDir(instanceID) + "/classid")
 }
 
 // loadClassID loads the persisted tc class ID for an instance.


### PR DESCRIPTION
## Summary

Follow-up to #179. Addresses two review comments on the tc class collision fix:

- **saveClassID now returns error** instead of discarding it with `_ =`. If the write fails (e.g. disk full), the error surfaces immediately rather than silently losing the collision-resolved class ID — which would cause `removeVMClass` to fall back to `deriveClassID` and target the wrong class.

- **Stale classid files are cleared** when no upload rate limiting is applied (`classID` is empty). Previously, if an instance was recreated without rate limiting, the old `classid` file persisted, causing `ReleaseAllocation` to delete the wrong tc class.

## Changes
- `lib/network/allocate.go` — `saveClassID` returns `error`; callers propagate it; new `clearClassID` helper; both `CreateAllocation` and `RecreateAllocation` clear stale files when `classID` is empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches network allocation/restore paths by changing `saveClassID` to fail fast on disk write errors and by deleting persisted class IDs when no rate limiting is applied, which could surface new allocation failures and affects tc class cleanup behavior.
> 
> **Overview**
> Improves tc class ID persistence during network allocation/restore by making `saveClassID` return an error and propagating failures from `CreateAllocation`/`RecreateAllocation` instead of silently ignoring write issues.
> 
> Also clears any existing `classid` file when `createTAPDevice` returns an empty class ID (no rate limiting), preventing stale persisted IDs from causing incorrect tc class deletion on release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0ec2e46d73f568b452392d8cf096d0d52cf3b1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->