### PR TITLE
ci: disable darwin runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
           make test TEST_TIMEOUT=20m
 
   test-darwin:
+    if: false
     runs-on: [self-hosted, macos, arm64]
     concurrency:
       group: macos-ci-test-${{ github.ref }}
@@ -191,6 +192,7 @@ jobs:
           make clean
 
   e2e-install:
+    if: false
     runs-on: [self-hosted, macos, arm64]
     needs: test-darwin
     concurrency:


### PR DESCRIPTION
## Summary

Skip the `test-darwin` and `e2e-install` jobs in `.github/workflows/test.yml` by setting `if: false`. Both jobs run on `[self-hosted, macos, arm64]` runners.

Leaving the job definitions in place so they can be re-enabled by removing the `if: false` line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that skips macOS CI coverage; the main risk is reduced detection of Darwin-specific regressions until re-enabled.
> 
> **Overview**
> Disables the macOS self-hosted CI jobs by adding `if: false` to `test-darwin` and the dependent `e2e-install` job in `.github/workflows/test.yml`, effectively skipping Darwin unit tests and install E2E checks while keeping the job definitions in place for easy re-enable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02832d89da5d98a5bc511e12a828b87138625aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->