### PR TITLE
Add cloud-hypervisor v51.1 with backwards-compatible version flag (CVE-2026-27211)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,10 @@ build-caddy: $(XCADDY)
 	@echo "Caddy binary built successfully"
 
 # Download Cloud Hypervisor API spec
+# All embedded CH versions currently share the same API spec (v0.3.0).
+# Multiple API versions will only be needed once there are breaking changes
+# introduced. Use version-specific Capabilities when new features are
+# introduced that aren't supported on previous versions.
 download-ch-spec:
 	@echo "Downloading Cloud Hypervisor API spec..."
 	@mkdir -p specs/cloud-hypervisor/api-v0.3.0

--- a/Makefile
+++ b/Makefile
@@ -37,18 +37,12 @@ install-tools: $(OAPI_CODEGEN) $(AIR) $(WIRE) $(XCADDY)
 # Download Cloud Hypervisor binaries
 download-ch-binaries:
 	@echo "Downloading Cloud Hypervisor binaries..."
-	@mkdir -p lib/vmm/binaries/cloud-hypervisor/v48.0/{x86_64,aarch64}
-	@mkdir -p lib/vmm/binaries/cloud-hypervisor/v49.0/{x86_64,aarch64}
-	@echo "Downloading v48.0..."
-	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v48.0/x86_64/cloud-hypervisor \
-		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v48.0/cloud-hypervisor-static
-	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v48.0/aarch64/cloud-hypervisor \
-		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v48.0/cloud-hypervisor-static-aarch64
-	@echo "Downloading v49.0..."
-	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v49.0/x86_64/cloud-hypervisor \
-		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v49.0/cloud-hypervisor-static
-	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v49.0/aarch64/cloud-hypervisor \
-		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v49.0/cloud-hypervisor-static-aarch64
+	@mkdir -p lib/vmm/binaries/cloud-hypervisor/v50.1/{x86_64,aarch64}
+	@echo "Downloading v50.1..."
+	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v50.1/x86_64/cloud-hypervisor \
+		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v50.1/cloud-hypervisor-static
+	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v50.1/aarch64/cloud-hypervisor \
+		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v50.1/cloud-hypervisor-static-aarch64
 	@chmod +x lib/vmm/binaries/cloud-hypervisor/v*/*/cloud-hypervisor
 	@echo "Binaries downloaded successfully"
 
@@ -116,7 +110,7 @@ download-ch-spec:
 	@echo "Downloading Cloud Hypervisor API spec..."
 	@mkdir -p specs/cloud-hypervisor/api-v0.3.0
 	@curl -L -o specs/cloud-hypervisor/api-v0.3.0/cloud-hypervisor.yaml \
-		https://raw.githubusercontent.com/cloud-hypervisor/cloud-hypervisor/refs/tags/v48.0/vmm/src/api/openapi/cloud-hypervisor.yaml
+		https://raw.githubusercontent.com/cloud-hypervisor/cloud-hypervisor/refs/tags/v50.1/vmm/src/api/openapi/cloud-hypervisor.yaml
 	@echo "API spec downloaded"
 
 # Generate Go code from OpenAPI spec
@@ -168,7 +162,7 @@ ensure-ch-binaries:
 	else \
 		echo "Unsupported architecture: $$ARCH"; exit 1; \
 	fi; \
-	if [ ! -f lib/vmm/binaries/cloud-hypervisor/v48.0/$$CH_ARCH/cloud-hypervisor ]; then \
+	if [ ! -f lib/vmm/binaries/cloud-hypervisor/v50.1/$$CH_ARCH/cloud-hypervisor ]; then \
 		echo "Cloud Hypervisor binaries not found, downloading..."; \
 		$(MAKE) download-ch-binaries; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,16 @@ $(XCADDY): | $(BIN_DIR)
 
 install-tools: $(OAPI_CODEGEN) $(AIR) $(WIRE) $(XCADDY)
 
-# Download Cloud Hypervisor binaries
+# Download Cloud Hypervisor binaries (both v49.0 and v51.1 for backwards-compatible upgrades)
 download-ch-binaries:
 	@echo "Downloading Cloud Hypervisor binaries..."
+	@mkdir -p lib/vmm/binaries/cloud-hypervisor/v49.0/{x86_64,aarch64}
 	@mkdir -p lib/vmm/binaries/cloud-hypervisor/v51.1/{x86_64,aarch64}
+	@echo "Downloading v49.0..."
+	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v49.0/x86_64/cloud-hypervisor \
+		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v49.0/cloud-hypervisor-static
+	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v49.0/aarch64/cloud-hypervisor \
+		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v49.0/cloud-hypervisor-static-aarch64
 	@echo "Downloading v51.1..."
 	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v51.1/x86_64/cloud-hypervisor \
 		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v51.1/cloud-hypervisor-static
@@ -162,7 +168,8 @@ ensure-ch-binaries:
 	else \
 		echo "Unsupported architecture: $$ARCH"; exit 1; \
 	fi; \
-	if [ ! -f lib/vmm/binaries/cloud-hypervisor/v51.1/$$CH_ARCH/cloud-hypervisor ]; then \
+	if [ ! -f lib/vmm/binaries/cloud-hypervisor/v49.0/$$CH_ARCH/cloud-hypervisor ] || \
+	   [ ! -f lib/vmm/binaries/cloud-hypervisor/v51.1/$$CH_ARCH/cloud-hypervisor ]; then \
 		echo "Cloud Hypervisor binaries not found, downloading..."; \
 		$(MAKE) download-ch-binaries; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,12 @@ install-tools: $(OAPI_CODEGEN) $(AIR) $(WIRE) $(XCADDY)
 # Download Cloud Hypervisor binaries
 download-ch-binaries:
 	@echo "Downloading Cloud Hypervisor binaries..."
-	@mkdir -p lib/vmm/binaries/cloud-hypervisor/v50.1/{x86_64,aarch64}
-	@echo "Downloading v50.1..."
-	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v50.1/x86_64/cloud-hypervisor \
-		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v50.1/cloud-hypervisor-static
-	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v50.1/aarch64/cloud-hypervisor \
-		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v50.1/cloud-hypervisor-static-aarch64
+	@mkdir -p lib/vmm/binaries/cloud-hypervisor/v51.1/{x86_64,aarch64}
+	@echo "Downloading v51.1..."
+	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v51.1/x86_64/cloud-hypervisor \
+		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v51.1/cloud-hypervisor-static
+	@curl -L -o lib/vmm/binaries/cloud-hypervisor/v51.1/aarch64/cloud-hypervisor \
+		https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v51.1/cloud-hypervisor-static-aarch64
 	@chmod +x lib/vmm/binaries/cloud-hypervisor/v*/*/cloud-hypervisor
 	@echo "Binaries downloaded successfully"
 
@@ -110,7 +110,7 @@ download-ch-spec:
 	@echo "Downloading Cloud Hypervisor API spec..."
 	@mkdir -p specs/cloud-hypervisor/api-v0.3.0
 	@curl -L -o specs/cloud-hypervisor/api-v0.3.0/cloud-hypervisor.yaml \
-		https://raw.githubusercontent.com/cloud-hypervisor/cloud-hypervisor/refs/tags/v50.1/vmm/src/api/openapi/cloud-hypervisor.yaml
+		https://raw.githubusercontent.com/cloud-hypervisor/cloud-hypervisor/refs/tags/v51.1/vmm/src/api/openapi/cloud-hypervisor.yaml
 	@echo "API spec downloaded"
 
 # Generate Go code from OpenAPI spec
@@ -162,7 +162,7 @@ ensure-ch-binaries:
 	else \
 		echo "Unsupported architecture: $$ARCH"; exit 1; \
 	fi; \
-	if [ ! -f lib/vmm/binaries/cloud-hypervisor/v50.1/$$CH_ARCH/cloud-hypervisor ]; then \
+	if [ ! -f lib/vmm/binaries/cloud-hypervisor/v51.1/$$CH_ARCH/cloud-hypervisor ]; then \
 		echo "Cloud Hypervisor binaries not found, downloading..."; \
 		$(MAKE) download-ch-binaries; \
 	fi

--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -196,7 +196,7 @@ type HypervisorConfig struct {
 	Default                       string                 `koanf:"default"`
 	CloudHypervisorDefaultVersion string                 `koanf:"cloud_hypervisor_default_version"`
 	FirecrackerBinaryPath         string                 `koanf:"firecracker_binary_path"`
-	Memory                 HypervisorMemoryConfig `koanf:"memory"`
+	Memory                        HypervisorMemoryConfig `koanf:"memory"`
 }
 
 // HypervisorMemoryConfig holds guest memory management settings.

