### PR TITLE
ci: use centralized vuln remediation workflow from infra

### DIFF
--- a/.github/vuln-remediation.json
+++ b/.github/vuln-remediation.json
@@ -1,0 +1,5 @@
+{
+  "non_production_paths": [],
+  "skip_packages": [],
+  "ecosystems": ["go"]
+}

--- a/.github/vuln-remediation.json
+++ b/.github/vuln-remediation.json
@@ -1,5 +1,0 @@
-{
-  "non_production_paths": [],
-  "skip_packages": [],
-  "ecosystems": ["go"]
-}

--- a/.github/workflows/vuln-remediation.yml
+++ b/.github/workflows/vuln-remediation.yml
@@ -1,0 +1,17 @@
+name: Vulnerability Remediation
+
+on:
+  schedule:
+    - cron: '0 3 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  remediate:
+    uses: kernel/infra/.github/workflows/vuln-remediation.yml@main
+    with:
+      go-version-file: 'go.mod'
+    secrets: inherit

--- a/.github/workflows/vuln-remediation.yml
+++ b/.github/workflows/vuln-remediation.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   remediate:
-    uses: kernel/infra/.github/workflows/vuln-remediation.yml@main
+    uses: kernel/security-workflows/.github/workflows/vuln-remediation.yml@main
     with:
       go-version-file: 'go.mod'
     secrets: inherit

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,1 @@
+version: 2


### PR DESCRIPTION
Replace per-repo workflow + prompt with a thin caller that invokes the reusable 3-stage pipeline (triage → fix → PR) in kernel/infra. Per-repo config in .github/vuln-remediation.json.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a scheduled/manual GitHub Actions workflow and a minimal `socket.yml` config file; no application/runtime code changes.
> 
> **Overview**
> Introduces a scheduled + manually-triggerable `Vulnerability Remediation` GitHub Actions workflow that delegates to the centralized reusable workflow in `kernel/security-workflows`, with permissions to open PRs and commit fixes.
> 
> Adds a minimal `socket.yml` (`version: 2`) to enable Socket configuration for dependency/vulnerability tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e069062ba1a7fbf655d30e22737efbeaed2f32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->