### PR TITLE
Retry instance directory deletion on ENOTEMPTY

### DIFF
--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -1289,6 +1289,58 @@ func TestStorageOperations(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestRemoveAllWithRetryRetriesDirectoryNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	path := "/tmp/test-instance"
+	attempts := 0
+	var slept []time.Duration
+
+	err := removeAllWithRetry(path, func(got string) error {
+		attempts++
+		require.Equal(t, path, got)
+		if attempts <= 3 {
+			return &os.PathError{Op: "unlinkat", Path: got, Err: syscall.ENOTEMPTY}
+		}
+		return nil
+	}, func(d time.Duration) {
+		slept = append(slept, d)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, attempts)
+	assert.Equal(t, []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+	}, slept)
+}
+
+func TestRemoveAllWithRetryStopsAfterMaxRetries(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	var slept []time.Duration
+
+	err := removeAllWithRetry("/tmp/test-instance", func(string) error {
+		attempts++
+		return &os.PathError{Op: "unlinkat", Path: "/tmp/test-instance", Err: syscall.ENOTEMPTY}
+	}, func(d time.Duration) {
+		slept = append(slept, d)
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, syscall.ENOTEMPTY)
+	assert.Equal(t, deleteInstanceDataMaxRetries+1, attempts)
+	assert.Equal(t, []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		80 * time.Millisecond,
+		100 * time.Millisecond,
+	}, slept)
+}
+
 func TestStandbyAndRestore(t *testing.T) {
 	t.Parallel()
 	// Require KVM access (don't skip, fail informatively)

--- a/lib/instances/storage.go
+++ b/lib/instances/storage.go
@@ -2,12 +2,21 @@ package instances
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
+	"time"
 
 	"github.com/kernel/hypeman/lib/autostandby"
 	"github.com/kernel/hypeman/lib/images"
+)
+
+const (
+	deleteInstanceDataMaxRetries     = 5
+	deleteInstanceDataInitialBackoff = 10 * time.Millisecond
+	deleteInstanceDataMaxBackoff     = 100 * time.Millisecond
 )
 
 // Filesystem structure:
@@ -111,13 +120,33 @@ func (m *manager) createVolumeOverlayDisk(instanceID, volumeID string, sizeBytes
 func (m *manager) deleteInstanceData(id string) error {
 	instDir := m.paths.InstanceDir(id)
 
-	if err := os.RemoveAll(instDir); err != nil {
+	if err := removeAllWithRetry(instDir, os.RemoveAll, time.Sleep); err != nil {
 		return fmt.Errorf("remove instance directory: %w", err)
 	}
 
 	m.deleteAdmissionAllocation(id)
 
 	return nil
+}
+
+func removeAllWithRetry(path string, removeAll func(string) error, sleep func(time.Duration)) error {
+	backoff := deleteInstanceDataInitialBackoff
+
+	for attempt := 0; ; attempt++ {
+		err := removeAll(path)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, syscall.ENOTEMPTY) || attempt >= deleteInstanceDataMaxRetries {
+			return err
+		}
+
+		sleep(backoff)
+		backoff *= 2
+		if backoff > deleteInstanceDataMaxBackoff {
+			backoff = deleteInstanceDataMaxBackoff
+		}
+	}
 }
 
 // listMetadataFiles returns paths to all instance metadata files


### PR DESCRIPTION
## Summary
- retry instance directory deletion when `os.RemoveAll` loses a race with concurrent writers and returns `ENOTEMPTY`
- use exponential backoff starting at 10ms and capping at 100ms for up to 5 retries
- add unit coverage for retry success and retry exhaustion

## Testing
- `go test ./lib/instances -run 'TestRemoveAllWithRetry|TestMetadataPersistence'` *(fails in this checkout because embedded binaries `lib/system/guest_agent/guest-agent` and `lib/hypervisor/vz/vz-shim/vz-shim` are missing)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches instance deletion cleanup by adding retry/backoff around `os.RemoveAll`, which could impact teardown timing and error handling if the retry logic misbehaves. Change is localized and guarded to only retry `ENOTEMPTY` with a small capped backoff.
> 
> **Overview**
> Improves instance teardown robustness by retrying instance directory removal when `os.RemoveAll` fails with `ENOTEMPTY`, using an exponential backoff (10ms doubling, capped at 100ms) for up to 5 retries via `removeAllWithRetry`.
> 
> Adds unit tests covering both the successful retry path and the max-retry exhaustion behavior, including verification of the backoff schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a33f36ca8a3c8bd0703b4d008e2dbad4ec9c257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->