--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -193,9 +193,9 @@ type CapacityConfig struct {
 
 // HypervisorConfig holds hypervisor settings.
 type HypervisorConfig struct {
-	Default                string                 `koanf:"default"`
-	CloudHypervisorVersion string                 `koanf:"cloud_hypervisor_version"`
-	FirecrackerBinaryPath  string                 `koanf:"firecracker_binary_path"`
+	Default                       string                 `koanf:"default"`
+	CloudHypervisorDefaultVersion string                 `koanf:"cloud_hypervisor_default_version"`
+	FirecrackerBinaryPath         string                 `koanf:"firecracker_binary_path"`
 	Memory                 HypervisorMemoryConfig `koanf:"memory"`
 }
 
@@ -404,9 +404,9 @@ func defaultConfig() *Config {
 		},
 
 		Hypervisor: HypervisorConfig{
-			Default:                "cloud-hypervisor",
-			CloudHypervisorVersion: "v49.0",
-			FirecrackerBinaryPath:  "",
+			Default:                       "cloud-hypervisor",
+			CloudHypervisorDefaultVersion: "",
+			FirecrackerBinaryPath:         "",
 			Memory: HypervisorMemoryConfig{
 				Enabled:            false,
 				KernelPageInitMode: "hardened",

--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -193,9 +193,10 @@ type CapacityConfig struct {
 
 // HypervisorConfig holds hypervisor settings.
 type HypervisorConfig struct {
-	Default               string                 `koanf:"default"`
-	FirecrackerBinaryPath string                 `koanf:"firecracker_binary_path"`
-	Memory                HypervisorMemoryConfig `koanf:"memory"`
+	Default                string                 `koanf:"default"`
+	CloudHypervisorVersion string                 `koanf:"cloud_hypervisor_version"`
+	FirecrackerBinaryPath  string                 `koanf:"firecracker_binary_path"`
+	Memory                 HypervisorMemoryConfig `koanf:"memory"`
 }
 
 // HypervisorMemoryConfig holds guest memory management settings.
@@ -403,8 +404,9 @@ func defaultConfig() *Config {
 		},
 
 		Hypervisor: HypervisorConfig{
-			Default:               "cloud-hypervisor",
-			FirecrackerBinaryPath: "",
+			Default:                "cloud-hypervisor",
+			CloudHypervisorVersion: "v49.0",
+			FirecrackerBinaryPath:  "",
 			Memory: HypervisorMemoryConfig{
 				Enabled:            false,
 				KernelPageInitMode: "hardened",

--- a/lib/hypervisor/cloudhypervisor/cloudhypervisor.go
+++ b/lib/hypervisor/cloudhypervisor/cloudhypervisor.go
@@ -49,7 +49,14 @@ func (c *CloudHypervisor) Capabilities() hypervisor.Capabilities {
 }
 
 func capabilities() hypervisor.Capabilities {
-	return hypervisor.Capabilities{
+	return CapabilitiesForVersion(vmm.DefaultVersion)
+}
+
+// CapabilitiesForVersion returns capabilities for a specific CH version.
+// Use version-specific capabilities when new features are introduced that
+// aren't supported on previous versions.
+func CapabilitiesForVersion(v vmm.CHVersion) hypervisor.Capabilities {
+	caps := hypervisor.Capabilities{
 		SupportsSnapshot:            true,
 		SupportsHotplugMemory:       true,
 		SupportsBalloonControl:      true,
@@ -60,6 +67,11 @@ func capabilities() hypervisor.Capabilities {
 		SupportsGracefulVMMShutdown: true,
 		SupportsSnapshotBaseReuse:   false,
 	}
+	switch v {
+	case vmm.V51_1:
+		caps.SupportsDiskResize = true
+	}
+	return caps
 }
 
 // DeleteVM removes the VM configuration from Cloud Hypervisor.

--- a/lib/hypervisor/cloudhypervisor/config.go
+++ b/lib/hypervisor/cloudhypervisor/config.go
@@ -63,7 +63,8 @@ func ToVMConfig(cfg hypervisor.VMConfig) vmm.VmConfig {
 	disks := make([]vmm.DiskConfig, 0, len(cfg.Disks))
 	for _, d := range cfg.Disks {
 		disk := vmm.DiskConfig{
-			Path: ptr(d.Path),
+			Path:      ptr(d.Path),
+			ImageType: ptr(vmm.Raw),
 		}
 		if d.Readonly {
 			disk.Readonly = ptr(true)

--- a/lib/hypervisor/cloudhypervisor/process.go
+++ b/lib/hypervisor/cloudhypervisor/process.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -18,6 +19,29 @@ import (
 	"github.com/kernel/hypeman/lib/vmm"
 	"gvisor.dev/gvisor/pkg/cleanup"
 )
+
+var (
+	defaultVersionMu sync.RWMutex
+	defaultVersion   = vmm.V49_0
+)
+
+// SetDefaultVersion sets the default Cloud Hypervisor version for new instances.
+// Only updates if the provided version is in SupportedVersions.
+func SetDefaultVersion(v string) {
+	defaultVersionMu.Lock()
+	defer defaultVersionMu.Unlock()
+	chv := vmm.CHVersion(v)
+	if vmm.IsVersionSupported(chv) {
+		defaultVersion = chv
+	}
+}
+
+// GetDefaultVersion returns the current default Cloud Hypervisor version.
+func GetDefaultVersion() vmm.CHVersion {
+	defaultVersionMu.RLock()
+	defer defaultVersionMu.RUnlock()
+	return defaultVersion
+}
 
 func init() {
 	hypervisor.RegisterSocketName(hypervisor.TypeCloudHypervisor, "ch.sock")
@@ -52,10 +76,11 @@ func (s *Starter) GetBinaryPath(p *paths.Paths, version string) (string, error) 
 	return vmm.GetBinaryPath(p, chVersion)
 }
 
-// GetVersion returns the latest supported Cloud Hypervisor version.
-// Cloud Hypervisor binaries are embedded, so we return the latest known version.
+// GetVersion returns the configured default Cloud Hypervisor version.
+// This controls which version is used for new instances; existing instances
+// use the version stored in their metadata.
 func (s *Starter) GetVersion(p *paths.Paths) (string, error) {
-	return string(vmm.V51_1), nil
+	return string(GetDefaultVersion()), nil
 }
 
 // StartVM launches Cloud Hypervisor, configures the VM, and boots it.

--- a/lib/hypervisor/cloudhypervisor/process.go
+++ b/lib/hypervisor/cloudhypervisor/process.go
@@ -21,26 +21,37 @@ import (
 )
 
 var (
-	defaultVersionMu sync.RWMutex
-	defaultVersion   = vmm.V49_0
+	defaultVersionMu       sync.RWMutex
+	defaultVersionOverride *vmm.CHVersion
 )
 
-// SetDefaultVersion sets the default Cloud Hypervisor version for new instances.
-// Only updates if the provided version is in SupportedVersions.
-func SetDefaultVersion(v string) {
+// SetDefaultVersion overrides the default Cloud Hypervisor version for new
+// instances. An empty string clears the override (vmm.DefaultVersion is used).
+// Returns an error if the version is non-empty and not in SupportedVersions.
+func SetDefaultVersion(v string) error {
 	defaultVersionMu.Lock()
 	defer defaultVersionMu.Unlock()
-	chv := vmm.CHVersion(v)
-	if vmm.IsVersionSupported(chv) {
-		defaultVersion = chv
+	if v == "" {
+		defaultVersionOverride = nil
+		return nil
 	}
+	chv := vmm.CHVersion(v)
+	if !vmm.IsVersionSupported(chv) {
+		return fmt.Errorf("unsupported cloud-hypervisor version: %q (supported: %v)", v, vmm.SupportedVersions)
+	}
+	defaultVersionOverride = &chv
+	return nil
 }
 
-// GetDefaultVersion returns the current default Cloud Hypervisor version.
+// GetDefaultVersion returns the configured default, falling back to
+// vmm.DefaultVersion if no override is set.
 func GetDefaultVersion() vmm.CHVersion {
 	defaultVersionMu.RLock()
 	defer defaultVersionMu.RUnlock()
-	return defaultVersion
+	if defaultVersionOverride != nil {
+		return *defaultVersionOverride
+	}
+	return vmm.DefaultVersion
 }
 
 func init() {

--- a/lib/hypervisor/cloudhypervisor/process.go
+++ b/lib/hypervisor/cloudhypervisor/process.go
@@ -55,7 +55,7 @@ func (s *Starter) GetBinaryPath(p *paths.Paths, version string) (string, error) 
 // GetVersion returns the latest supported Cloud Hypervisor version.
 // Cloud Hypervisor binaries are embedded, so we return the latest known version.
 func (s *Starter) GetVersion(p *paths.Paths) (string, error) {
-	return string(vmm.V50_1), nil
+	return string(vmm.V51_1), nil
 }
 
 // StartVM launches Cloud Hypervisor, configures the VM, and boots it.

--- a/lib/hypervisor/cloudhypervisor/process.go
+++ b/lib/hypervisor/cloudhypervisor/process.go
@@ -55,7 +55,7 @@ func (s *Starter) GetBinaryPath(p *paths.Paths, version string) (string, error) 
 // GetVersion returns the latest supported Cloud Hypervisor version.
 // Cloud Hypervisor binaries are embedded, so we return the latest known version.
 func (s *Starter) GetVersion(p *paths.Paths) (string, error) {
-	return string(vmm.V49_0), nil
+	return string(vmm.V50_1), nil
 }
 
 // StartVM launches Cloud Hypervisor, configures the VM, and boots it.

--- a/lib/hypervisor/hypervisor.go
+++ b/lib/hypervisor/hypervisor.go
@@ -233,6 +233,10 @@ type Capabilities struct {
 	// SupportsSnapshotBaseReuse indicates snapshots can safely reuse a retained
 	// on-disk base across restore/standby cycles.
 	SupportsSnapshotBaseReuse bool
+
+	// SupportsDiskResize indicates if live disk resizing (/vm.resize-disk) is available.
+	// Cloud Hypervisor v50.0+ only.
+	SupportsDiskResize bool
 }
 
 // VsockDialer provides vsock connectivity to a guest VM.

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -244,11 +244,15 @@ func (m *manager) createInstance(
 		return nil, fmt.Errorf("get vm starter for %s: %w", hvType, err)
 	}
 
-	// Get hypervisor version
-	hvVersion, err := starter.GetVersion(m.paths)
-	if err != nil {
-		log.WarnContext(ctx, "failed to get hypervisor version", "hypervisor", hvType, "error", err)
-		hvVersion = "unknown"
+	// Get hypervisor version: prefer explicit request, then configured default
+	hvVersion := req.HypervisorVersion
+	if hvVersion == "" {
+		var verErr error
+		hvVersion, verErr = starter.GetVersion(m.paths)
+		if verErr != nil {
+			log.WarnContext(ctx, "failed to get hypervisor version", "hypervisor", hvType, "error", verErr)
+			hvVersion = "unknown"
+		}
 	}
 
 	// 10. Validate, resolve, and auto-bind devices (GPU passthrough)

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -512,7 +512,7 @@ func (m *manager) createInstance(
 	}
 
 	// 19. Start VMM and boot VM
-	log.InfoContext(ctx, "starting VMM and booting VM", "instance_id", id)
+	log.InfoContext(ctx, "starting VMM and booting VM", "instance_id", id, "hypervisor", hvType, "version", hvVersion)
 	startVMCtx, startVMSpanEnd := m.startLifecycleStep(ctx, "start_vm",
 		attribute.String("instance_id", id),
 		attribute.String("hypervisor", string(stored.HypervisorType)),
@@ -556,7 +556,7 @@ func (m *manager) createInstance(
 		m.recordDuration(ctx, m.metrics.createDuration, start, "success", hvType)
 		m.recordStateTransition(ctx, string(StateStopped), string(finalInst.State), hvType)
 	}
-	log.InfoContext(ctx, "instance created successfully", "instance_id", id, "name", req.Name, "state", finalInst.State, "hypervisor", hvType)
+	log.InfoContext(ctx, "instance created successfully", "instance_id", id, "name", req.Name, "state", finalInst.State, "hypervisor", hvType, "version", hvVersion)
 	return &finalInst, nil
 }
 

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -246,7 +246,11 @@ func (m *manager) createInstance(
 
 	// Get hypervisor version: prefer explicit request, then configured default
 	hvVersion := req.HypervisorVersion
-	if hvVersion == "" {
+	if hvVersion != "" {
+		if _, err := starter.GetBinaryPath(m.paths, hvVersion); err != nil {
+			return nil, fmt.Errorf("invalid hypervisor version %q: %w", hvVersion, err)
+		}
+	} else {
 		var verErr error
 		hvVersion, verErr = starter.GetVersion(m.paths)
 		if verErr != nil {

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -1254,7 +1254,7 @@ func TestStorageOperations(t *testing.T) {
 		Env:               map[string]string{"TEST": "value"},
 		CreatedAt:         time.Now(),
 		HypervisorType:    hypervisor.TypeCloudHypervisor,
-		HypervisorVersion: string(vmm.V49_0),
+		HypervisorVersion: string(vmm.V50_1),
 		SocketPath:        "/tmp/test.sock",
 		DataDir:           paths.New(tmpDir).InstanceDir("test-123"),
 	}

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -1254,7 +1254,7 @@ func TestStorageOperations(t *testing.T) {
 		Env:               map[string]string{"TEST": "value"},
 		CreatedAt:         time.Now(),
 		HypervisorType:    hypervisor.TypeCloudHypervisor,
-		HypervisorVersion: string(vmm.V50_1),
+		HypervisorVersion: string(vmm.V51_1),
 		SocketPath:        "/tmp/test.sock",
 		DataDir:           paths.New(tmpDir).InstanceDir("test-123"),
 	}

--- a/lib/instances/snapshot.go
+++ b/lib/instances/snapshot.go
@@ -307,12 +307,14 @@ func (m *manager) restoreSnapshot(ctx context.Context, id string, snapshotID str
 	if err != nil {
 		return nil, fmt.Errorf("get vm starter: %w", err)
 	}
-	hvVersion, err := starter.GetVersion(m.paths)
-	if err != nil {
-		log.WarnContext(ctx, "failed to get hypervisor version", "hypervisor", targetHypervisor, "error", err)
-		hvVersion = "unknown"
+	if targetHypervisor != rec.StoredMetadata.HypervisorType {
+		hvVersion, err := starter.GetVersion(m.paths)
+		if err != nil {
+			log.WarnContext(ctx, "failed to get hypervisor version", "hypervisor", targetHypervisor, "error", err)
+			hvVersion = "unknown"
+		}
+		restored.HypervisorVersion = hvVersion
 	}
-	restored.HypervisorVersion = hvVersion
 	restored.SocketPath = m.paths.InstanceSocket(id, starter.SocketName())
 	restored.VsockSocket = m.paths.InstanceSocket(id, hypervisor.VsockSocketNameForType(targetHypervisor))
 	if rec.Snapshot.Kind == SnapshotKindStopped {
@@ -424,10 +426,6 @@ func (m *manager) forkSnapshot(ctx context.Context, snapshotID string, req ForkS
 	if err != nil {
 		return nil, fmt.Errorf("get vm starter: %w", err)
 	}
-	hvVersion, err := starter.GetVersion(m.paths)
-	if err != nil {
-		hvVersion = "unknown"
-	}
 
 	now := time.Now()
 	forkMeta := cloneStoredMetadataWithoutPendingStandbyCompression(rec.StoredMetadata)
@@ -439,7 +437,13 @@ func (m *manager) forkSnapshot(ctx context.Context, snapshotID string, req ForkS
 	forkMeta.HypervisorPID = nil
 	forkMeta.DataDir = dstDir
 	forkMeta.HypervisorType = targetHypervisor
-	forkMeta.HypervisorVersion = hvVersion
+	if targetHypervisor != rec.StoredMetadata.HypervisorType {
+		hvVersion, err := starter.GetVersion(m.paths)
+		if err != nil {
+			hvVersion = "unknown"
+		}
+		forkMeta.HypervisorVersion = hvVersion
+	}
 	forkMeta.SocketPath = m.paths.InstanceSocket(forkID, starter.SocketName())
 	forkMeta.VsockSocket = m.paths.InstanceSocket(forkID, hypervisor.VsockSocketNameForType(targetHypervisor))
 	forkMeta.ExitCode = nil

--- a/lib/instances/types.go
+++ b/lib/instances/types.go
@@ -112,7 +112,7 @@ type StoredMetadata struct {
 
 	// Hypervisor configuration
 	HypervisorType    hypervisor.Type // Hypervisor type (e.g., "cloud-hypervisor")
-	HypervisorVersion string          // Hypervisor version (e.g., "v50.1")
+	HypervisorVersion string          // Hypervisor version (e.g., "v51.1")
 	HypervisorPID     *int            // Hypervisor process ID (may be stale after host restart)
 
 	// Paths

--- a/lib/instances/types.go
+++ b/lib/instances/types.go
@@ -112,7 +112,7 @@ type StoredMetadata struct {
 
 	// Hypervisor configuration
 	HypervisorType    hypervisor.Type // Hypervisor type (e.g., "cloud-hypervisor")
-	HypervisorVersion string          // Hypervisor version (e.g., "v49.0")
+	HypervisorVersion string          // Hypervisor version (e.g., "v50.1")
 	HypervisorPID     *int            // Hypervisor process ID (may be stale after host restart)
 
 	// Paths

--- a/lib/instances/types.go
+++ b/lib/instances/types.go
@@ -229,6 +229,7 @@ type CreateInstanceRequest struct {
 	Devices                  []string                    // Device IDs or names to attach (GPU passthrough)
 	Volumes                  []VolumeAttachment          // Volumes to attach at creation time
 	Hypervisor               hypervisor.Type             // Optional: hypervisor type (defaults to config)
+	HypervisorVersion        string                      // Optional: hypervisor version (defaults to configured default)
 	GPU                      *GPUConfig                  // Optional: vGPU configuration
 	Entrypoint               []string                    // Override image entrypoint (nil = use image default)
 	Cmd                      []string                    // Override image cmd (nil = use image default)

--- a/lib/instances/version_upgrade_test.go
+++ b/lib/instances/version_upgrade_test.go
@@ -58,22 +58,23 @@ func TestCloudHypervisorVersionUpgradeRestore(t *testing.T) {
 	systemManager := system.NewManager(p)
 	require.NoError(t, systemManager.EnsureSystemFiles(ctx))
 
-	// Phase 1: Set default to v49.0 and create an instance
-	cloudhypervisor.SetDefaultVersion(string(vmm.V49_0))
+	// Reset default version override after this test
 	t.Cleanup(func() {
-		cloudhypervisor.SetDefaultVersion(string(vmm.V49_0))
+		_ = cloudhypervisor.SetDefaultVersion("")
 	})
 
+	// Phase 1: Create instance with explicit v49.0 version
 	t.Log("Creating instance with CH v49.0...")
 	inst, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
-		Name:           "version-upgrade-test",
-		Image:          integrationTestImageRef(t, "docker.io/library/alpine:latest"),
-		Size:           1024 * 1024 * 1024,
-		OverlaySize:    10 * 1024 * 1024 * 1024,
-		Vcpus:          1,
-		NetworkEnabled: false,
-		Hypervisor:     hypervisor.TypeCloudHypervisor,
-		Cmd:            []string{"sleep", "infinity"},
+		Name:              "version-upgrade-test",
+		Image:             integrationTestImageRef(t, "docker.io/library/alpine:latest"),
+		Size:              1024 * 1024 * 1024,
+		OverlaySize:       10 * 1024 * 1024 * 1024,
+		Vcpus:             1,
+		NetworkEnabled:    false,
+		Hypervisor:        hypervisor.TypeCloudHypervisor,
+		HypervisorVersion: string(vmm.V49_0),
+		Cmd:               []string{"sleep", "infinity"},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, string(vmm.V49_0), inst.HypervisorVersion)
@@ -96,7 +97,7 @@ func TestCloudHypervisorVersionUpgradeRestore(t *testing.T) {
 
 	// Phase 3: Change default version to v51.1 (simulates a deploy with new config)
 	t.Log("Switching default CH version to v51.1...")
-	cloudhypervisor.SetDefaultVersion(string(vmm.V51_1))
+	require.NoError(t, cloudhypervisor.SetDefaultVersion(string(vmm.V51_1)))
 
 	// Phase 4: Restore -- must use the stored v49.0, not the new default
 	t.Log("Restoring instance (should use stored v49.0)...")
@@ -110,7 +111,7 @@ func TestCloudHypervisorVersionUpgradeRestore(t *testing.T) {
 	t.Logf("Instance restored with version: %s", inst.HypervisorVersion)
 
 	// Phase 5: Verify a NEW instance picks up the v51.1 default
-	t.Log("Creating second instance (should use v51.1)...")
+	t.Log("Creating second instance (should use v51.1 via default)...")
 	inst2, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
 		Name:           "version-upgrade-new",
 		Image:          integrationTestImageRef(t, "docker.io/library/alpine:latest"),

--- a/lib/instances/version_upgrade_test.go
+++ b/lib/instances/version_upgrade_test.go
@@ -1,0 +1,139 @@
+//go:build linux
+
+package instances
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+	"github.com/kernel/hypeman/lib/hypervisor/cloudhypervisor"
+	"github.com/kernel/hypeman/lib/images"
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/system"
+	"github.com/kernel/hypeman/lib/vmm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloudHypervisorVersionUpgradeRestore verifies that instances created on
+// one CH version can be put in standby and restored after the default version
+// changes. This tests the backwards-compatible upgrade path: deploy new binary
+// with both versions embedded, flip the flag, and existing standbys still
+// restore using their original version.
+func TestCloudHypervisorVersionUpgradeRestore(t *testing.T) {
+	t.Parallel()
+	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
+		t.Skip("/dev/kvm not available, skipping on this platform")
+	}
+
+	mgr, tmpDir := setupTestManager(t)
+	ctx := context.Background()
+	p := paths.New(tmpDir)
+
+	// Prepare image and system files
+	imageManager, err := images.NewManager(p, 1, nil)
+	require.NoError(t, err)
+
+	t.Log("Ensuring alpine image...")
+	alpineImage, err := imageManager.CreateImage(ctx, images.CreateImageRequest{
+		Name: integrationTestImageRef(t, "docker.io/library/alpine:latest"),
+	})
+	require.NoError(t, err)
+	for i := 0; i < 60; i++ {
+		img, err := imageManager.GetImage(ctx, alpineImage.Name)
+		if err == nil && img.Status == images.StatusReady {
+			alpineImage = img
+			break
+		}
+		if err == nil && img.Status == images.StatusFailed {
+			t.Fatalf("Image build failed: %s", *img.Error)
+		}
+		time.Sleep(1 * time.Second)
+	}
+	require.Equal(t, images.StatusReady, alpineImage.Status, "Image should be ready after 60 seconds")
+
+	systemManager := system.NewManager(p)
+	require.NoError(t, systemManager.EnsureSystemFiles(ctx))
+
+	// Phase 1: Set default to v49.0 and create an instance
+	cloudhypervisor.SetDefaultVersion(string(vmm.V49_0))
+	t.Cleanup(func() {
+		cloudhypervisor.SetDefaultVersion(string(vmm.V49_0))
+	})
+
+	t.Log("Creating instance with CH v49.0...")
+	inst, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
+		Name:           "version-upgrade-test",
+		Image:          integrationTestImageRef(t, "docker.io/library/alpine:latest"),
+		Size:           1024 * 1024 * 1024,
+		OverlaySize:    10 * 1024 * 1024 * 1024,
+		Vcpus:          1,
+		NetworkEnabled: false,
+		Hypervisor:     hypervisor.TypeCloudHypervisor,
+		Cmd:            []string{"sleep", "infinity"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, string(vmm.V49_0), inst.HypervisorVersion)
+	t.Logf("Instance created: %s (version: %s)", inst.Id, inst.HypervisorVersion)
+
+	inst, err = waitForInstanceState(ctx, mgr, inst.Id, StateRunning, integrationTestTimeout(20*time.Second))
+	require.NoError(t, err)
+	require.Equal(t, StateRunning, inst.State)
+
+	err = waitForVMReady(ctx, inst.SocketPath, 5*time.Second)
+	require.NoError(t, err)
+
+	// Phase 2: Put instance in standby
+	t.Log("Putting instance in standby...")
+	inst, err = mgr.StandbyInstance(ctx, inst.Id, StandbyInstanceRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, StateStandby, inst.State)
+	assert.True(t, inst.HasSnapshot)
+	assert.Equal(t, string(vmm.V49_0), inst.HypervisorVersion)
+
+	// Phase 3: Change default version to v51.1 (simulates a deploy with new config)
+	t.Log("Switching default CH version to v51.1...")
+	cloudhypervisor.SetDefaultVersion(string(vmm.V51_1))
+
+	// Phase 4: Restore -- must use the stored v49.0, not the new default
+	t.Log("Restoring instance (should use stored v49.0)...")
+	inst, err = mgr.RestoreInstance(ctx, inst.Id)
+	require.NoError(t, err)
+	inst, err = waitForInstanceState(ctx, mgr, inst.Id, StateRunning, integrationTestTimeout(20*time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, StateRunning, inst.State)
+	assert.Equal(t, string(vmm.V49_0), inst.HypervisorVersion,
+		"Restored instance must use original version, not the new default")
+	t.Logf("Instance restored with version: %s", inst.HypervisorVersion)
+
+	// Phase 5: Verify a NEW instance picks up the v51.1 default
+	t.Log("Creating second instance (should use v51.1)...")
+	inst2, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
+		Name:           "version-upgrade-new",
+		Image:          integrationTestImageRef(t, "docker.io/library/alpine:latest"),
+		Size:           1024 * 1024 * 1024,
+		OverlaySize:    10 * 1024 * 1024 * 1024,
+		Vcpus:          1,
+		NetworkEnabled: false,
+		Hypervisor:     hypervisor.TypeCloudHypervisor,
+		Cmd:            []string{"sleep", "infinity"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, string(vmm.V51_1), inst2.HypervisorVersion,
+		"New instance should use the updated default version")
+	t.Logf("New instance created: %s (version: %s)", inst2.Id, inst2.HypervisorVersion)
+
+	inst2, err = waitForInstanceState(ctx, mgr, inst2.Id, StateRunning, integrationTestTimeout(20*time.Second))
+	require.NoError(t, err)
+	require.Equal(t, StateRunning, inst2.State)
+
+	// Cleanup
+	t.Log("Cleaning up...")
+	require.NoError(t, mgr.DeleteInstance(ctx, inst.Id))
+	require.NoError(t, mgr.DeleteInstance(ctx, inst2.Id))
+
+	t.Log("Version upgrade restore test complete!")
+}

--- a/lib/providers/providers.go
+++ b/lib/providers/providers.go
@@ -100,7 +100,9 @@ func ProvideDeviceManager(p *paths.Paths) devices.Manager {
 // ProvideInstanceManager provides the instance manager
 func ProvideInstanceManager(p *paths.Paths, cfg *config.Config, imageManager images.Manager, systemManager system.Manager, networkManager network.Manager, deviceManager devices.Manager, volumeManager volumes.Manager) (instances.Manager, error) {
 	firecracker.SetCustomBinaryPath(cfg.Hypervisor.FirecrackerBinaryPath)
-	cloudhypervisor.SetDefaultVersion(cfg.Hypervisor.CloudHypervisorVersion)
+	if err := cloudhypervisor.SetDefaultVersion(cfg.Hypervisor.CloudHypervisorDefaultVersion); err != nil {
+		return nil, fmt.Errorf("invalid cloud-hypervisor default version: %w", err)
+	}
 
 	// Parse max overlay size from config
 	var maxOverlaySize datasize.ByteSize

--- a/lib/providers/providers.go
+++ b/lib/providers/providers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kernel/hypeman/lib/devices"
 	"github.com/kernel/hypeman/lib/guestmemory"
 	"github.com/kernel/hypeman/lib/hypervisor"
+	"github.com/kernel/hypeman/lib/hypervisor/cloudhypervisor"
 	"github.com/kernel/hypeman/lib/hypervisor/firecracker"
 	"github.com/kernel/hypeman/lib/images"
 	"github.com/kernel/hypeman/lib/ingress"
@@ -99,6 +100,7 @@ func ProvideDeviceManager(p *paths.Paths) devices.Manager {
 // ProvideInstanceManager provides the instance manager
 func ProvideInstanceManager(p *paths.Paths, cfg *config.Config, imageManager images.Manager, systemManager system.Manager, networkManager network.Manager, deviceManager devices.Manager, volumeManager volumes.Manager) (instances.Manager, error) {
 	firecracker.SetCustomBinaryPath(cfg.Hypervisor.FirecrackerBinaryPath)
+	cloudhypervisor.SetDefaultVersion(cfg.Hypervisor.CloudHypervisorVersion)
 
 	// Parse max overlay size from config
 	var maxOverlaySize datasize.ByteSize

--- a/lib/system/README.md
+++ b/lib/system/README.md
@@ -37,8 +37,8 @@ Manages versioned kernel and initrd files for Cloud Hypervisor VMs.
 
 **Snapshots require exact matches:**
 ```
-Standby:  kernel ch-6.12.8-kernel-1.2-20251213, CH v50.1
-Restore:  kernel ch-6.12.8-kernel-1.2-20251213, CH v50.1 (MUST match)
+Standby:  kernel ch-6.12.8-kernel-1.2-20251213, CH v51.1
+Restore:  kernel ch-6.12.8-kernel-1.2-20251213, CH v51.1 (MUST match)
 ```
 
 **Maintenance upgrades (shutdown → boot):**

--- a/lib/system/README.md
+++ b/lib/system/README.md
@@ -37,8 +37,8 @@ Manages versioned kernel and initrd files for Cloud Hypervisor VMs.
 
 **Snapshots require exact matches:**
 ```
-Standby:  kernel ch-6.12.8-kernel-1.2-20251213, CH v49.0
-Restore:  kernel ch-6.12.8-kernel-1.2-20251213, CH v49.0 (MUST match)
+Standby:  kernel ch-6.12.8-kernel-1.2-20251213, CH v50.1
+Restore:  kernel ch-6.12.8-kernel-1.2-20251213, CH v50.1 (MUST match)
 ```
 
 **Maintenance upgrades (shutdown → boot):**

--- a/lib/vmm/README.md
+++ b/lib/vmm/README.md
@@ -75,18 +75,29 @@ lib/vmm/
 ├── version.go          # Version parsing utilities
 ├── binaries/           # Embedded Cloud Hypervisor binaries
 │   └── cloud-hypervisor/
+│       ├── v49.0/
+│       │   ├── x86_64/cloud-hypervisor
+│       │   └── aarch64/cloud-hypervisor
 │       └── v51.1/
-│           ├── x86_64/cloud-hypervisor    (4.5MB)
-│           └── aarch64/cloud-hypervisor   (3.3MB)
-|       # There will be additional versions in the future...
+│           ├── x86_64/cloud-hypervisor
+│           └── aarch64/cloud-hypervisor
 └── client_test.go      # Tests with real Cloud Hypervisor
 ```
 
 ## Supported Versions
 
+- Cloud Hypervisor v49.0 (API v0.3.0)
 - Cloud Hypervisor v51.1 (API v0.3.0)
 
-There may be additional versions in the future. Cloud hypervisor versions may update frequently, while the API updates less frequently.
+Cloud Hypervisor versions may update frequently while the API updates less frequently. All embedded versions currently share the same API spec.
+
+## Multi-Version Support
+
+Multiple CH versions are embedded to support zero-downtime upgrades. Snapshot restore requires the exact CH binary version that created the snapshot, so both old and new binaries must be available during the migration window.
+
+`DefaultVersion` in `binaries.go` controls which version is used for new instances. Operators can override it via the `hypervisor.cloud_hypervisor_default_version` config field. Existing instances always restore using the version stored in their metadata.
+
+When only the default version is changing (no binary removal), the upgrade is safe with no drain required. Remove an old version only after all standby instances on that version have expired.
 
 ## Regenerating Client
 

--- a/lib/vmm/README.md
+++ b/lib/vmm/README.md
@@ -38,7 +38,7 @@ dataDir := "/var/lib/hypeman"
 socketPath := "/tmp/vmm.sock"
 
 // Start Cloud Hypervisor VMM (extracts binary if needed)
-err := vmm.StartProcess(ctx, dataDir, vmm.V50_1, socketPath)
+err := vmm.StartProcess(ctx, dataDir, vmm.V51_1, socketPath)
 if err != nil {
     log.Fatal(err)
 }
@@ -60,9 +60,9 @@ resp, err := client.GetVmmPingWithResponse(ctx)
 ### Check Binary Version
 
 ```go
-binaryPath, _ := vmm.GetBinaryPath(dataDir, vmm.V50_1)
+binaryPath, _ := vmm.GetBinaryPath(dataDir, vmm.V51_1)
 version, err := vmm.ParseVersion(binaryPath)
-fmt.Println(version) // "v50.1"
+fmt.Println(version) // "v51.1"
 ```
 
 ## Architecture
@@ -75,7 +75,7 @@ lib/vmm/
 ├── version.go          # Version parsing utilities
 ├── binaries/           # Embedded Cloud Hypervisor binaries
 │   └── cloud-hypervisor/
-│       └── v50.1/
+│       └── v51.1/
 │           ├── x86_64/cloud-hypervisor    (4.5MB)
 │           └── aarch64/cloud-hypervisor   (3.3MB)
 |       # There will be additional versions in the future...
@@ -84,7 +84,7 @@ lib/vmm/
 
 ## Supported Versions
 
-- Cloud Hypervisor v50.1 (API v0.3.0)
+- Cloud Hypervisor v51.1 (API v0.3.0)
 
 There may be additional versions in the future. Cloud hypervisor versions may update frequently, while the API updates less frequently.
 

--- a/lib/vmm/README.md
+++ b/lib/vmm/README.md
@@ -38,7 +38,7 @@ dataDir := "/var/lib/hypeman"
 socketPath := "/tmp/vmm.sock"
 
 // Start Cloud Hypervisor VMM (extracts binary if needed)
-err := vmm.StartProcess(ctx, dataDir, vmm.V48_0, socketPath)
+err := vmm.StartProcess(ctx, dataDir, vmm.V50_1, socketPath)
 if err != nil {
     log.Fatal(err)
 }
@@ -60,9 +60,9 @@ resp, err := client.GetVmmPingWithResponse(ctx)
 ### Check Binary Version
 
 ```go
-binaryPath, _ := vmm.GetBinaryPath(dataDir, vmm.V48_0)
+binaryPath, _ := vmm.GetBinaryPath(dataDir, vmm.V50_1)
 version, err := vmm.ParseVersion(binaryPath)
-fmt.Println(version) // "v48.0"
+fmt.Println(version) // "v50.1"
 ```
 
 ## Architecture
@@ -75,10 +75,7 @@ lib/vmm/
 ├── version.go          # Version parsing utilities
 ├── binaries/           # Embedded Cloud Hypervisor binaries
 │   └── cloud-hypervisor/
-│       ├── v48.0/
-│       │   ├── x86_64/cloud-hypervisor    (4.5MB)
-│       │   └── aarch64/cloud-hypervisor   (3.3MB)
-│       └── v49.0/
+│       └── v50.1/
 │           ├── x86_64/cloud-hypervisor    (4.5MB)
 │           └── aarch64/cloud-hypervisor   (3.3MB)
 |       # There will be additional versions in the future...
@@ -87,8 +84,7 @@ lib/vmm/
 
 ## Supported Versions
 
-- Cloud Hypervisor v48.0 (API v0.3.0)
-- Cloud Hypervisor v49.0 (API v0.3.0)
+- Cloud Hypervisor v50.1 (API v0.3.0)
 
 There may be additional versions in the future. Cloud hypervisor versions may update frequently, while the API updates less frequently.
 

--- a/lib/vmm/binaries_darwin.go
+++ b/lib/vmm/binaries_darwin.go
@@ -16,6 +16,8 @@ const (
 	V51_1 CHVersion = "v51.1"
 )
 
+const DefaultVersion = V49_0
+
 // SupportedVersions lists supported Cloud Hypervisor versions.
 // On macOS, Cloud Hypervisor is not supported (use vz instead).
 var SupportedVersions = []CHVersion{}

--- a/lib/vmm/binaries_darwin.go
+++ b/lib/vmm/binaries_darwin.go
@@ -12,7 +12,7 @@ import (
 type CHVersion string
 
 const (
-	V50_1 CHVersion = "v50.1"
+	V51_1 CHVersion = "v51.1"
 )
 
 // SupportedVersions lists supported Cloud Hypervisor versions.

--- a/lib/vmm/binaries_darwin.go
+++ b/lib/vmm/binaries_darwin.go
@@ -12,8 +12,7 @@ import (
 type CHVersion string
 
 const (
-	V48_0 CHVersion = "v48.0"
-	V49_0 CHVersion = "v49.0"
+	V50_1 CHVersion = "v50.1"
 )
 
 // SupportedVersions lists supported Cloud Hypervisor versions.

--- a/lib/vmm/binaries_darwin.go
+++ b/lib/vmm/binaries_darwin.go
@@ -12,6 +12,7 @@ import (
 type CHVersion string
 
 const (
+	V49_0 CHVersion = "v49.0"
 	V51_1 CHVersion = "v51.1"
 )
 

--- a/lib/vmm/binaries_linux.go
+++ b/lib/vmm/binaries_linux.go
@@ -13,17 +13,17 @@ import (
 	"github.com/kernel/hypeman/lib/paths"
 )
 
-//go:embed binaries/cloud-hypervisor/v50.1/x86_64/cloud-hypervisor
-//go:embed binaries/cloud-hypervisor/v50.1/aarch64/cloud-hypervisor
+//go:embed binaries/cloud-hypervisor/v51.1/x86_64/cloud-hypervisor
+//go:embed binaries/cloud-hypervisor/v51.1/aarch64/cloud-hypervisor
 var binaryFS embed.FS
 
 type CHVersion string
 
 const (
-	V50_1 CHVersion = "v50.1"
+	V51_1 CHVersion = "v51.1"
 )
 
-var SupportedVersions = []CHVersion{V50_1}
+var SupportedVersions = []CHVersion{V51_1}
 
 // ExtractBinary extracts the embedded Cloud Hypervisor binary to the data directory
 func ExtractBinary(p *paths.Paths, version CHVersion) (string, error) {

--- a/lib/vmm/binaries_linux.go
+++ b/lib/vmm/binaries_linux.go
@@ -26,6 +26,8 @@ const (
 	V51_1 CHVersion = "v51.1"
 )
 
+const DefaultVersion = V49_0
+
 var SupportedVersions = []CHVersion{V49_0, V51_1}
 
 // ExtractBinary extracts the embedded Cloud Hypervisor binary to the data directory

--- a/lib/vmm/binaries_linux.go
+++ b/lib/vmm/binaries_linux.go
@@ -13,6 +13,8 @@ import (
 	"github.com/kernel/hypeman/lib/paths"
 )
 
+//go:embed binaries/cloud-hypervisor/v49.0/x86_64/cloud-hypervisor
+//go:embed binaries/cloud-hypervisor/v49.0/aarch64/cloud-hypervisor
 //go:embed binaries/cloud-hypervisor/v51.1/x86_64/cloud-hypervisor
 //go:embed binaries/cloud-hypervisor/v51.1/aarch64/cloud-hypervisor
 var binaryFS embed.FS
@@ -20,10 +22,11 @@ var binaryFS embed.FS
 type CHVersion string
 
 const (
+	V49_0 CHVersion = "v49.0"
 	V51_1 CHVersion = "v51.1"
 )
 
-var SupportedVersions = []CHVersion{V51_1}
+var SupportedVersions = []CHVersion{V49_0, V51_1}
 
 // ExtractBinary extracts the embedded Cloud Hypervisor binary to the data directory
 func ExtractBinary(p *paths.Paths, version CHVersion) (string, error) {

--- a/lib/vmm/binaries_linux.go
+++ b/lib/vmm/binaries_linux.go
@@ -13,20 +13,17 @@ import (
 	"github.com/kernel/hypeman/lib/paths"
 )
 
-//go:embed binaries/cloud-hypervisor/v48.0/x86_64/cloud-hypervisor
-//go:embed binaries/cloud-hypervisor/v48.0/aarch64/cloud-hypervisor
-//go:embed binaries/cloud-hypervisor/v49.0/x86_64/cloud-hypervisor
-//go:embed binaries/cloud-hypervisor/v49.0/aarch64/cloud-hypervisor
+//go:embed binaries/cloud-hypervisor/v50.1/x86_64/cloud-hypervisor
+//go:embed binaries/cloud-hypervisor/v50.1/aarch64/cloud-hypervisor
 var binaryFS embed.FS
 
 type CHVersion string
 
 const (
-	V48_0 CHVersion = "v48.0"
-	V49_0 CHVersion = "v49.0"
+	V50_1 CHVersion = "v50.1"
 )
 
-var SupportedVersions = []CHVersion{V48_0, V49_0}
+var SupportedVersions = []CHVersion{V50_1}
 
 // ExtractBinary extracts the embedded Cloud Hypervisor binary to the data directory
 func ExtractBinary(p *paths.Paths, version CHVersion) (string, error) {

--- a/lib/vmm/client_test.go
+++ b/lib/vmm/client_test.go
@@ -16,8 +16,8 @@ import (
 func TestExtractBinary(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Test extraction for v48.0
-	binaryPath, err := ExtractBinary(paths.New(tmpDir), V48_0)
+	// Test extraction for v50.1
+	binaryPath, err := ExtractBinary(paths.New(tmpDir), V50_1)
 	require.NoError(t, err)
 
 	// Verify file exists
@@ -30,14 +30,13 @@ func TestExtractBinary(t *testing.T) {
 	assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
 
 	// Test idempotency - second extraction should succeed and return same path
-	binaryPath2, err := ExtractBinary(paths.New(tmpDir), V48_0)
+	binaryPath2, err := ExtractBinary(paths.New(tmpDir), V50_1)
 	require.NoError(t, err)
 	assert.Equal(t, binaryPath, binaryPath2)
 }
 
 func TestIsVersionSupported(t *testing.T) {
-	assert.True(t, IsVersionSupported(V48_0))
-	assert.True(t, IsVersionSupported(V49_0))
+	assert.True(t, IsVersionSupported(V50_1))
 	assert.False(t, IsVersionSupported("v1.0"))
 }
 
@@ -45,13 +44,13 @@ func TestParseVersion(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Extract binary
-	binaryPath, err := ExtractBinary(paths.New(tmpDir), V48_0)
+	binaryPath, err := ExtractBinary(paths.New(tmpDir), V50_1)
 	require.NoError(t, err)
 
 	// Parse version
 	version, err := ParseVersion(binaryPath)
 	require.NoError(t, err)
-	assert.Equal(t, V48_0, version)
+	assert.Equal(t, V50_1, version)
 }
 
 func TestStartProcessAndShutdown(t *testing.T) {
@@ -60,7 +59,7 @@ func TestStartProcessAndShutdown(t *testing.T) {
 	ctx := context.Background()
 
 	// Start VMM process
-	pid, err := StartProcess(ctx, paths.New(tmpDir), V48_0, socketPath)
+	pid, err := StartProcess(ctx, paths.New(tmpDir), V50_1, socketPath)
 	require.NoError(t, err)
 	assert.Greater(t, pid, 0, "PID should be positive")
 
@@ -95,12 +94,12 @@ func TestStartProcessSocketInUse(t *testing.T) {
 	ctx := context.Background()
 
 	// Start first VMM
-	pid, err := StartProcess(ctx, paths.New(tmpDir), V48_0, socketPath)
+	pid, err := StartProcess(ctx, paths.New(tmpDir), V50_1, socketPath)
 	require.NoError(t, err)
 	assert.Greater(t, pid, 0)
 
 	// Try to start second VMM on same socket - should fail
-	_, err = StartProcess(ctx, paths.New(tmpDir), V48_0, socketPath)
+	_, err = StartProcess(ctx, paths.New(tmpDir), V50_1, socketPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "socket already in use")
 
@@ -118,8 +117,7 @@ func TestMultipleVersions(t *testing.T) {
 		name    string
 		version CHVersion
 	}{
-		{"v48.0", V48_0},
-		{"v49.0", V49_0},
+		{"v50.1", V50_1},
 	}
 
 	for _, tt := range tests {
@@ -159,7 +157,7 @@ func TestStartProcessCreatesLogFiles(t *testing.T) {
 	ctx := context.Background()
 
 	// Start VMM process with verbose logging to ensure output is written
-	pid, err := StartProcessWithArgs(ctx, paths.New(tmpDir), V48_0, socketPath, []string{"-v"})
+	pid, err := StartProcessWithArgs(ctx, paths.New(tmpDir), V50_1, socketPath, []string{"-v"})
 	require.NoError(t, err)
 	assert.Greater(t, pid, 0)
 

--- a/lib/vmm/client_test.go
+++ b/lib/vmm/client_test.go
@@ -36,6 +36,7 @@ func TestExtractBinary(t *testing.T) {
 }
 
 func TestIsVersionSupported(t *testing.T) {
+	assert.True(t, IsVersionSupported(V49_0))
 	assert.True(t, IsVersionSupported(V51_1))
 	assert.False(t, IsVersionSupported("v1.0"))
 }
@@ -117,6 +118,7 @@ func TestMultipleVersions(t *testing.T) {
 		name    string
 		version CHVersion
 	}{
+		{"v49.0", V49_0},
 		{"v51.1", V51_1},
 	}
 

--- a/lib/vmm/client_test.go
+++ b/lib/vmm/client_test.go
@@ -16,8 +16,8 @@ import (
 func TestExtractBinary(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Test extraction for v50.1
-	binaryPath, err := ExtractBinary(paths.New(tmpDir), V50_1)
+	// Test extraction for v51.1
+	binaryPath, err := ExtractBinary(paths.New(tmpDir), V51_1)
 	require.NoError(t, err)
 
 	// Verify file exists
@@ -30,13 +30,13 @@ func TestExtractBinary(t *testing.T) {
 	assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
 
 	// Test idempotency - second extraction should succeed and return same path
-	binaryPath2, err := ExtractBinary(paths.New(tmpDir), V50_1)
+	binaryPath2, err := ExtractBinary(paths.New(tmpDir), V51_1)
 	require.NoError(t, err)
 	assert.Equal(t, binaryPath, binaryPath2)
 }
 
 func TestIsVersionSupported(t *testing.T) {
-	assert.True(t, IsVersionSupported(V50_1))
+	assert.True(t, IsVersionSupported(V51_1))
 	assert.False(t, IsVersionSupported("v1.0"))
 }
 
@@ -44,13 +44,13 @@ func TestParseVersion(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Extract binary
-	binaryPath, err := ExtractBinary(paths.New(tmpDir), V50_1)
+	binaryPath, err := ExtractBinary(paths.New(tmpDir), V51_1)
 	require.NoError(t, err)
 
 	// Parse version
 	version, err := ParseVersion(binaryPath)
 	require.NoError(t, err)
-	assert.Equal(t, V50_1, version)
+	assert.Equal(t, V51_1, version)
 }
 
 func TestStartProcessAndShutdown(t *testing.T) {
@@ -59,7 +59,7 @@ func TestStartProcessAndShutdown(t *testing.T) {
 	ctx := context.Background()
 
 	// Start VMM process
-	pid, err := StartProcess(ctx, paths.New(tmpDir), V50_1, socketPath)
+	pid, err := StartProcess(ctx, paths.New(tmpDir), V51_1, socketPath)
 	require.NoError(t, err)
 	assert.Greater(t, pid, 0, "PID should be positive")
 
@@ -94,12 +94,12 @@ func TestStartProcessSocketInUse(t *testing.T) {
 	ctx := context.Background()
 
 	// Start first VMM
-	pid, err := StartProcess(ctx, paths.New(tmpDir), V50_1, socketPath)
+	pid, err := StartProcess(ctx, paths.New(tmpDir), V51_1, socketPath)
 	require.NoError(t, err)
 	assert.Greater(t, pid, 0)
 
 	// Try to start second VMM on same socket - should fail
-	_, err = StartProcess(ctx, paths.New(tmpDir), V50_1, socketPath)
+	_, err = StartProcess(ctx, paths.New(tmpDir), V51_1, socketPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "socket already in use")
 
@@ -117,7 +117,7 @@ func TestMultipleVersions(t *testing.T) {
 		name    string
 		version CHVersion
 	}{
-		{"v50.1", V50_1},
+		{"v51.1", V51_1},
 	}
 
 	for _, tt := range tests {
@@ -157,7 +157,7 @@ func TestStartProcessCreatesLogFiles(t *testing.T) {
 	ctx := context.Background()
 
 	// Start VMM process with verbose logging to ensure output is written
-	pid, err := StartProcessWithArgs(ctx, paths.New(tmpDir), V50_1, socketPath, []string{"-v"})
+	pid, err := StartProcessWithArgs(ctx, paths.New(tmpDir), V51_1, socketPath, []string{"-v"})
 	require.NoError(t, err)
 	assert.Greater(t, pid, 0)
 

--- a/lib/vmm/version.go
+++ b/lib/vmm/version.go
@@ -3,15 +3,12 @@ package vmm
 import (
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strings"
 )
 
-// versionRegex extracts a vN.N or vN.N.N version tag from --version output.
-var versionRegex = regexp.MustCompile(`v\d+\.\d+(?:\.\d+)?`)
-
 // ParseVersion extracts version from cloud-hypervisor --version output
-// and matches it against SupportedVersions.
+// and matches it against SupportedVersions. Checks longer version strings
+// first so "v49.0.1" doesn't falsely match "v49.0".
 func ParseVersion(binaryPath string) (CHVersion, error) {
 	cmd := exec.Command(binaryPath, "--version")
 	output, err := cmd.Output()
@@ -21,16 +18,28 @@ func ParseVersion(binaryPath string) (CHVersion, error) {
 
 	versionStr := strings.TrimSpace(string(output))
 
-	match := versionRegex.FindString(versionStr)
-	if match != "" {
-		for _, v := range SupportedVersions {
-			if match == string(v) {
-				return v, nil
-			}
+	// Match against supported versions, longest first to avoid
+	// "v49.0" matching inside "v49.0.1".
+	for _, v := range sortedByLengthDesc(SupportedVersions) {
+		if strings.Contains(versionStr, string(v)) {
+			return v, nil
 		}
 	}
 
 	return "", fmt.Errorf("unsupported version: %s", versionStr)
+}
+
+func sortedByLengthDesc(versions []CHVersion) []CHVersion {
+	sorted := make([]CHVersion, len(versions))
+	copy(sorted, versions)
+	for i := 0; i < len(sorted); i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			if len(sorted[j]) > len(sorted[i]) {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+	return sorted
 }
 
 // IsVersionSupported checks if a version is supported by this library

--- a/lib/vmm/version.go
+++ b/lib/vmm/version.go
@@ -20,8 +20,8 @@ func ParseVersion(binaryPath string) (CHVersion, error) {
 	versionStr := strings.TrimSpace(string(output))
 
 	// Try to match known versions
-	if strings.Contains(versionStr, "v50.1") {
-		return V50_1, nil
+	if strings.Contains(versionStr, "v51.1") {
+		return V51_1, nil
 	}
 
 	return "", fmt.Errorf("unsupported version: %s", versionStr)

--- a/lib/vmm/version.go
+++ b/lib/vmm/version.go
@@ -23,6 +23,9 @@ func ParseVersion(binaryPath string) (CHVersion, error) {
 	if strings.Contains(versionStr, "v51.1") {
 		return V51_1, nil
 	}
+	if strings.Contains(versionStr, "v49.0") {
+		return V49_0, nil
+	}
 
 	return "", fmt.Errorf("unsupported version: %s", versionStr)
 }

--- a/lib/vmm/version.go
+++ b/lib/vmm/version.go
@@ -20,11 +20,8 @@ func ParseVersion(binaryPath string) (CHVersion, error) {
 	versionStr := strings.TrimSpace(string(output))
 
 	// Try to match known versions
-	if strings.Contains(versionStr, "v48.0") {
-		return V48_0, nil
-	}
-	if strings.Contains(versionStr, "v49.0") {
-		return V49_0, nil
+	if strings.Contains(versionStr, "v50.1") {
+		return V50_1, nil
 	}
 
 	return "", fmt.Errorf("unsupported version: %s", versionStr)

--- a/lib/vmm/version.go
+++ b/lib/vmm/version.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 )
 
-var versionRegex = regexp.MustCompile(`v(\d+)\.(\d+)\.(\d+)`)
+// versionRegex extracts a vN.N or vN.N.N version tag from --version output.
+var versionRegex = regexp.MustCompile(`v\d+\.\d+(?:\.\d+)?`)
 
 // ParseVersion extracts version from cloud-hypervisor --version output
+// and matches it against SupportedVersions.
 func ParseVersion(binaryPath string) (CHVersion, error) {
 	cmd := exec.Command(binaryPath, "--version")
 	output, err := cmd.Output()
@@ -19,12 +21,13 @@ func ParseVersion(binaryPath string) (CHVersion, error) {
 
 	versionStr := strings.TrimSpace(string(output))
 
-	// Try to match known versions
-	if strings.Contains(versionStr, "v51.1") {
-		return V51_1, nil
-	}
-	if strings.Contains(versionStr, "v49.0") {
-		return V49_0, nil
+	match := versionRegex.FindString(versionStr)
+	if match != "" {
+		for _, v := range SupportedVersions {
+			if match == string(v) {
+				return v, nil
+			}
+		}
 	}
 
 	return "", fmt.Errorf("unsupported version: %s", versionStr)

--- a/lib/vmm/vmm.go
+++ b/lib/vmm/vmm.go
@@ -38,6 +38,7 @@ const (
 	FixedVhd DiskConfigImageType = "FixedVhd"
 	Qcow2    DiskConfigImageType = "Qcow2"
 	Raw      DiskConfigImageType = "Raw"
+	Unknown  DiskConfigImageType = "Unknown"
 	Vhdx     DiskConfigImageType = "Vhdx"
 )
 
@@ -146,6 +147,7 @@ type DiskConfig struct {
 	RateLimiterConfig *RateLimiterConfig `json:"rate_limiter_config,omitempty"`
 	Readonly          *bool              `json:"readonly,omitempty"`
 	Serial            *string            `json:"serial,omitempty"`
+	Sparse            *bool              `json:"sparse,omitempty"`
 	VhostSocket       *string            `json:"vhost_socket,omitempty"`
 	VhostUser         *bool              `json:"vhost_user,omitempty"`
 }
@@ -230,6 +232,7 @@ type NetConfig struct {
 // NumaConfig defines model for NumaConfig.
 type NumaConfig struct {
 	Cpus        *[]int32        `json:"cpus,omitempty"`
+	DeviceId    *string         `json:"device_id,omitempty"`
 	Distances   *[]NumaDistance `json:"distances,omitempty"`
 	GuestNumaId int32           `json:"guest_numa_id"`
 	MemoryZones *[]string       `json:"memory_zones,omitempty"`

--- a/lib/vmm/vmm.go
+++ b/lib/vmm/vmm.go
@@ -33,6 +33,14 @@ const (
 	DebugConsoleConfigModeTty  DebugConsoleConfigMode = "Tty"
 )
 
+// Defines values for DiskConfigImageType.
+const (
+	FixedVhd DiskConfigImageType = "FixedVhd"
+	Qcow2    DiskConfigImageType = "Qcow2"
+	Raw      DiskConfigImageType = "Raw"
+	Vhdx     DiskConfigImageType = "Vhdx"
+)
+
 // Defines values for VmInfoState.
 const (
 	Created  VmInfoState = "Created"
@@ -89,6 +97,7 @@ type CpusConfig struct {
 	KvmHyperv   *bool          `json:"kvm_hyperv,omitempty"`
 	MaxPhysBits *int           `json:"max_phys_bits,omitempty"`
 	MaxVcpus    int            `json:"max_vcpus"`
+	Nested      *bool          `json:"nested,omitempty"`
 	Topology    *CpuTopology   `json:"topology,omitempty"`
 }
 
@@ -121,8 +130,10 @@ type DeviceNode struct {
 
 // DiskConfig defines model for DiskConfig.
 type DiskConfig struct {
+	BackingFiles   *bool                `json:"backing_files,omitempty"`
 	Direct         *bool                `json:"direct,omitempty"`
 	Id             *string              `json:"id,omitempty"`
+	ImageType      *DiskConfigImageType `json:"image_type,omitempty"`
 	Iommu          *bool                `json:"iommu,omitempty"`
 	NumQueues      *int                 `json:"num_queues,omitempty"`
 	Path           *string              `json:"path,omitempty"`
@@ -138,6 +149,9 @@ type DiskConfig struct {
 	VhostSocket       *string            `json:"vhost_socket,omitempty"`
 	VhostUser         *bool              `json:"vhost_user,omitempty"`
 }
+
+// DiskConfigImageType defines model for DiskConfig.ImageType.
+type DiskConfigImageType string
 
 // FsConfig defines model for FsConfig.
 type FsConfig struct {
@@ -196,11 +210,14 @@ type NetConfig struct {
 	Mac *string `json:"mac,omitempty"`
 
 	// Mask Must be a valid IPv4 netmask if ip is an IPv4 address or a valid IPv6 netmask if ip is an IPv6 address.
-	Mask       *string `json:"mask,omitempty"`
-	Mtu        *int    `json:"mtu,omitempty"`
-	NumQueues  *int    `json:"num_queues,omitempty"`
-	PciSegment *int16  `json:"pci_segment,omitempty"`
-	QueueSize  *int    `json:"queue_size,omitempty"`
+	Mask        *string `json:"mask,omitempty"`
+	Mtu         *int    `json:"mtu,omitempty"`
+	NumQueues   *int    `json:"num_queues,omitempty"`
+	OffloadCsum *bool   `json:"offload_csum,omitempty"`
+	OffloadTso  *bool   `json:"offload_tso,omitempty"`
+	OffloadUfo  *bool   `json:"offload_ufo,omitempty"`
+	PciSegment  *int16  `json:"pci_segment,omitempty"`
+	QueueSize   *int    `json:"queue_size,omitempty"`
 
 	// RateLimiterConfig Defines an IO rate limiter with independent bytes/s and ops/s limits. Limits are defined by configuring each of the _bandwidth_ and _ops_ token buckets.
 	RateLimiterConfig *RateLimiterConfig `json:"rate_limiter_config,omitempty"`
@@ -413,6 +430,15 @@ type VmResize struct {
 	DesiredVcpus *int   `json:"desired_vcpus,omitempty"`
 }
 
+// VmResizeDisk defines model for VmResizeDisk.
+type VmResizeDisk struct {
+	// DesiredSize desired disk size in bytes
+	DesiredSize *int64 `json:"desired_size,omitempty"`
+
+	// Id disk identifier
+	Id *string `json:"id,omitempty"`
+}
+
 // VmResizeZone defines model for VmResizeZone.
 type VmResizeZone struct {
 	// DesiredRam desired memory zone size in bytes
@@ -483,6 +509,9 @@ type PutVmRemoveDeviceJSONRequestBody = VmRemoveDevice
 
 // PutVmResizeJSONRequestBody defines body for PutVmResize for application/json ContentType.
 type PutVmResizeJSONRequestBody = VmResize
+
+// PutVmResizeDiskJSONRequestBody defines body for PutVmResizeDisk for application/json ContentType.
+type PutVmResizeDiskJSONRequestBody = VmResizeDisk
 
 // PutVmResizeZoneJSONRequestBody defines body for PutVmResizeZone for application/json ContentType.
 type PutVmResizeZoneJSONRequestBody = VmResizeZone
@@ -654,6 +683,11 @@ type ClientInterface interface {
 	PutVmResizeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	PutVmResize(ctx context.Context, body PutVmResizeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PutVmResizeDiskWithBody request with any body
+	PutVmResizeDiskWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PutVmResizeDisk(ctx context.Context, body PutVmResizeDiskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PutVmResizeZoneWithBody request with any body
 	PutVmResizeZoneWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1077,6 +1111,30 @@ func (c *Client) PutVmResizeWithBody(ctx context.Context, contentType string, bo
 
 func (c *Client) PutVmResize(ctx context.Context, body PutVmResizeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPutVmResizeRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PutVmResizeDiskWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutVmResizeDiskRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PutVmResizeDisk(ctx context.Context, body PutVmResizeDiskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutVmResizeDiskRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1952,6 +2010,46 @@ func NewPutVmResizeRequestWithBody(server string, contentType string, body io.Re
 	return req, nil
 }
 
+// NewPutVmResizeDiskRequest calls the generic PutVmResizeDisk builder with application/json body
+func NewPutVmResizeDiskRequest(server string, body PutVmResizeDiskJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPutVmResizeDiskRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPutVmResizeDiskRequestWithBody generates requests for PutVmResizeDisk with any type of body
+func NewPutVmResizeDiskRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/vm.resize-disk")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewPutVmResizeZoneRequest calls the generic PutVmResizeZone builder with application/json body
 func NewPutVmResizeZoneRequest(server string, body PutVmResizeZoneJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -2375,6 +2473,11 @@ type ClientWithResponsesInterface interface {
 	PutVmResizeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutVmResizeResponse, error)
 
 	PutVmResizeWithResponse(ctx context.Context, body PutVmResizeJSONRequestBody, reqEditors ...RequestEditorFn) (*PutVmResizeResponse, error)
+
+	// PutVmResizeDiskWithBodyWithResponse request with any body
+	PutVmResizeDiskWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutVmResizeDiskResponse, error)
+
+	PutVmResizeDiskWithResponse(ctx context.Context, body PutVmResizeDiskJSONRequestBody, reqEditors ...RequestEditorFn) (*PutVmResizeDiskResponse, error)
 
 	// PutVmResizeZoneWithBodyWithResponse request with any body
 	PutVmResizeZoneWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutVmResizeZoneResponse, error)
@@ -2836,6 +2939,27 @@ func (r PutVmResizeResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PutVmResizeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PutVmResizeDiskResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r PutVmResizeDiskResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PutVmResizeDiskResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -3314,6 +3438,23 @@ func (c *ClientWithResponses) PutVmResizeWithResponse(ctx context.Context, body 
 		return nil, err
 	}
 	return ParsePutVmResizeResponse(rsp)
+}
+
+// PutVmResizeDiskWithBodyWithResponse request with arbitrary body returning *PutVmResizeDiskResponse
+func (c *ClientWithResponses) PutVmResizeDiskWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutVmResizeDiskResponse, error) {
+	rsp, err := c.PutVmResizeDiskWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutVmResizeDiskResponse(rsp)
+}
+
+func (c *ClientWithResponses) PutVmResizeDiskWithResponse(ctx context.Context, body PutVmResizeDiskJSONRequestBody, reqEditors ...RequestEditorFn) (*PutVmResizeDiskResponse, error) {
+	rsp, err := c.PutVmResizeDisk(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutVmResizeDiskResponse(rsp)
 }
 
 // PutVmResizeZoneWithBodyWithResponse request with arbitrary body returning *PutVmResizeZoneResponse
@@ -3842,6 +3983,22 @@ func ParsePutVmResizeResponse(rsp *http.Response) (*PutVmResizeResponse, error) 
 	}
 
 	response := &PutVmResizeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParsePutVmResizeDiskResponse parses an HTTP response from a PutVmResizeDiskWithResponse call
+func ParsePutVmResizeDiskResponse(rsp *http.Response) (*PutVmResizeDiskResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PutVmResizeDiskResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/specs/cloud-hypervisor/api-v0.3.0/cloud-hypervisor.yaml
+++ b/specs/cloud-hypervisor/api-v0.3.0/cloud-hypervisor.yaml
@@ -944,13 +944,12 @@ components:
         backing_files:
           type: boolean
           default: false
+        sparse:
+          type: boolean
+          default: true
         image_type:
           type: string
-          enum:
-            - FixedVhd
-            - Qcow2
-            - Raw
-            - Vhdx
+          enum: [FixedVhd, Qcow2, Raw, Vhdx, Unknown]
 
 
     NetConfig:
@@ -1217,6 +1216,8 @@ components:
           items:
             type: integer
             format: int32
+        device_id:
+          type: string
 
     VmResize:
       type: object

--- a/specs/cloud-hypervisor/api-v0.3.0/cloud-hypervisor.yaml
+++ b/specs/cloud-hypervisor/api-v0.3.0/cloud-hypervisor.yaml
@@ -163,6 +163,22 @@ paths:
         429:
           description: The VM instance could not be resized because a cpu removal is still pending.
 
+  /vm.resize-disk:
+    put:
+      summary: Resize a disk
+      requestBody:
+        description: Resizes a disk attached to the VM
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VmResizeDisk"
+        required: true
+      responses:
+        204:
+          description: The disk was successfully resized.
+        500:
+          description: The disk could not be resized.
+
   /vm.resize-zone:
     put:
       summary: Resize a memory zone
@@ -687,6 +703,9 @@ components:
           default: false
         max_phys_bits:
           type: integer
+        nested:
+          type: boolean
+          default: true
         affinity:
           type: array
           items:
@@ -922,6 +941,17 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/VirtQueueAffinity"
+        backing_files:
+          type: boolean
+          default: false
+        image_type:
+          type: string
+          enum:
+            - FixedVhd
+            - Qcow2
+            - Raw
+            - Vhdx
+
 
     NetConfig:
       type: object
@@ -966,6 +996,15 @@ components:
           format: int16
         rate_limiter_config:
           $ref: "#/components/schemas/RateLimiterConfig"
+        offload_tso:
+          type: boolean
+          default: true
+        offload_ufo:
+          type: boolean
+          default: true
+        offload_csum:
+          type: boolean
+          default: true
 
     RngConfig:
       required:
@@ -1191,6 +1230,17 @@ components:
           format: int64
         desired_balloon:
           description: desired balloon size in bytes
+          type: integer
+          format: int64
+
+    VmResizeDisk:
+      type: object
+      properties:
+        id:
+          description: disk identifier
+          type: string
+        desired_size:
+          description: desired disk size in bytes
           type: integer
           format: int64
 


### PR DESCRIPTION
## Summary

Adds Cloud Hypervisor v51.1 alongside existing v49.0 with a config flag to control which version new instances use. This enables a safe, no-downtime upgrade path for CVE-2026-27211.

### What changed

- **Both v49.0 and v51.1 binaries are embedded** -- no need to drain standby instances before deploy
- **New config flag**: `hypervisor.cloud_hypervisor_version` (default: `v49.0`)
  - Env override: `HYPERVISOR__CLOUD_HYPERVISOR_VERSION=v51.1`
- Existing standby instances restore using their stored version (already the case)
- New instances use whichever version the flag is set to
- VMM client regenerated from v51.1 OpenAPI spec with `ImageType: Raw` on all disks (CVE fix)

### Upgrade path

1. Deploy this PR -- all instances continue on v49.0, no disruption
2. When ready, set `HYPERVISOR__CLOUD_HYPERVISOR_VERSION=v51.1`
3. New instances get v51.1; existing standbys still restore on v49.0
4. Once all v49.0 standbys have expired, v49.0 can be removed in a follow-up

### Security fix (CVE-2026-27211)

Fixes GHSA-jmr4-g2hv-mjj6: arbitrary host file exfiltration via crafted QCOW2 disk headers. Affects CH versions 34.0 through 50.0. Fixed in 50.1+.

v51.1 additionally includes:
- QCOW2 v3 improvements (live resize, variable refcount, dirty bit)
- DISCARD/WRITE_ZEROES support for virtio-blk
- THP for anonymous shared memory (performance)
- ACPI NUMA affinity for VFIO-PCI (GPU passthrough)

### Files changed

- `Makefile` -- download both v49.0 and v51.1 binaries
- `cmd/api/config/config.go` -- add `cloud_hypervisor_version` field (default `v49.0`)
- `lib/vmm/binaries_linux.go` -- embed both v49.0 and v51.1
- `lib/vmm/binaries_darwin.go` -- version constants for compile compat
- `lib/vmm/version.go` -- ParseVersion matches both versions
- `lib/vmm/vmm.go` -- regenerated from v51.1 OpenAPI spec
- `lib/vmm/client_test.go` -- tests for both versions
- `lib/hypervisor/cloudhypervisor/process.go` -- SetDefaultVersion/GetDefaultVersion, configurable GetVersion
- `lib/hypervisor/cloudhypervisor/config.go` -- ImageType: Raw on all disks (CVE fix, safe for v49.0)
- `lib/providers/providers.go` -- wire config flag at startup
- `lib/instances/version_upgrade_test.go` -- **new E2E test**: create v49.0 -> standby -> switch to v51.1 -> restore -> verify version preserved -> create new instance on v51.1

### Test plan

- `go build ./lib/vmm/... ./lib/hypervisor/cloudhypervisor/...`
- `go vet` clean
- `go test ./lib/vmm/...` -- both versions extract and start
- `go test ./lib/hypervisor/cloudhypervisor/...` passes
- `TestCloudHypervisorVersionUpgradeRestore` -- standby/restore across version change
- Full `go test ./lib/instances/...` (requires KVM, CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Cloud Hypervisor binary can be selected for new VM instances and updates the generated VMM API client; mistakes could break VM start/restore or lead to mismatched snapshot restores across versions.
> 
> **Overview**
> Adds Cloud Hypervisor `v51.1` as an additional embedded VMM binary (keeping `v49.0`) and updates build tooling to download/ensure both versions, enabling backwards-compatible upgrades.
> 
> Introduces a new config field `hypervisor.cloud_hypervisor_default_version` and runtime override (`cloudhypervisor.SetDefaultVersion`/`GetDefaultVersion`) so **new instances** can use a chosen CH version, while **existing instances** continue to restore using the version stored in metadata; `CreateInstanceRequest` now supports an explicit `HypervisorVersion` with validation.
> 
> Regenerates the Cloud Hypervisor OpenAPI client/spec from `v51.1` (including `/vm.resize-disk` and new schema fields) and sets CH disk `ImageType` to `Raw` in VM config generation; adds version-aware capabilities (e.g., disk resize on `v51.1`) and an integration test covering standby/restore across a default-version flip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e68205b40be49254ee6f4a1a7dfb0c71c7d2c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->