### PR TITLE
Speed up instance name resolution

### DIFF
--- a/lib/dns/server.go
+++ b/lib/dns/server.go
@@ -37,12 +37,8 @@ const (
 // InstanceResolver provides instance IP resolution.
 // This interface is implemented by the instances package.
 type InstanceResolver interface {
-	// ResolveInstanceIP resolves an instance name or ID to its IP address.
+	// ResolveInstanceIP resolves an instance name or ID to its IP address for DNS.
 	ResolveInstanceIP(ctx context.Context, nameOrID string) (string, error)
-}
-
-type dnsInstanceResolver interface {
-	ResolveInstanceIPForDNS(ctx context.Context, nameOrID string) (string, error)
 }
 
 // Server provides DNS-based instance resolution for Caddy.
@@ -184,13 +180,7 @@ func (s *Server) handleAQuery(m *dns.Msg, q dns.Question) {
 	ctx, cancel := context.WithTimeout(context.Background(), resolverTimeout)
 	defer cancel()
 
-	var ip string
-	var err error
-	if resolver, ok := s.resolver.(dnsInstanceResolver); ok {
-		ip, err = resolver.ResolveInstanceIPForDNS(ctx, instanceName)
-	} else {
-		ip, err = s.resolver.ResolveInstanceIP(ctx, instanceName)
-	}
+	ip, err := s.resolver.ResolveInstanceIP(ctx, instanceName)
 	if err != nil {
 		s.log.Debug("DNS resolution failed", "instance", instanceName, "error", err)
 		// Return NXDOMAIN by not adding any answer records

--- a/lib/dns/server.go
+++ b/lib/dns/server.go
@@ -41,6 +41,10 @@ type InstanceResolver interface {
 	ResolveInstanceIP(ctx context.Context, nameOrID string) (string, error)
 }
 
+type dnsInstanceResolver interface {
+	ResolveInstanceIPForDNS(ctx context.Context, nameOrID string) (string, error)
+}
+
 // Server provides DNS-based instance resolution for Caddy.
 // It listens on a local port and responds to A record queries
 // for instances in the form "<instance>.hypeman.internal".
@@ -180,7 +184,13 @@ func (s *Server) handleAQuery(m *dns.Msg, q dns.Question) {
 	ctx, cancel := context.WithTimeout(context.Background(), resolverTimeout)
 	defer cancel()
 
-	ip, err := s.resolver.ResolveInstanceIP(ctx, instanceName)
+	var ip string
+	var err error
+	if resolver, ok := s.resolver.(dnsInstanceResolver); ok {
+		ip, err = resolver.ResolveInstanceIPForDNS(ctx, instanceName)
+	} else {
+		ip, err = s.resolver.ResolveInstanceIP(ctx, instanceName)
+	}
 	if err != nil {
 		s.log.Debug("DNS resolution failed", "instance", instanceName, "error", err)
 		// Return NXDOMAIN by not adding any answer records

--- a/lib/instances/fork.go
+++ b/lib/instances/fork.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -366,25 +365,6 @@ func validateForkVolumeSafety(volumes []VolumeAttachment) error {
 		}
 	}
 	return nil
-}
-
-func (m *manager) instanceNameExists(name string) (bool, error) {
-	metaFiles, err := m.listMetadataFiles()
-	if err != nil {
-		return false, err
-	}
-
-	for _, metaFile := range metaFiles {
-		id := filepath.Base(filepath.Dir(metaFile))
-		meta, err := m.loadMetadata(id)
-		if err != nil {
-			continue
-		}
-		if meta.Name == name {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 func resolveForkTargetState(requested State, sourceState State) (State, error) {

--- a/lib/instances/ingress_resolver.go
+++ b/lib/instances/ingress_resolver.go
@@ -25,21 +25,9 @@ func NewIngressResolver(manager Manager) *IngressResolver {
 
 // ResolveInstanceIP resolves an instance name, ID, or ID prefix to its IP address.
 func (r *IngressResolver) ResolveInstanceIP(ctx context.Context, nameOrID string) (string, error) {
-	inst, err := r.manager.GetInstance(ctx, nameOrID)
-	if err != nil {
-		return "", fmt.Errorf("instance not found: %s", nameOrID)
-	}
-
-	return resolvedInstanceIP(inst, nameOrID)
-}
-
-// ResolveInstanceIPForDNS resolves an instance IP for DNS lookups.
-// DNS keeps exact ID/name behavior, but requires longer ID prefixes to avoid
-// accidental broad matches from short DNS labels.
-func (r *IngressResolver) ResolveInstanceIPForDNS(ctx context.Context, nameOrID string) (string, error) {
 	manager, ok := r.manager.(minPrefixInstanceManager)
 	if !ok {
-		return r.ResolveInstanceIP(ctx, nameOrID)
+		return "", fmt.Errorf("instance resolver does not support DNS-safe lookup")
 	}
 
 	inst, err := manager.getInstanceWithMinIDPrefix(ctx, nameOrID, dnsMinIDPrefixLength)
@@ -47,10 +35,6 @@ func (r *IngressResolver) ResolveInstanceIPForDNS(ctx context.Context, nameOrID 
 		return "", fmt.Errorf("instance not found: %s", nameOrID)
 	}
 
-	return resolvedInstanceIP(inst, nameOrID)
-}
-
-func resolvedInstanceIP(inst *Instance, nameOrID string) (string, error) {
 	// Check if instance has network enabled
 	if !inst.NetworkEnabled {
 		return "", fmt.Errorf("instance %s has no network configured", nameOrID)

--- a/lib/instances/ingress_resolver.go
+++ b/lib/instances/ingress_resolver.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 )
 
+const dnsMinIDPrefixLength = 8
+
 // IngressResolver provides instance resolution for the ingress package.
 // It implements ingress.InstanceResolver interface without importing the ingress package
 // to avoid import cycles.
 type IngressResolver struct {
 	manager Manager
+}
+
+type minPrefixInstanceManager interface {
+	getInstanceWithMinIDPrefix(ctx context.Context, idOrName string, minPrefixLength int) (*Instance, error)
 }
 
 // NewIngressResolver creates a new IngressResolver that wraps an instance manager.
@@ -24,6 +30,27 @@ func (r *IngressResolver) ResolveInstanceIP(ctx context.Context, nameOrID string
 		return "", fmt.Errorf("instance not found: %s", nameOrID)
 	}
 
+	return resolvedInstanceIP(inst, nameOrID)
+}
+
+// ResolveInstanceIPForDNS resolves an instance IP for DNS lookups.
+// DNS keeps exact ID/name behavior, but requires longer ID prefixes to avoid
+// accidental broad matches from short DNS labels.
+func (r *IngressResolver) ResolveInstanceIPForDNS(ctx context.Context, nameOrID string) (string, error) {
+	manager, ok := r.manager.(minPrefixInstanceManager)
+	if !ok {
+		return r.ResolveInstanceIP(ctx, nameOrID)
+	}
+
+	inst, err := manager.getInstanceWithMinIDPrefix(ctx, nameOrID, dnsMinIDPrefixLength)
+	if err != nil {
+		return "", fmt.Errorf("instance not found: %s", nameOrID)
+	}
+
+	return resolvedInstanceIP(inst, nameOrID)
+}
+
+func resolvedInstanceIP(inst *Instance, nameOrID string) (string, error) {
 	// Check if instance has network enabled
 	if !inst.NetworkEnabled {
 		return "", fmt.Errorf("instance %s has no network configured", nameOrID)

--- a/lib/instances/manager.go
+++ b/lib/instances/manager.go
@@ -299,6 +299,15 @@ func (m *manager) maybePersistBootMarkers(ctx context.Context, id string) {
 	m.persistBootMarkers(ctx, id)
 }
 
+func (m *manager) finalizeResolvedInstance(ctx context.Context, inst *Instance) {
+	if inst.State == StateStopped && inst.ExitCode != nil {
+		m.maybePersistExitInfo(ctx, inst.Id)
+	}
+	if (inst.State == StateRunning || inst.State == StateInitializing) && inst.BootMarkersHydrated {
+		m.maybePersistBootMarkers(ctx, inst.Id)
+	}
+}
+
 func (m *manager) recordImageUsage(ctx context.Context, imageInfo *images.Image) {
 	if m.imageUsageRecorder == nil || imageInfo == nil {
 		return
@@ -499,66 +508,36 @@ func (m *manager) ListInstances(ctx context.Context, filter *ListInstancesFilter
 // Lookup order: exact ID match -> exact name match -> ID prefix match.
 // Returns ErrAmbiguousName if prefix matches multiple instances.
 func (m *manager) GetInstance(ctx context.Context, idOrName string) (*Instance, error) {
+	return m.getInstanceWithMinIDPrefix(ctx, idOrName, 1)
+}
+
+func (m *manager) getInstanceWithMinIDPrefix(ctx context.Context, idOrName string, minPrefixLength int) (*Instance, error) {
 	// 1. Try exact ID match first (most common case)
 	lock := m.getInstanceLock(idOrName)
 	lock.RLock()
 	inst, err := m.getInstance(ctx, idOrName)
 	lock.RUnlock()
 	if err == nil {
-		// If VM is stopped with unpersisted exit info, persist under write lock.
-		// This handles the "app exited on its own" case where stopInstance wasn't called.
-		if inst.State == StateStopped && inst.ExitCode != nil {
-			m.maybePersistExitInfo(ctx, inst.Id)
-		}
-		if (inst.State == StateRunning || inst.State == StateInitializing) && inst.BootMarkersHydrated {
-			m.maybePersistBootMarkers(ctx, inst.Id)
-		}
+		m.finalizeResolvedInstance(ctx, inst)
 		return inst, nil
 	}
 
-	// 2. List all instances for name and prefix matching
-	instances, err := m.ListInstances(ctx, nil)
+	// 2. Resolve exact name or ID prefix from metadata only, then hydrate the
+	// single matched instance.
+	meta, err := m.findInstanceMetadataByNameOrIDPrefix(idOrName, minPrefixLength)
 	if err != nil {
 		return nil, err
 	}
 
-	// 3. Try exact name match
-	var nameMatches []Instance
-	for _, inst := range instances {
-		if inst.Name == idOrName {
-			nameMatches = append(nameMatches, inst)
-		}
+	resolvedLock := m.getInstanceLock(meta.Id)
+	resolvedLock.RLock()
+	inst, err = m.getInstance(ctx, meta.Id)
+	resolvedLock.RUnlock()
+	if err != nil {
+		return nil, err
 	}
-	if len(nameMatches) == 1 {
-		inst := &nameMatches[0]
-		if inst.State == StateStopped && inst.ExitCode != nil {
-			m.maybePersistExitInfo(ctx, inst.Id)
-		}
-		return inst, nil
-	}
-	if len(nameMatches) > 1 {
-		return nil, ErrAmbiguousName
-	}
-
-	// 4. Try ID prefix match
-	var prefixMatches []Instance
-	for _, inst := range instances {
-		if len(idOrName) > 0 && len(inst.Id) >= len(idOrName) && inst.Id[:len(idOrName)] == idOrName {
-			prefixMatches = append(prefixMatches, inst)
-		}
-	}
-	if len(prefixMatches) == 1 {
-		inst := &prefixMatches[0]
-		if inst.State == StateStopped && inst.ExitCode != nil {
-			m.maybePersistExitInfo(ctx, inst.Id)
-		}
-		return inst, nil
-	}
-	if len(prefixMatches) > 1 {
-		return nil, ErrAmbiguousName
-	}
-
-	return nil, ErrNotFound
+	m.finalizeResolvedInstance(ctx, inst)
+	return inst, nil
 }
 
 // StreamInstanceLogs streams instance logs from the specified source

--- a/lib/instances/query.go
+++ b/lib/instances/query.go
@@ -649,6 +649,87 @@ func (m *manager) listInstances(ctx context.Context) ([]Instance, error) {
 	return result, nil
 }
 
+func (m *manager) findInstanceMetadataByExactName(name string) (*metadata, error) {
+	files, err := m.listMetadataFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		id := filepath.Base(filepath.Dir(file))
+		meta, err := m.loadMetadata(id)
+		if err != nil {
+			continue
+		}
+		if meta.Name == name {
+			return meta, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *manager) findInstanceMetadataByNameOrIDPrefix(idOrName string, minPrefixLength int) (*metadata, error) {
+	files, err := m.listMetadataFiles()
+	if err != nil {
+		return nil, err
+	}
+	if minPrefixLength < 1 {
+		minPrefixLength = 1
+	}
+
+	var nameMatch *metadata
+	var prefixMatch *metadata
+	nameMatches := 0
+	prefixMatches := 0
+
+	for _, file := range files {
+		id := filepath.Base(filepath.Dir(file))
+		meta, err := m.loadMetadata(id)
+		if err != nil {
+			continue
+		}
+
+		if meta.Name == idOrName {
+			nameMatches++
+			if nameMatches == 1 {
+				nameMatch = meta
+			}
+		}
+
+		if len(idOrName) >= minPrefixLength && strings.HasPrefix(meta.Id, idOrName) {
+			prefixMatches++
+			if prefixMatches == 1 {
+				prefixMatch = meta
+			}
+		}
+	}
+
+	if nameMatches == 1 {
+		return nameMatch, nil
+	}
+	if nameMatches > 1 {
+		return nil, ErrAmbiguousName
+	}
+	if prefixMatches == 1 {
+		return prefixMatch, nil
+	}
+	if prefixMatches > 1 {
+		return nil, ErrAmbiguousName
+	}
+	return nil, ErrNotFound
+}
+
+func (m *manager) instanceNameExists(name string) (bool, error) {
+	_, err := m.findInstanceMetadataByExactName(name)
+	if err == nil {
+		return true, nil
+	}
+	if err == ErrNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
 // getInstance returns a single instance by ID
 func (m *manager) getInstance(ctx context.Context, id string) (*Instance, error) {
 	log := logger.FromContext(ctx)


### PR DESCRIPTION
## Summary
- resolve instance names and ID prefixes from metadata before hydrating a single matched instance
- avoid `GetInstance(name)` falling back to full `ListInstances`, which queried every hypervisor socket
- keep existing API/CLI prefix behavior, but require DNS ID-prefix lookups to use at least 8 characters
- centralize metadata name lookup used by fork validation

## Validation
- `make build`

## Notes
This preserves exact ID and exact name lookup behavior. The stricter 8-character prefix rule only applies to internal DNS resolution so short DNS labels do not accidentally match broad ID prefixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core instance lookup semantics and introduces a stricter prefix rule for DNS resolution, which could affect callers relying on short prefixes or on the previous list-based resolution behavior.
> 
> **Overview**
> Speeds up `GetInstance` lookups by resolving exact names and ID prefixes via metadata first, then hydrating only the single matched instance (avoiding a full `ListInstances`/hypervisor query fanout).
> 
> Adds a DNS-specific resolution path that requires an **8-character minimum ID prefix** for internal DNS queries (via `IngressResolver`) to reduce accidental broad prefix matches, and centralizes post-lookup side effects (persisting exit info/boot markers) plus metadata-only name existence checks used by fork validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58516810e3993b55937b451b606a44f35b4ef62f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->