### PR TITLE
ci: notify Slack when release workflow fails

### DIFF
--- a/.github/workflows/_notify-slack.yml
+++ b/.github/workflows/_notify-slack.yml
@@ -1,0 +1,21 @@
+name: Notify Slack on deploy failure
+
+on:
+  workflow_call:
+    secrets:
+      SLACK_DEPLOY_WEBHOOK_URL:
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: *${{ github.workflow }}* failed on `${{ github.repository }}@${{ github.ref_name }}` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>"
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,9 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-on-failure:
+    needs: [release]
+    if: ${{ failure() }}
+    uses: ./.github/workflows/_notify-slack.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds reusable workflow `.github/workflows/_notify-slack.yml` that posts a failure notification via incoming webhook (`SLACK_DEPLOY_WEBHOOK_URL` secret).
- Wires it into `release.yml` as a `notify-on-failure` job that runs only when the release job failed.

## Setup required
- Create a Slack incoming webhook (or reuse the same one used by `kernel/kernel` and `kernel/infra`).
- Add it as repo (or org) secret `SLACK_DEPLOY_WEBHOOK_URL`.

## Test plan
- [ ] Add `SLACK_DEPLOY_WEBHOOK_URL` secret
- [ ] Force a release failure (push a bad tag), confirm Slack message arrives
- [ ] Trigger a successful release, confirm no notification fires