### PR TITLE
fix: Linux CI test env propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,13 +271,13 @@ test-linux: ensure-ch-binaries ensure-firecracker-binaries ensure-caddy-binaries
 	if [ -n "$(VERBOSE)" ]; then VERBOSE_FLAG="-v"; fi; \
 	if [ -n "$(TEST)" ]; then \
 		echo "Running specific test: $(TEST)"; \
-		sudo env "PATH=$$TEST_PATH" "DOCKER_CONFIG=$${DOCKER_CONFIG:-$$HOME/.docker}" \
+		sudo env "PATH=$$TEST_PATH" "DOCKER_CONFIG=$${DOCKER_CONFIG:-$$HOME/.docker}" "CI=$${CI:-}" \
 			"HYPEMAN_TEST_PREWARM_DIR=$${HYPEMAN_TEST_PREWARM_DIR:-}" \
 			"HYPEMAN_TEST_PREWARM_STRICT=$${HYPEMAN_TEST_PREWARM_STRICT:-}" \
 			"HYPEMAN_TEST_REGISTRY=$${HYPEMAN_TEST_REGISTRY:-}" \
 			go test -tags containers_image_openpgp -run=$(TEST) $$VERBOSE_FLAG -timeout=$(TEST_TIMEOUT) ./...; \
 	else \
-		sudo env "PATH=$$TEST_PATH" "DOCKER_CONFIG=$${DOCKER_CONFIG:-$$HOME/.docker}" \
+		sudo env "PATH=$$TEST_PATH" "DOCKER_CONFIG=$${DOCKER_CONFIG:-$$HOME/.docker}" "CI=$${CI:-}" \
 			"HYPEMAN_TEST_PREWARM_DIR=$${HYPEMAN_TEST_PREWARM_DIR:-}" \
 			"HYPEMAN_TEST_PREWARM_STRICT=$${HYPEMAN_TEST_PREWARM_STRICT:-}" \
 			"HYPEMAN_TEST_REGISTRY=$${HYPEMAN_TEST_REGISTRY:-}" \
@@ -309,7 +309,7 @@ test-guestmemory-linux: ensure-ch-binaries ensure-firecracker-binaries ensure-ca
 	echo "Running manual guest memory integration tests (CloudHypervisor, QEMU, Firecracker)"; \
 	for TEST_NAME in TestGuestMemoryPolicyCloudHypervisor TestGuestMemoryPolicyQEMU TestGuestMemoryPolicyFirecracker; do \
 		echo "Running $$TEST_NAME"; \
-		sudo env "PATH=$$TEST_PATH" "DOCKER_CONFIG=$${DOCKER_CONFIG:-$$HOME/.docker}" "HYPEMAN_RUN_GUESTMEMORY_TESTS=1" \
+		sudo env "PATH=$$TEST_PATH" "DOCKER_CONFIG=$${DOCKER_CONFIG:-$$HOME/.docker}" "CI=$${CI:-}" "HYPEMAN_RUN_GUESTMEMORY_TESTS=1" \
 			go test -count=1 -tags containers_image_openpgp -run="^$$TEST_NAME$$" -timeout="$$GUESTMEM_TIMEOUT" ./lib/instances || exit $$?; \
 	done
 


### PR DESCRIPTION
## Summary
- forward `CI` into the sudo-backed Linux `go test` invocations in `make test`
- do the same for the manual Linux guest-memory test entrypoint for consistency
- restore the repo's intended CI timeout behavior for Linux integration tests

## Root cause
Linux CI runs tests through `make test`, which uses `sudo env ... go test ...`.
That command forwarded `PATH`, `DOCKER_CONFIG`, and the prewarm vars, but not `CI`.
As a result, integration-test helpers like `integrationTestTimeout(...)` behaved as if they were running locally, so sub-45s waits stayed at 20s instead of widening on CI.

This surfaced in the latest `main` merge as a flaky failure in `TestStandbyAndRestore` during the initial create-to-running wait.

## Verification
- verified on `deft-kernel-dev` that the child sudo test process now receives `CI=true`
- ran `make test TEST=TestStandbyAndRestore TEST_TIMEOUT=90m` remotely with `CI=true`
- also ran targeted remote repro loops before the fix to confirm the failure was contention-sensitive rather than a deterministic restore bug

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Makefile-only change that only affects how test processes inherit environment variables under `sudo`. Main risk is unintended behavior differences in local Linux runs if `CI` is set in the caller environment.
> 
> **Overview**
> Fixes Linux test runs invoked via `sudo env ... go test` to **preserve the `CI` environment variable**, aligning integration-test behavior (e.g., CI-specific timeouts) with actual CI execution.
> 
> Applies the same `CI` forwarding to the `test-guestmemory-linux` manual integration test target for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3331b288d7bf44e66977d0f4e3b2e23447da86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->