### PR TITLE
Fix snapshot disk utilization classification for Firecracker

### DIFF
--- a/lib/diskutilization/README.md
+++ b/lib/diskutilization/README.md
@@ -33,8 +33,8 @@ Concretely, the collector reads filesystem metadata and uses the allocated block
 
 Snapshots are classified by the memory artifact present in `snapshot-latest`:
 
-- `snapshot_compressed` for compressed memory files such as `memory-ranges.zst` or `memory-ranges.lz4`
-- `snapshot_uncompressed` for raw `memory-ranges`
+- `snapshot_compressed` for compressed memory files such as `memory-ranges.zst`, `memory-ranges.lz4`, `memory.zst`, or `memory.lz4`
+- `snapshot_uncompressed` for raw `memory-ranges` or `memory`
 - `snapshot_other` when a snapshot directory exists but does not match a recognized memory artifact shape
 
 The full `snapshot-latest` directory is counted once under its classified snapshot component so the metric includes related config and state files, not just the memory artifact itself.

--- a/lib/diskutilization/diskutilization.go
+++ b/lib/diskutilization/diskutilization.go
@@ -136,9 +136,15 @@ func classifySnapshotDir(snapshotDir string) (component string, exists bool, err
 	switch {
 	case pathExists(filepath.Join(snapshotDir, "memory-ranges.zst")):
 		return ComponentSnapshotCompressed, true, nil
+	case pathExists(filepath.Join(snapshotDir, "memory.zst")):
+		return ComponentSnapshotCompressed, true, nil
 	case pathExists(filepath.Join(snapshotDir, "memory-ranges.lz4")):
 		return ComponentSnapshotCompressed, true, nil
+	case pathExists(filepath.Join(snapshotDir, "memory.lz4")):
+		return ComponentSnapshotCompressed, true, nil
 	case pathExists(filepath.Join(snapshotDir, "memory-ranges")):
+		return ComponentSnapshotUncompressed, true, nil
+	case pathExists(filepath.Join(snapshotDir, "memory")):
 		return ComponentSnapshotUncompressed, true, nil
 	default:
 		return ComponentSnapshotOther, true, nil

--- a/lib/diskutilization/diskutilization_test.go
+++ b/lib/diskutilization/diskutilization_test.go
@@ -55,7 +55,19 @@ func TestCollect_UsesAllocatedBytesAndClassifiesSnapshots(t *testing.T) {
 	}))
 	require.NoError(t, os.WriteFile(filepath.Join(compressedSnapshotDir, "config.json"), []byte(`{}`), 0644))
 
-	otherSnapshotDir := p.InstanceSnapshotLatest("inst-3")
+	firecrackerUncompressedSnapshotDir := p.InstanceSnapshotLatest("inst-3")
+	require.NoError(t, createSparseTestFile(filepath.Join(firecrackerUncompressedSnapshotDir, "memory"), 48*1024*1024, []sparseWrite{
+		{offset: 0, data: bytes.Repeat([]byte("f"), 4096)},
+	}))
+	require.NoError(t, os.WriteFile(filepath.Join(firecrackerUncompressedSnapshotDir, "config.json"), []byte(`{}`), 0644))
+
+	firecrackerCompressedSnapshotDir := p.InstanceSnapshotLatest("inst-4")
+	require.NoError(t, createSparseTestFile(filepath.Join(firecrackerCompressedSnapshotDir, "memory.zst"), 24*1024*1024, []sparseWrite{
+		{offset: 0, data: bytes.Repeat([]byte("z"), 4096)},
+	}))
+	require.NoError(t, os.WriteFile(filepath.Join(firecrackerCompressedSnapshotDir, "config.json"), []byte(`{}`), 0644))
+
+	otherSnapshotDir := p.InstanceSnapshotLatest("inst-5")
 	require.NoError(t, os.MkdirAll(otherSnapshotDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(otherSnapshotDir, "config.json"), []byte(`{}`), 0644))
 
@@ -72,13 +84,17 @@ func TestCollect_UsesAllocatedBytesAndClassifiesSnapshots(t *testing.T) {
 
 	uncompressedTotal, err := sumTreeAllocatedBytes(uncompressedSnapshotDir)
 	require.NoError(t, err)
+	firecrackerUncompressedTotal, err := sumTreeAllocatedBytes(firecrackerUncompressedSnapshotDir)
+	require.NoError(t, err)
 	compressedTotal, err := sumTreeAllocatedBytes(compressedSnapshotDir)
+	require.NoError(t, err)
+	firecrackerCompressedTotal, err := sumTreeAllocatedBytes(firecrackerCompressedSnapshotDir)
 	require.NoError(t, err)
 	otherTotal, err := sumTreeAllocatedBytes(otherSnapshotDir)
 	require.NoError(t, err)
 
-	require.Equal(t, uncompressedTotal, utilization.SnapshotUncompressed)
-	require.Equal(t, compressedTotal, utilization.SnapshotCompressed)
+	require.Equal(t, uncompressedTotal+firecrackerUncompressedTotal, utilization.SnapshotUncompressed)
+	require.Equal(t, compressedTotal+firecrackerCompressedTotal, utilization.SnapshotCompressed)
 	require.Equal(t, otherTotal, utilization.SnapshotOther)
 }
 

--- a/lib/resources/monitoring_test.go
+++ b/lib/resources/monitoring_test.go
@@ -230,7 +230,7 @@ func TestStartMonitoringPublishesDiskUtilizationFromCachedSnapshot(t *testing.T)
 		{offset: 0, data: bytes.Repeat([]byte("o"), 4096)},
 	}))
 	snapshotDir := mgr.paths.InstanceSnapshotLatest("vm-1")
-	require.NoError(t, createMonitoringSparseTestFile(filepath.Join(snapshotDir, "memory-ranges.zst"), 32*1024*1024, []monitoringSparseWrite{
+	require.NoError(t, createMonitoringSparseTestFile(filepath.Join(snapshotDir, "memory.zst"), 32*1024*1024, []monitoringSparseWrite{
 		{offset: 0, data: bytes.Repeat([]byte("s"), 4096)},
 	}))
 	require.NoError(t, os.WriteFile(filepath.Join(snapshotDir, "config.json"), []byte(`{}`), 0644))


### PR DESCRIPTION
## Summary
- classify Firecracker standby snapshots that use `memory`, `memory.zst`, or `memory.lz4`
- keep recognizing the legacy `memory-ranges*` snapshot names
- update disk utilization and monitoring tests to cover the live Firecracker layout

## Testing
- go test ./lib/diskutilization
- go test ./lib/resources -run TestStartMonitoringPublishesDiskUtilizationFromCachedSnapshot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes snapshot classification logic that feeds disk utilization metrics, which could affect monitoring/alerting and capacity dashboards if misclassified. Scope is small and covered by updated unit/integration-style tests.
> 
> **Overview**
> Updates snapshot disk utilization classification to recognize Firecracker standby snapshot layouts by treating `memory`, `memory.zst`, and `memory.lz4` as valid snapshot memory artifacts (alongside legacy `memory-ranges*`).
> 
> Refreshes documentation and expands tests to cover the new Firecracker filenames, including monitoring’s cached disk-utilization metric emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2795f6f200836d21347f7d3e6b77614b57c32a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->