### PR TITLE
ci: add Semgrep SAST scanning on pull requests

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,17 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    uses: kernel/security-workflows/.github/workflows/semgrep.yml@main
+    with:
+      extra-configs: '--config p/golang --config p/trailofbits'
+      codebase-description: 'Hypervisor runtime managing VMs for customer browser sessions'
+    secrets: inherit

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,5 @@
+node_modules/
+vendor/
+dist/
+*_test.go
+go.sum


### PR DESCRIPTION
Adds Semgrep static analysis on PRs to main via the reusable workflow in kernel/security-workflows. Includes .semgrepignore for generated code, test fixtures, and lock files.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds static analysis on PRs; the main risk is new PR check noise or false positives affecting developer workflow.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/semgrep.yml`) that runs Semgrep on pull requests to `main` via the shared `kernel/security-workflows` reusable workflow, enabling the `p/golang` and `p/trailofbits` rulesets.
> 
> Introduces `.semgrepignore` to exclude dependencies/build output and other low-signal files (e.g., `node_modules/`, `vendor/`, `dist/`, `*_test.go`, `go.sum`) from scanning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c774a239cbb09d509c6edbf9bc5d7795a57a7a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->