### PR TITLE
Add burst-proof resource reservations

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -122,6 +122,7 @@ Common settings:
 | `metrics.resource_refresh_interval` | Refresh interval for cached resource capacity metrics | `120s` |
 | `limits.max_concurrent_builds` | Max concurrent image builds | `1` |
 | `limits.max_overlay_size` | Max overlay filesystem size | `100GB` |
+| `limits.name_patterns` | Ordered regex overrides for per-instance CPU/memory/overlay limits | _(empty)_ |
 | `acme.email` | Email for ACME certificate registration | _(empty)_ |
 | `acme.dns_provider` | DNS provider for ACME challenges | _(empty)_ |
 | `acme.cloudflare_api_token` | Cloudflare API token | _(empty)_ |

--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -153,12 +153,13 @@ type RegistryConfig struct {
 
 // LimitsConfig holds per-instance and aggregate resource limits.
 type LimitsConfig struct {
-	MaxVcpusPerInstance   int     `koanf:"max_vcpus_per_instance"`
-	MaxMemoryPerInstance  string  `koanf:"max_memory_per_instance"`
-	MaxTotalVolumeStorage string  `koanf:"max_total_volume_storage"`
-	MaxConcurrentBuilds   int     `koanf:"max_concurrent_builds"`
-	MaxOverlaySize        string  `koanf:"max_overlay_size"`
-	MaxImageStorage       float64 `koanf:"max_image_storage"`
+	MaxVcpusPerInstance   int                       `koanf:"max_vcpus_per_instance"`
+	MaxMemoryPerInstance  string                    `koanf:"max_memory_per_instance"`
+	MaxTotalVolumeStorage string                    `koanf:"max_total_volume_storage"`
+	MaxConcurrentBuilds   int                       `koanf:"max_concurrent_builds"`
+	MaxOverlaySize        string                    `koanf:"max_overlay_size"`
+	MaxImageStorage       float64                   `koanf:"max_image_storage"`
+	NamePatterns          []NamePatternLimitsConfig `koanf:"name_patterns"`
 }
 
 // OversubscriptionConfig holds oversubscription ratios (1.0 = no oversubscription).
@@ -361,6 +362,7 @@ func defaultConfig() *Config {
 			MaxConcurrentBuilds:   1,
 			MaxOverlaySize:        "100GB",
 			MaxImageStorage:       0.2,
+			NamePatterns:          nil,
 		},
 
 		Oversubscription: OversubscriptionConfig{
@@ -532,6 +534,24 @@ func (c *Config) Validate() error {
 	if c.Build.Timeout <= 0 {
 		return fmt.Errorf("build.timeout must be positive, got %d", c.Build.Timeout)
 	}
+	if c.Limits.MaxVcpusPerInstance < 0 {
+		return fmt.Errorf("limits.max_vcpus_per_instance must be >= 0, got %d", c.Limits.MaxVcpusPerInstance)
+	}
+	if err := validateOptionalByteSize("limits.max_memory_per_instance", c.Limits.MaxMemoryPerInstance); err != nil {
+		return err
+	}
+	if err := validateByteSize("limits.max_overlay_size", c.Limits.MaxOverlaySize); err != nil {
+		return err
+	}
+	if c.Limits.MaxConcurrentBuilds <= 0 {
+		return fmt.Errorf("limits.max_concurrent_builds must be positive, got %d", c.Limits.MaxConcurrentBuilds)
+	}
+	if c.Limits.MaxImageStorage < 0 {
+		return fmt.Errorf("limits.max_image_storage must be >= 0, got %v", c.Limits.MaxImageStorage)
+	}
+	if err := validateNamePatternLimits(c.Limits.NamePatterns); err != nil {
+		return err
+	}
 	if err := validateDuration("images.auto_delete.unused_for", c.Images.AutoDelete.UnusedFor); err != nil {
 		return err
 	}
@@ -604,6 +624,14 @@ func validateByteSize(field string, value string) error {
 		return fmt.Errorf("%s must be a valid byte size, got %q: %w", field, value, err)
 	}
 	return nil
+}
+
+func validateOptionalByteSize(field string, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return validateByteSize(field, value)
 }
 
 func validateDuration(field string, value string) error {

--- a/cmd/api/config/config_test.go
+++ b/cmd/api/config/config_test.go
@@ -288,3 +288,87 @@ func TestValidateAllowsDisabledSnapshotCompressionDefaultWithoutValidAlgorithm(t
 		t.Fatalf("expected disabled snapshot compression default to ignore algorithm/level, got %v", err)
 	}
 }
+
+func TestLoadParsesNamePatternLimits(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	configYAML := `
+limits:
+  name_patterns:
+    - pattern: '^prod-'
+      max_vcpus_per_instance: 8
+      max_memory_per_instance: 64GB
+    - pattern: '^tiny-'
+      max_overlay_size: 5GB
+`
+	if err := os.WriteFile(cfgPath, []byte(configYAML), 0600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	if len(cfg.Limits.NamePatterns) != 2 {
+		t.Fatalf("expected 2 name pattern limit entries, got %d", len(cfg.Limits.NamePatterns))
+	}
+	if cfg.Limits.NamePatterns[0].Pattern != "^prod-" {
+		t.Fatalf("expected first pattern to load, got %q", cfg.Limits.NamePatterns[0].Pattern)
+	}
+	if cfg.Limits.NamePatterns[0].MaxVcpusPerInstance == nil || *cfg.Limits.NamePatterns[0].MaxVcpusPerInstance != 8 {
+		t.Fatalf("expected first max_vcpus_per_instance to load, got %#v", cfg.Limits.NamePatterns[0].MaxVcpusPerInstance)
+	}
+	if cfg.Limits.NamePatterns[0].MaxMemoryPerInstance == nil || *cfg.Limits.NamePatterns[0].MaxMemoryPerInstance != "64GB" {
+		t.Fatalf("expected first max_memory_per_instance to load, got %#v", cfg.Limits.NamePatterns[0].MaxMemoryPerInstance)
+	}
+	if cfg.Limits.NamePatterns[1].MaxOverlaySize == nil || *cfg.Limits.NamePatterns[1].MaxOverlaySize != "5GB" {
+		t.Fatalf("expected second max_overlay_size to load, got %#v", cfg.Limits.NamePatterns[1].MaxOverlaySize)
+	}
+}
+
+func TestValidateRejectsInvalidNamePatternLimitRegex(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Limits.NamePatterns = []NamePatternLimitsConfig{
+		{Pattern: "["},
+	}
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "limits.name_patterns[0].pattern") {
+		t.Fatalf("expected invalid regex validation error, got %v", err)
+	}
+}
+
+func TestValidateRejectsInvalidNamePatternLimitSize(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Limits.NamePatterns = []NamePatternLimitsConfig{
+		{
+			Pattern:              "^prod-",
+			MaxMemoryPerInstance: strPtr("definitely-not-a-size"),
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "limits.name_patterns[0].max_memory_per_instance") {
+		t.Fatalf("expected invalid size validation error, got %v", err)
+	}
+}
+
+func TestValidateAllowsUnlimitedNamePatternLimitSize(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Limits.NamePatterns = []NamePatternLimitsConfig{
+		{
+			Pattern:              "^prod-",
+			MaxMemoryPerInstance: strPtr("0"),
+			MaxOverlaySize:       strPtr("0"),
+		},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected zero-valued size overrides to validate, got %v", err)
+	}
+}
+
+func strPtr(v string) *string {
+	return &v
+}

--- a/cmd/api/config/limits_patterns.go
+++ b/cmd/api/config/limits_patterns.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// NamePatternLimitsConfig holds per-name regex resource limit overrides.
+// The first matching pattern wins. Omitted fields fall back to the global limits block.
+type NamePatternLimitsConfig struct {
+	Pattern              string  `koanf:"pattern"`
+	MaxVcpusPerInstance  *int    `koanf:"max_vcpus_per_instance"`
+	MaxMemoryPerInstance *string `koanf:"max_memory_per_instance"`
+	MaxOverlaySize       *string `koanf:"max_overlay_size"`
+}
+
+func validateNamePatternLimits(patterns []NamePatternLimitsConfig) error {
+	for i := range patterns {
+		cfg := &patterns[i]
+		cfg.Pattern = strings.TrimSpace(cfg.Pattern)
+		if cfg.Pattern == "" {
+			return fmt.Errorf("limits.name_patterns[%d].pattern must not be empty", i)
+		}
+		if _, err := regexp.Compile(cfg.Pattern); err != nil {
+			return fmt.Errorf("limits.name_patterns[%d].pattern must be a valid regex, got %q: %w", i, cfg.Pattern, err)
+		}
+		if cfg.MaxVcpusPerInstance != nil && *cfg.MaxVcpusPerInstance < 0 {
+			return fmt.Errorf("limits.name_patterns[%d].max_vcpus_per_instance must be >= 0, got %d", i, *cfg.MaxVcpusPerInstance)
+		}
+		if cfg.MaxMemoryPerInstance != nil {
+			value := strings.TrimSpace(*cfg.MaxMemoryPerInstance)
+			if value == "" {
+				return fmt.Errorf("limits.name_patterns[%d].max_memory_per_instance must not be empty", i)
+			}
+			*cfg.MaxMemoryPerInstance = value
+			if err := validateOptionalByteSize(fmt.Sprintf("limits.name_patterns[%d].max_memory_per_instance", i), value); err != nil {
+				return err
+			}
+		}
+		if cfg.MaxOverlaySize != nil {
+			value := strings.TrimSpace(*cfg.MaxOverlaySize)
+			if value == "" {
+				return fmt.Errorf("limits.name_patterns[%d].max_overlay_size must not be empty", i)
+			}
+			*cfg.MaxOverlaySize = value
+			if err := validateOptionalByteSize(fmt.Sprintf("limits.name_patterns[%d].max_overlay_size", i), value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/config.example.darwin.yaml
+++ b/config.example.darwin.yaml
@@ -115,6 +115,12 @@ limits:
   max_vcpus_per_instance: 4
   max_memory_per_instance: 8GB
   # max_total_volume_storage: ""  # 0 or empty = unlimited
+  # name_patterns:
+  #   - pattern: '^build-'
+  #     max_vcpus_per_instance: 8
+  #   - pattern: '^tiny-'
+  #     max_memory_per_instance: 2GB
+  #     max_overlay_size: 5GB
 
 # =============================================================================
 # OpenTelemetry (optional, same as Linux)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -146,3 +146,9 @@ data_dir: /var/lib/hypeman
 #   max_total_volume_storage: ""  # 0 or empty = unlimited
 #   max_concurrent_builds: 1
 #   max_overlay_size: 100GB
+#   name_patterns:
+#     - pattern: '^prod-'
+#       max_vcpus_per_instance: 32
+#       max_memory_per_instance: 64GB
+#     - pattern: '^sandbox-'
+#       max_overlay_size: 20GB

--- a/lib/instances/admission.go
+++ b/lib/instances/admission.go
@@ -1,0 +1,22 @@
+package instances
+
+func volumeOverlayReservationBytes(volumes []VolumeAttachment) int64 {
+	var total int64
+	for _, vol := range volumes {
+		if vol.Overlay {
+			total += vol.OverlaySize
+		}
+	}
+	return total
+}
+
+func requestedDiskReservationBytes(overlaySize int64, volumes []VolumeAttachment) int64 {
+	return overlaySize + volumeOverlayReservationBytes(volumes)
+}
+
+func storedDiskReservationBytes(stored *StoredMetadata) int64 {
+	if stored == nil {
+		return 0
+	}
+	return requestedDiskReservationBytes(stored.OverlaySize, stored.Volumes)
+}

--- a/lib/instances/admission_test.go
+++ b/lib/instances/admission_test.go
@@ -1,0 +1,33 @@
+package instances
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestedDiskReservationBytes(t *testing.T) {
+	t.Parallel()
+
+	diskBytes := requestedDiskReservationBytes(10, []VolumeAttachment{
+		{VolumeID: "base-only", Overlay: false, OverlaySize: 100},
+		{VolumeID: "overlay-a", Overlay: true, OverlaySize: 20},
+		{VolumeID: "overlay-b", Overlay: true, OverlaySize: 30},
+	})
+
+	assert.Equal(t, int64(60), diskBytes)
+}
+
+func TestStoredDiskReservationBytes(t *testing.T) {
+	t.Parallel()
+
+	diskBytes := storedDiskReservationBytes(&StoredMetadata{
+		OverlaySize: 15,
+		Volumes: []VolumeAttachment{
+			{VolumeID: "base-only", Overlay: false, OverlaySize: 100},
+			{VolumeID: "overlay", Overlay: true, OverlaySize: 25},
+		},
+	})
+
+	assert.Equal(t, int64(40), diskBytes)
+}

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -182,13 +182,22 @@ func (m *manager) createInstance(
 		return nil, fmt.Errorf("total memory %d (size + hotplug_size) exceeds maximum allowed %d per instance", totalMemory, m.limits.MaxMemoryPerInstance)
 	}
 
-	// Validate aggregate resource limits via ResourceValidator (if configured)
+	diskBytes := requestedDiskReservationBytes(overlaySize, req.Volumes)
+	reservedResources := false
+
+	// Reserve aggregate resources for this create while it is in flight.
 	if m.resourceValidator != nil {
 		needsGPU := req.GPU != nil && req.GPU.Profile != ""
-		if err := m.resourceValidator.ValidateAllocation(ctx, vcpus, totalMemory, req.NetworkBandwidthDownload, req.NetworkBandwidthUpload, req.DiskIOBps, needsGPU); err != nil {
-			log.ErrorContext(ctx, "resource validation failed", "error", err)
+		if err := m.resourceValidator.ReserveAllocation(ctx, id, vcpus, totalMemory, req.NetworkBandwidthDownload, req.NetworkBandwidthUpload, req.DiskIOBps, diskBytes, needsGPU); err != nil {
+			log.ErrorContext(ctx, "resource reservation failed", "error", err)
 			return nil, fmt.Errorf("%w: %v", ErrInsufficientResources, err)
 		}
+		reservedResources = true
+		defer func() {
+			if reservedResources {
+				m.resourceValidator.FinishAllocation(id)
+			}
+		}()
 	}
 
 	if req.Env == nil {
@@ -492,6 +501,10 @@ func (m *manager) createInstance(
 		return nil, err
 	}
 	startVMSpanEnd(nil)
+	if reservedResources {
+		m.resourceValidator.FinishAllocation(id)
+		reservedResources = false
+	}
 
 	// 20. Persist runtime metadata updates after VM boot.
 	meta = &metadata{StoredMetadata: *stored}

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -164,22 +164,14 @@ func (m *manager) createInstance(
 	if overlaySize == 0 {
 		overlaySize = 10 * 1024 * 1024 * 1024 // 10GB default
 	}
-	// Validate overlay size against max
-	if overlaySize > m.limits.MaxOverlaySize {
-		return nil, fmt.Errorf("overlay size %d exceeds maximum allowed size %d", overlaySize, m.limits.MaxOverlaySize)
-	}
 	vcpus := req.Vcpus
 	if vcpus == 0 {
 		vcpus = 2
 	}
 
-	// Validate per-instance resource limits
-	if m.limits.MaxVcpusPerInstance > 0 && vcpus > m.limits.MaxVcpusPerInstance {
-		return nil, fmt.Errorf("vcpus %d exceeds maximum allowed %d per instance", vcpus, m.limits.MaxVcpusPerInstance)
-	}
 	totalMemory := size + hotplugSize
-	if m.limits.MaxMemoryPerInstance > 0 && totalMemory > m.limits.MaxMemoryPerInstance {
-		return nil, fmt.Errorf("total memory %d (size + hotplug_size) exceeds maximum allowed %d per instance", totalMemory, m.limits.MaxMemoryPerInstance)
+	if err := validateResourceLimitsForName(req.Name, m.limits, overlaySize, vcpus, totalMemory); err != nil {
+		return nil, err
 	}
 
 	diskBytes := requestedDiskReservationBytes(overlaySize, req.Volumes)

--- a/lib/instances/fork.go
+++ b/lib/instances/fork.go
@@ -297,6 +297,9 @@ func (m *manager) forkInstanceFromStoppedOrStandby(ctx context.Context, id strin
 		forkMeta.IP = ""
 		forkMeta.MAC = ""
 	}
+	if err := validateResourceLimitsForName(req.Name, m.limits, forkMeta.OverlaySize, forkMeta.Vcpus, forkMeta.Size+forkMeta.HotplugSize); err != nil {
+		return nil, err
+	}
 
 	if source.State == StateStandby {
 		snapshotConfigPath := m.paths.InstanceSnapshotConfig(forkID)

--- a/lib/instances/manager.go
+++ b/lib/instances/manager.go
@@ -74,9 +74,10 @@ type ImageUsageRecorderSetter interface {
 
 // ResourceLimits contains configurable resource limits for instances
 type ResourceLimits struct {
-	MaxOverlaySize       int64 // Maximum overlay disk size in bytes per instance
+	MaxOverlaySize       int64 // Maximum overlay disk size in bytes per instance (0 = unlimited)
 	MaxVcpusPerInstance  int   // Maximum vCPUs per instance (0 = unlimited)
 	MaxMemoryPerInstance int64 // Maximum memory in bytes per instance (0 = unlimited)
+	NamePatterns         []NamedResourceLimit
 }
 
 // ResourceValidator validates if resources can be allocated

--- a/lib/instances/manager.go
+++ b/lib/instances/manager.go
@@ -84,7 +84,12 @@ type ResourceValidator interface {
 	// ValidateAllocation checks if the requested resources are available.
 	// Returns nil if allocation is allowed, or a detailed error describing
 	// which resource is insufficient and the current capacity/usage.
-	ValidateAllocation(ctx context.Context, vcpus int, memoryBytes int64, networkDownloadBps int64, networkUploadBps int64, diskIOBps int64, needsGPU bool) error
+	ValidateAllocation(ctx context.Context, vcpus int, memoryBytes int64, networkDownloadBps int64, networkUploadBps int64, diskIOBps int64, diskBytes int64, needsGPU bool) error
+	// ReserveAllocation tentatively reserves resources for an in-flight operation.
+	// Call FinishAllocation once the operation fails or becomes visible to resource accounting.
+	ReserveAllocation(ctx context.Context, instanceID string, vcpus int, memoryBytes int64, networkDownloadBps int64, networkUploadBps int64, diskIOBps int64, diskBytes int64, needsGPU bool) error
+	// FinishAllocation removes any pending reservation for the given instance ID.
+	FinishAllocation(instanceID string)
 }
 
 type manager struct {

--- a/lib/instances/name_limits.go
+++ b/lib/instances/name_limits.go
@@ -1,0 +1,77 @@
+package instances
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// NamedResourceLimit applies per-instance limits to names matching Pattern.
+// The first matching pattern wins, and omitted fields fall back to global limits.
+type NamedResourceLimit struct {
+	Pattern              string
+	re                   *regexp.Regexp
+	MaxVcpusPerInstance  *int
+	MaxMemoryPerInstance *int64
+	MaxOverlaySize       *int64
+}
+
+func NewNamedResourceLimit(pattern string, maxVcpus *int, maxMemory *int64, maxOverlay *int64) (NamedResourceLimit, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return NamedResourceLimit{}, fmt.Errorf("compile name limit regex %q: %w", pattern, err)
+	}
+
+	return NamedResourceLimit{
+		Pattern:              pattern,
+		re:                   re,
+		MaxVcpusPerInstance:  maxVcpus,
+		MaxMemoryPerInstance: maxMemory,
+		MaxOverlaySize:       maxOverlay,
+	}, nil
+}
+
+func (l NamedResourceLimit) matches(name string) bool {
+	return l.re != nil && l.re.MatchString(name)
+}
+
+func (l ResourceLimits) ForName(name string) ResourceLimits {
+	resolved := ResourceLimits{
+		MaxOverlaySize:       l.MaxOverlaySize,
+		MaxVcpusPerInstance:  l.MaxVcpusPerInstance,
+		MaxMemoryPerInstance: l.MaxMemoryPerInstance,
+	}
+
+	for _, pattern := range l.NamePatterns {
+		if !pattern.matches(name) {
+			continue
+		}
+		if pattern.MaxOverlaySize != nil {
+			resolved.MaxOverlaySize = *pattern.MaxOverlaySize
+		}
+		if pattern.MaxVcpusPerInstance != nil {
+			resolved.MaxVcpusPerInstance = *pattern.MaxVcpusPerInstance
+		}
+		if pattern.MaxMemoryPerInstance != nil {
+			resolved.MaxMemoryPerInstance = *pattern.MaxMemoryPerInstance
+		}
+		break
+	}
+
+	return resolved
+}
+
+func validateResourceLimitsForName(name string, limits ResourceLimits, overlaySize int64, vcpus int, totalMemory int64) error {
+	effective := limits.ForName(name)
+
+	if effective.MaxOverlaySize > 0 && overlaySize > effective.MaxOverlaySize {
+		return fmt.Errorf("overlay size %d exceeds maximum allowed size %d", overlaySize, effective.MaxOverlaySize)
+	}
+	if effective.MaxVcpusPerInstance > 0 && vcpus > effective.MaxVcpusPerInstance {
+		return fmt.Errorf("vcpus %d exceeds maximum allowed %d per instance", vcpus, effective.MaxVcpusPerInstance)
+	}
+	if effective.MaxMemoryPerInstance > 0 && totalMemory > effective.MaxMemoryPerInstance {
+		return fmt.Errorf("total memory %d (size + hotplug_size) exceeds maximum allowed %d per instance", totalMemory, effective.MaxMemoryPerInstance)
+	}
+
+	return nil
+}

--- a/lib/instances/name_limits_test.go
+++ b/lib/instances/name_limits_test.go
@@ -1,0 +1,93 @@
+package instances
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceLimitsForName_FirstMatchWins(t *testing.T) {
+	t.Parallel()
+
+	eight := 8
+	four := 4
+	sixtyFourGiB := int64(64 * 1024 * 1024 * 1024)
+	thirtyTwoGiB := int64(32 * 1024 * 1024 * 1024)
+	twentyGiB := int64(20 * 1024 * 1024 * 1024)
+
+	first, err := NewNamedResourceLimit("^prod-.*", &eight, &sixtyFourGiB, nil)
+	require.NoError(t, err)
+	second, err := NewNamedResourceLimit("^prod-api-.*", &four, &thirtyTwoGiB, &twentyGiB)
+	require.NoError(t, err)
+
+	limits := ResourceLimits{
+		MaxOverlaySize:       10 * 1024 * 1024 * 1024,
+		MaxVcpusPerInstance:  2,
+		MaxMemoryPerInstance: 8 * 1024 * 1024 * 1024,
+		NamePatterns:         []NamedResourceLimit{first, second},
+	}
+
+	resolved := limits.ForName("prod-api-1")
+	assert.Equal(t, 8, resolved.MaxVcpusPerInstance)
+	assert.Equal(t, sixtyFourGiB, resolved.MaxMemoryPerInstance)
+	assert.Equal(t, int64(10*1024*1024*1024), resolved.MaxOverlaySize)
+}
+
+func TestResourceLimitsForName_FallsBackWhenFieldOmitted(t *testing.T) {
+	t.Parallel()
+
+	twentyGiB := int64(20 * 1024 * 1024 * 1024)
+	override, err := NewNamedResourceLimit("^small-.*", nil, nil, &twentyGiB)
+	require.NoError(t, err)
+
+	limits := ResourceLimits{
+		MaxOverlaySize:       100 * 1024 * 1024 * 1024,
+		MaxVcpusPerInstance:  16,
+		MaxMemoryPerInstance: 32 * 1024 * 1024 * 1024,
+		NamePatterns:         []NamedResourceLimit{override},
+	}
+
+	resolved := limits.ForName("small-worker")
+	assert.Equal(t, int64(20*1024*1024*1024), resolved.MaxOverlaySize)
+	assert.Equal(t, 16, resolved.MaxVcpusPerInstance)
+	assert.Equal(t, int64(32*1024*1024*1024), resolved.MaxMemoryPerInstance)
+}
+
+func TestValidateResourceLimitsForName_ZeroOverrideMeansUnlimited(t *testing.T) {
+	t.Parallel()
+
+	zeroInt := 0
+	zeroBytes := int64(0)
+	override, err := NewNamedResourceLimit("^burst-.*", &zeroInt, &zeroBytes, &zeroBytes)
+	require.NoError(t, err)
+
+	limits := ResourceLimits{
+		MaxOverlaySize:       5 * 1024 * 1024 * 1024,
+		MaxVcpusPerInstance:  2,
+		MaxMemoryPerInstance: 4 * 1024 * 1024 * 1024,
+		NamePatterns:         []NamedResourceLimit{override},
+	}
+
+	err = validateResourceLimitsForName("burst-worker", limits, 50*1024*1024*1024, 32, 128*1024*1024*1024)
+	require.NoError(t, err)
+}
+
+func TestValidateResourceLimitsForName_RejectsWhenResolvedLimitExceeded(t *testing.T) {
+	t.Parallel()
+
+	four := 4
+	override, err := NewNamedResourceLimit("^db-.*", &four, nil, nil)
+	require.NoError(t, err)
+
+	limits := ResourceLimits{
+		MaxOverlaySize:       100 * 1024 * 1024 * 1024,
+		MaxVcpusPerInstance:  16,
+		MaxMemoryPerInstance: 64 * 1024 * 1024 * 1024,
+		NamePatterns:         []NamedResourceLimit{override},
+	}
+
+	err = validateResourceLimitsForName("db-primary", limits, 10*1024*1024*1024, 8, 16*1024*1024*1024)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vcpus 8 exceeds maximum allowed 4 per instance")
+}

--- a/lib/instances/restore.go
+++ b/lib/instances/restore.go
@@ -59,13 +59,21 @@ func (m *manager) restoreInstance(
 	}
 
 	// 2b. Validate aggregate resource limits before allocating resources (if configured)
+	reservedResources := false
 	if m.resourceValidator != nil {
 		needsGPU := stored.GPUProfile != ""
 		totalMemory := stored.Size + stored.HotplugSize
-		if err := m.resourceValidator.ValidateAllocation(ctx, stored.Vcpus, totalMemory, stored.NetworkBandwidthDownload, stored.NetworkBandwidthUpload, stored.DiskIOBps, needsGPU); err != nil {
-			log.ErrorContext(ctx, "resource validation failed for restore", "instance_id", id, "error", err)
+		diskBytes := storedDiskReservationBytes(stored)
+		if err := m.resourceValidator.ReserveAllocation(ctx, id, stored.Vcpus, totalMemory, stored.NetworkBandwidthDownload, stored.NetworkBandwidthUpload, stored.DiskIOBps, diskBytes, needsGPU); err != nil {
+			log.ErrorContext(ctx, "resource reservation failed for restore", "instance_id", id, "error", err)
 			return nil, fmt.Errorf("%w: %v", ErrInsufficientResources, err)
 		}
+		reservedResources = true
+		defer func() {
+			if reservedResources {
+				m.resourceValidator.FinishAllocation(id)
+			}
+		}()
 	}
 
 	// 3. Get snapshot directory
@@ -253,6 +261,10 @@ func (m *manager) restoreInstance(
 		return nil, fmt.Errorf("resume vm failed: %w", err)
 	}
 	resumeSpanEnd(nil)
+	if reservedResources {
+		m.resourceValidator.FinishAllocation(id)
+		reservedResources = false
+	}
 
 	// Forked standby restores may allocate a fresh identity while the guest memory snapshot
 	// still has the source VM's old IP configuration. Reconfigure guest networking after

--- a/lib/instances/snapshot.go
+++ b/lib/instances/snapshot.go
@@ -450,6 +450,9 @@ func (m *manager) forkSnapshot(ctx context.Context, snapshotID string, req ForkS
 		forkMeta.IP = ""
 		forkMeta.MAC = ""
 	}
+	if err := validateResourceLimitsForName(req.Name, m.limits, forkMeta.OverlaySize, forkMeta.Vcpus, forkMeta.Size+forkMeta.HotplugSize); err != nil {
+		return nil, err
+	}
 
 	if rec.Snapshot.Kind == SnapshotKindStandby {
 		netCfg := (*hypervisor.ForkNetworkConfig)(nil)

--- a/lib/instances/start.go
+++ b/lib/instances/start.go
@@ -61,13 +61,21 @@ func (m *manager) startInstance(
 	}
 
 	// 2b. Validate aggregate resource limits before allocating resources (if configured)
+	reservedResources := false
 	if m.resourceValidator != nil {
 		needsGPU := stored.GPUProfile != ""
 		totalMemory := stored.Size + stored.HotplugSize
-		if err := m.resourceValidator.ValidateAllocation(ctx, stored.Vcpus, totalMemory, stored.NetworkBandwidthDownload, stored.NetworkBandwidthUpload, stored.DiskIOBps, needsGPU); err != nil {
-			log.ErrorContext(ctx, "resource validation failed for start", "instance_id", id, "error", err)
+		diskBytes := storedDiskReservationBytes(stored)
+		if err := m.resourceValidator.ReserveAllocation(ctx, id, stored.Vcpus, totalMemory, stored.NetworkBandwidthDownload, stored.NetworkBandwidthUpload, stored.DiskIOBps, diskBytes, needsGPU); err != nil {
+			log.ErrorContext(ctx, "resource reservation failed for start", "instance_id", id, "error", err)
 			return nil, fmt.Errorf("%w: %v", ErrInsufficientResources, err)
 		}
+		reservedResources = true
+		defer func() {
+			if reservedResources {
+				m.resourceValidator.FinishAllocation(id)
+			}
+		}()
 	}
 
 	// 3. Get image info (needed for buildHypervisorConfig)
@@ -188,6 +196,10 @@ func (m *manager) startInstance(
 		return nil, err
 	}
 	startVMSpanEnd(nil)
+	if reservedResources {
+		m.resourceValidator.FinishAllocation(id)
+		reservedResources = false
+	}
 
 	// Success - release cleanup stack (prevent cleanup)
 	cu.Release()

--- a/lib/providers/instance_limits.go
+++ b/lib/providers/instance_limits.go
@@ -1,0 +1,89 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/kernel/hypeman/cmd/api/config"
+	"github.com/kernel/hypeman/lib/instances"
+)
+
+func parseInstanceLimits(cfg *config.Config) (instances.ResourceLimits, error) {
+	maxOverlaySize, err := parseByteSizeLimit("limits.max_overlay_size", cfg.Limits.MaxOverlaySize)
+	if err != nil {
+		return instances.ResourceLimits{}, err
+	}
+
+	maxMemoryPerInstance, err := parseOptionalByteSizeLimit("limits.max_memory_per_instance", cfg.Limits.MaxMemoryPerInstance)
+	if err != nil {
+		return instances.ResourceLimits{}, err
+	}
+
+	namePatterns := make([]instances.NamedResourceLimit, 0, len(cfg.Limits.NamePatterns))
+	for i, patternCfg := range cfg.Limits.NamePatterns {
+		var maxVcpus *int
+		if patternCfg.MaxVcpusPerInstance != nil {
+			value := *patternCfg.MaxVcpusPerInstance
+			maxVcpus = &value
+		}
+
+		maxMemory, err := parseOptionalByteSizePtr(fmt.Sprintf("limits.name_patterns[%d].max_memory_per_instance", i), patternCfg.MaxMemoryPerInstance)
+		if err != nil {
+			return instances.ResourceLimits{}, err
+		}
+		maxOverlay, err := parseOptionalByteSizePtr(fmt.Sprintf("limits.name_patterns[%d].max_overlay_size", i), patternCfg.MaxOverlaySize)
+		if err != nil {
+			return instances.ResourceLimits{}, err
+		}
+
+		pattern, err := instances.NewNamedResourceLimit(patternCfg.Pattern, maxVcpus, maxMemory, maxOverlay)
+		if err != nil {
+			return instances.ResourceLimits{}, fmt.Errorf("parse limits.name_patterns[%d]: %w", i, err)
+		}
+		namePatterns = append(namePatterns, pattern)
+	}
+
+	return instances.ResourceLimits{
+		MaxOverlaySize:       maxOverlaySize,
+		MaxVcpusPerInstance:  cfg.Limits.MaxVcpusPerInstance,
+		MaxMemoryPerInstance: maxMemoryPerInstance,
+		NamePatterns:         namePatterns,
+	}, nil
+}
+
+func parseOptionalByteSizePtr(field string, value *string) (*int64, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	parsed, err := parseOptionalByteSizeLimit(field, *value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parsed, nil
+}
+
+func parseOptionalByteSizeLimit(field string, value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+
+	return parseByteSizeLimit(field, value)
+}
+
+func parseByteSizeLimit(field string, value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, fmt.Errorf("%s must not be empty", field)
+	}
+
+	var size datasize.ByteSize
+	if err := size.UnmarshalText([]byte(value)); err != nil {
+		return 0, fmt.Errorf("%s must be a valid byte size, got %q: %w", field, value, err)
+	}
+
+	return int64(size), nil
+}

--- a/lib/providers/providers.go
+++ b/lib/providers/providers.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/c2h5oh/datasize"
 	"github.com/kernel/hypeman/cmd/api/config"
 	"github.com/kernel/hypeman/lib/builds"
 	"github.com/kernel/hypeman/lib/devices"
@@ -100,30 +99,13 @@ func ProvideDeviceManager(p *paths.Paths) devices.Manager {
 func ProvideInstanceManager(p *paths.Paths, cfg *config.Config, imageManager images.Manager, systemManager system.Manager, networkManager network.Manager, deviceManager devices.Manager, volumeManager volumes.Manager) (instances.Manager, error) {
 	firecracker.SetCustomBinaryPath(cfg.Hypervisor.FirecrackerBinaryPath)
 
-	// Parse max overlay size from config
-	var maxOverlaySize datasize.ByteSize
-	if err := maxOverlaySize.UnmarshalText([]byte(cfg.Limits.MaxOverlaySize)); err != nil {
-		return nil, fmt.Errorf("failed to parse MAX_OVERLAY_SIZE '%s': %w (expected format like '100GB', '50G', '10GiB')", cfg.Limits.MaxOverlaySize, err)
-	}
-
-	// Parse max memory per instance (empty or "0" means unlimited)
-	var maxMemoryPerInstance int64
-	if cfg.Limits.MaxMemoryPerInstance != "" && cfg.Limits.MaxMemoryPerInstance != "0" {
-		var memSize datasize.ByteSize
-		if err := memSize.UnmarshalText([]byte(cfg.Limits.MaxMemoryPerInstance)); err != nil {
-			return nil, fmt.Errorf("failed to parse MAX_MEMORY_PER_INSTANCE '%s': %w", cfg.Limits.MaxMemoryPerInstance, err)
-		}
-		maxMemoryPerInstance = int64(memSize)
+	limits, err := parseInstanceLimits(cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	// Note: Aggregate CPU/memory limits are now handled via oversubscription ratios
 	// in the ResourceManager, wired up via SetResourceValidator after initialization.
-	limits := instances.ResourceLimits{
-		MaxOverlaySize:       int64(maxOverlaySize),
-		MaxVcpusPerInstance:  cfg.Limits.MaxVcpusPerInstance,
-		MaxMemoryPerInstance: maxMemoryPerInstance,
-	}
-
 	meter := otel.GetMeterProvider().Meter("hypeman")
 	tracer := otel.GetTracerProvider().Tracer("hypeman/instances")
 	defaultHypervisor := hypervisor.Type(cfg.Hypervisor.Default)

--- a/lib/resources/resource.go
+++ b/lib/resources/resource.go
@@ -155,6 +155,15 @@ type InstanceUtilizationInfo struct {
 	AllocatedMemoryBytes int64 // Allocated memory in bytes (Size + HotplugSize)
 }
 
+type pendingAllocation struct {
+	CPU         int64
+	MemoryBytes int64
+	DiskBytes   int64
+	NetworkBps  int64
+	DiskIOBps   int64
+	GPUSlots    int
+}
+
 // Manager coordinates resource discovery and allocation tracking.
 type Manager struct {
 	cfg   *config.Config
@@ -168,6 +177,9 @@ type Manager struct {
 	instanceLister InstanceLister
 	imageLister    ImageLister
 	volumeLister   VolumeLister
+
+	// Pending allocations are used only for admission decisions.
+	pending map[string]pendingAllocation
 }
 
 // NewManager creates a new resource manager.
@@ -177,6 +189,7 @@ func NewManager(cfg *config.Config, p *paths.Paths) *Manager {
 		paths:      p,
 		resources:  make(map[ResourceType]Resource),
 		monitoring: &monitoringState{},
+		pending:    make(map[string]pendingAllocation),
 	}
 }
 
@@ -400,86 +413,226 @@ func (m *Manager) GetFullStatus(ctx context.Context) (*FullResourceStatus, error
 
 // CanAllocate checks if the requested amount can be allocated for a resource type.
 func (m *Manager) CanAllocate(ctx context.Context, rt ResourceType, amount int64) (bool, error) {
-	status, err := m.GetStatus(ctx, rt)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	status, err := m.getAdmissionStatusLocked(ctx, rt, "")
 	if err != nil {
 		return false, err
 	}
 	return amount <= status.Available, nil
 }
 
-// ValidateAllocation checks if the requested resources can be allocated.
-// Returns nil if allocation is allowed, or a detailed error describing
-// which resource is insufficient and the current capacity/usage.
-// Parameters match instances.AllocationRequest to implement instances.ResourceValidator.
-func (m *Manager) ValidateAllocation(ctx context.Context, vcpus int, memoryBytes int64, networkDownloadBps int64, networkUploadBps int64, diskIOBps int64, needsGPU bool) error {
+func normalizeNetworkBandwidth(downloadBps, uploadBps int64) int64 {
+	netBandwidth := downloadBps
+	if uploadBps > netBandwidth {
+		netBandwidth = uploadBps
+	}
+	return netBandwidth
+}
+
+func newPendingAllocation(vcpus int, memoryBytes int64, networkDownloadBps int64, networkUploadBps int64, diskIOBps int64, diskBytes int64, needsGPU bool) pendingAllocation {
+	req := pendingAllocation{
+		CPU:         int64(vcpus),
+		MemoryBytes: memoryBytes,
+		DiskBytes:   diskBytes,
+		NetworkBps:  normalizeNetworkBandwidth(networkDownloadBps, networkUploadBps),
+		DiskIOBps:   diskIOBps,
+	}
+	if needsGPU {
+		req.GPUSlots = 1
+	}
+	return req
+}
+
+func (m *Manager) pendingAmountLocked(rt ResourceType, excludeID string) int64 {
+	var total int64
+	for id, pending := range m.pending {
+		if id == excludeID {
+			continue
+		}
+		switch rt {
+		case ResourceCPU:
+			total += pending.CPU
+		case ResourceMemory:
+			total += pending.MemoryBytes
+		case ResourceDisk:
+			total += pending.DiskBytes
+		case ResourceNetwork:
+			total += pending.NetworkBps
+		case ResourceDiskIO:
+			total += pending.DiskIOBps
+		}
+	}
+	return total
+}
+
+func (m *Manager) pendingGPUSlotsLocked(excludeID string) int {
+	var total int
+	for id, pending := range m.pending {
+		if id == excludeID {
+			continue
+		}
+		total += pending.GPUSlots
+	}
+	return total
+}
+
+func (m *Manager) getAdmissionStatusLocked(ctx context.Context, rt ResourceType, excludeID string) (*ResourceStatus, error) {
+	res, ok := m.resources[rt]
+	if !ok {
+		return nil, fmt.Errorf("unknown resource type: %s", rt)
+	}
+
+	capacity := res.Capacity()
+	ratio := m.GetOversubRatio(rt)
+	effectiveLimit := int64(float64(capacity) * ratio)
+
+	allocated, err := res.Allocated(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get allocated %s: %w", rt, err)
+	}
+	allocated += m.pendingAmountLocked(rt, excludeID)
+
+	available := effectiveLimit - allocated
+	if available < 0 {
+		available = 0
+	}
+
+	status := &ResourceStatus{
+		Type:           rt,
+		Capacity:       capacity,
+		EffectiveLimit: effectiveLimit,
+		Allocated:      allocated,
+		Available:      available,
+		OversubRatio:   ratio,
+	}
+	if rt == ResourceNetwork {
+		if m.cfg.Capacity.Network != "" {
+			status.Source = SourceConfigured
+		} else {
+			status.Source = SourceDetected
+		}
+	}
+	return status, nil
+}
+
+func (m *Manager) validateAllocationLocked(ctx context.Context, excludeID string, req pendingAllocation) error {
 	// Check CPU
-	if vcpus > 0 {
-		status, err := m.GetStatus(ctx, ResourceCPU)
+	if req.CPU > 0 {
+		status, err := m.getAdmissionStatusLocked(ctx, ResourceCPU, excludeID)
 		if err != nil {
 			return fmt.Errorf("check CPU capacity: %w", err)
 		}
-		if int64(vcpus) > status.Available {
+		if req.CPU > status.Available {
 			return fmt.Errorf("insufficient CPU: requested %d vCPUs, but only %d available (currently allocated: %d, effective limit: %d with %.1fx oversubscription)",
-				vcpus, status.Available, status.Allocated, status.EffectiveLimit, status.OversubRatio)
+				req.CPU, status.Available, status.Allocated, status.EffectiveLimit, status.OversubRatio)
 		}
 	}
 
 	// Check Memory
-	if memoryBytes > 0 {
-		status, err := m.GetStatus(ctx, ResourceMemory)
+	if req.MemoryBytes > 0 {
+		status, err := m.getAdmissionStatusLocked(ctx, ResourceMemory, excludeID)
 		if err != nil {
 			return fmt.Errorf("check memory capacity: %w", err)
 		}
-		if memoryBytes > status.Available {
+		if req.MemoryBytes > status.Available {
 			return fmt.Errorf("insufficient memory: requested %s, but only %s available (currently allocated: %s, effective limit: %s with %.1fx oversubscription)",
-				datasize.ByteSize(memoryBytes).HR(), datasize.ByteSize(status.Available).HR(), datasize.ByteSize(status.Allocated).HR(), datasize.ByteSize(status.EffectiveLimit).HR(), status.OversubRatio)
+				datasize.ByteSize(req.MemoryBytes).HR(), datasize.ByteSize(status.Available).HR(), datasize.ByteSize(status.Allocated).HR(), datasize.ByteSize(status.EffectiveLimit).HR(), status.OversubRatio)
+		}
+	}
+
+	// Check Disk
+	if req.DiskBytes > 0 {
+		status, err := m.getAdmissionStatusLocked(ctx, ResourceDisk, excludeID)
+		if err != nil {
+			return fmt.Errorf("check disk capacity: %w", err)
+		}
+		if req.DiskBytes > status.Available {
+			return fmt.Errorf("insufficient disk: requested %s, but only %s available (currently allocated: %s, effective limit: %s with %.1fx oversubscription)",
+				datasize.ByteSize(req.DiskBytes).HR(), datasize.ByteSize(status.Available).HR(), datasize.ByteSize(status.Allocated).HR(), datasize.ByteSize(status.EffectiveLimit).HR(), status.OversubRatio)
 		}
 	}
 
 	// Check Network (use max of download/upload since they share physical link)
-	netBandwidth := networkDownloadBps
-	if networkUploadBps > netBandwidth {
-		netBandwidth = networkUploadBps
-	}
-	if netBandwidth > 0 {
-		status, err := m.GetStatus(ctx, ResourceNetwork)
+	if req.NetworkBps > 0 {
+		status, err := m.getAdmissionStatusLocked(ctx, ResourceNetwork, excludeID)
 		if err != nil {
 			return fmt.Errorf("check network capacity: %w", err)
 		}
-		if netBandwidth > status.Available {
+		if req.NetworkBps > status.Available {
 			return fmt.Errorf("insufficient network bandwidth: requested %s/s, but only %s/s available (currently allocated: %s/s, effective limit: %s/s with %.1fx oversubscription)",
-				datasize.ByteSize(netBandwidth).HR(), datasize.ByteSize(status.Available).HR(), datasize.ByteSize(status.Allocated).HR(), datasize.ByteSize(status.EffectiveLimit).HR(), status.OversubRatio)
+				datasize.ByteSize(req.NetworkBps).HR(), datasize.ByteSize(status.Available).HR(), datasize.ByteSize(status.Allocated).HR(), datasize.ByteSize(status.EffectiveLimit).HR(), status.OversubRatio)
 		}
 	}
 
 	// Check Disk I/O
-	if diskIOBps > 0 {
-		status, err := m.GetStatus(ctx, ResourceDiskIO)
+	if req.DiskIOBps > 0 {
+		status, err := m.getAdmissionStatusLocked(ctx, ResourceDiskIO, excludeID)
 		if err != nil {
 			return fmt.Errorf("check disk I/O capacity: %w", err)
 		}
-		if diskIOBps > status.Available {
+		if req.DiskIOBps > status.Available {
 			return fmt.Errorf("insufficient disk I/O: requested %s/s, but only %s/s available (currently allocated: %s/s, effective limit: %s/s with %.1fx oversubscription)",
-				datasize.ByteSize(diskIOBps).HR(), datasize.ByteSize(status.Available).HR(),
+				datasize.ByteSize(req.DiskIOBps).HR(), datasize.ByteSize(status.Available).HR(),
 				datasize.ByteSize(status.Allocated).HR(), datasize.ByteSize(status.EffectiveLimit).HR(),
 				status.OversubRatio)
 		}
 	}
 
 	// Check GPU if needed
-	if needsGPU {
-		gpuStatus := GetGPUStatus()
+	if req.GPUSlots > 0 {
+		gpuStatus := currentGPUStatusProvider()()
 		if gpuStatus == nil {
 			return fmt.Errorf("insufficient GPU: no GPU available on this host")
 		}
-		availableSlots := gpuStatus.TotalSlots - gpuStatus.UsedSlots
-		if availableSlots <= 0 {
-			return fmt.Errorf("insufficient GPU: all %d %s slots are in use",
-				gpuStatus.TotalSlots, gpuStatus.Mode)
+		availableSlots := gpuStatus.TotalSlots - gpuStatus.UsedSlots - m.pendingGPUSlotsLocked(excludeID)
+		if availableSlots < req.GPUSlots {
+			if availableSlots <= 0 {
+				return fmt.Errorf("insufficient GPU: all %d %s slots are in use",
+					gpuStatus.TotalSlots, gpuStatus.Mode)
+			}
+			return fmt.Errorf("insufficient GPU: requested %d %s slot(s), but only %d available",
+				req.GPUSlots, gpuStatus.Mode, availableSlots)
 		}
 	}
 
 	return nil
+}
+
+// ValidateAllocation checks if the requested resources can be allocated.
+// Returns nil if allocation is allowed, or a detailed error describing
+// which resource is insufficient and the current capacity/usage.
+func (m *Manager) ValidateAllocation(ctx context.Context, vcpus int, memoryBytes int64, networkDownloadBps int64, networkUploadBps int64, diskIOBps int64, diskBytes int64, needsGPU bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	req := newPendingAllocation(vcpus, memoryBytes, networkDownloadBps, networkUploadBps, diskIOBps, diskBytes, needsGPU)
+	return m.validateAllocationLocked(ctx, "", req)
+}
+
+// ReserveAllocation tentatively reserves resources for an in-flight operation.
+func (m *Manager) ReserveAllocation(ctx context.Context, instanceID string, vcpus int, memoryBytes int64, networkDownloadBps int64, networkUploadBps int64, diskIOBps int64, diskBytes int64, needsGPU bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	req := newPendingAllocation(vcpus, memoryBytes, networkDownloadBps, networkUploadBps, diskIOBps, diskBytes, needsGPU)
+	if err := m.validateAllocationLocked(ctx, instanceID, req); err != nil {
+		return err
+	}
+	m.pending[instanceID] = req
+	return nil
+}
+
+// FinishAllocation removes any pending reservation for the given instance ID.
+func (m *Manager) FinishAllocation(instanceID string) {
+	if instanceID == "" {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.pending, instanceID)
 }
 
 // CPUCapacity returns the raw CPU capacity (number of vCPUs).

--- a/lib/resources/resource_test.go
+++ b/lib/resources/resource_test.go
@@ -457,3 +457,78 @@ func TestDiskBreakdown_IncludesOCICacheAndVolumeOverlays(t *testing.T) {
 	// Overlays should be (10+5) + (8+2) = 25GB
 	assert.Equal(t, int64(25*1024*1024*1024), status.DiskDetail.Overlays)
 }
+
+func TestValidateAllocation_Disk(t *testing.T) {
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		Capacity: config.CapacityConfig{
+			Disk: "100GB",
+		},
+		Oversubscription: config.OversubscriptionConfig{
+			CPU: 1.0, Memory: 1.0, Disk: 1.0, Network: 1.0, DiskIO: 1.0,
+		},
+	}
+	p := paths.New(cfg.DataDir)
+
+	mgr := NewManager(cfg, p)
+	mgr.SetInstanceLister(&mockInstanceLister{
+		allocations: []InstanceAllocation{
+			{
+				ID:                 "vm-1",
+				OverlayBytes:       20 * 1024 * 1024 * 1024,
+				VolumeOverlayBytes: 5 * 1024 * 1024 * 1024,
+				State:              "Running",
+			},
+		},
+	})
+	mgr.SetImageLister(&mockImageLister{totalBytes: 10 * 1024 * 1024 * 1024})
+	mgr.SetVolumeLister(&mockVolumeLister{totalBytes: 35 * 1024 * 1024 * 1024})
+
+	err := mgr.Initialize(context.Background())
+	require.NoError(t, err)
+
+	err = mgr.ValidateAllocation(context.Background(), 0, 0, 0, 0, 0, 30*1024*1024*1024, false)
+	require.NoError(t, err)
+
+	err = mgr.ValidateAllocation(context.Background(), 0, 0, 0, 0, 0, 31*1024*1024*1024, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient disk")
+}
+
+func TestReserveAllocation_TracksPendingCapacity(t *testing.T) {
+	cfg := &config.Config{
+		DataDir: t.TempDir(),
+		Capacity: config.CapacityConfig{
+			Disk: "100GB",
+		},
+		Oversubscription: config.OversubscriptionConfig{
+			CPU: 1.0, Memory: 1.0, Disk: 1.0, Network: 1.0, DiskIO: 1.0,
+		},
+	}
+	p := paths.New(cfg.DataDir)
+
+	mgr := NewManager(cfg, p)
+	mgr.SetInstanceLister(&mockInstanceLister{})
+	mgr.SetImageLister(&mockImageLister{})
+	mgr.SetVolumeLister(&mockVolumeLister{})
+
+	err := mgr.Initialize(context.Background())
+	require.NoError(t, err)
+
+	err = mgr.ReserveAllocation(context.Background(), "pending-a", 0, 0, 0, 0, 0, 60*1024*1024*1024, false)
+	require.NoError(t, err)
+
+	err = mgr.ReserveAllocation(context.Background(), "pending-b", 0, 0, 0, 0, 0, 50*1024*1024*1024, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient disk")
+
+	visibleStatus, err := mgr.GetStatus(context.Background(), ResourceDisk)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), visibleStatus.Allocated)
+
+	mgr.FinishAllocation("pending-a")
+	mgr.FinishAllocation("pending-a")
+
+	err = mgr.ReserveAllocation(context.Background(), "pending-b", 0, 0, 0, 0, 0, 50*1024*1024*1024, false)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- add disk to aggregate resource admission checks
- reserve resources in memory during create/start/restore to prevent burst oversubscription
- add focused resource-manager coverage for disk and pending reservations

## Testing
- go test ./lib/resources

## Notes
- full lib/instances tests are blocked in this checkout by missing embedded binaries: guest_agent/guest-agent and vz-shim/vz-shim