### PR TITLE
Make instance lifecycle no-ops idempotent

### DIFF
--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -1,0 +1,214 @@
+package instances
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const lifecycleNoopHypervisorType hypervisor.Type = "lifecycle-noop-test"
+
+var lifecycleNoopHypervisorStates sync.Map
+
+func init() {
+	hypervisor.RegisterClientFactory(lifecycleNoopHypervisorType, func(socketPath string) (hypervisor.Hypervisor, error) {
+		state, ok := lifecycleNoopHypervisorStates.Load(socketPath)
+		if !ok {
+			return nil, errors.New("missing fake hypervisor state")
+		}
+		return lifecycleNoopHypervisor{state: state.(hypervisor.VMState)}, nil
+	})
+}
+
+type lifecycleNoopHypervisor struct {
+	state hypervisor.VMState
+}
+
+func (h lifecycleNoopHypervisor) DeleteVM(context.Context) error { return nil }
+func (h lifecycleNoopHypervisor) Shutdown(context.Context) error { return nil }
+func (h lifecycleNoopHypervisor) GetVMInfo(context.Context) (*hypervisor.VMInfo, error) {
+	return &hypervisor.VMInfo{State: h.state}, nil
+}
+func (h lifecycleNoopHypervisor) Pause(context.Context) error            { return nil }
+func (h lifecycleNoopHypervisor) Resume(context.Context) error           { return nil }
+func (h lifecycleNoopHypervisor) Snapshot(context.Context, string) error { return nil }
+func (h lifecycleNoopHypervisor) ResizeMemory(context.Context, int64) error {
+	return nil
+}
+func (h lifecycleNoopHypervisor) ResizeMemoryAndWait(context.Context, int64, time.Duration) error {
+	return nil
+}
+func (h lifecycleNoopHypervisor) SetTargetGuestMemoryBytes(context.Context, int64) error {
+	return nil
+}
+func (h lifecycleNoopHypervisor) GetTargetGuestMemoryBytes(context.Context) (int64, error) {
+	return 0, nil
+}
+func (h lifecycleNoopHypervisor) Capabilities() hypervisor.Capabilities {
+	return hypervisor.Capabilities{}
+}
+
+func TestLifecycleNoopTransitionsReturnCurrentInstanceWithoutEvent(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name   string
+		state  State
+		action func(context.Context, *manager, string) (*Instance, error)
+	}{
+		{
+			name:  "restore running",
+			state: StateRunning,
+			action: func(ctx context.Context, m *manager, id string) (*Instance, error) {
+				return m.RestoreInstance(ctx, id)
+			},
+		},
+		{
+			name:  "restore initializing",
+			state: StateInitializing,
+			action: func(ctx context.Context, m *manager, id string) (*Instance, error) {
+				return m.RestoreInstance(ctx, id)
+			},
+		},
+		{
+			name:  "start running without overrides",
+			state: StateRunning,
+			action: func(ctx context.Context, m *manager, id string) (*Instance, error) {
+				return m.StartInstance(ctx, id, StartInstanceRequest{})
+			},
+		},
+		{
+			name:  "start initializing without overrides",
+			state: StateInitializing,
+			action: func(ctx context.Context, m *manager, id string) (*Instance, error) {
+				return m.StartInstance(ctx, id, StartInstanceRequest{})
+			},
+		},
+		{
+			name:  "standby already standby without options",
+			state: StateStandby,
+			action: func(ctx context.Context, m *manager, id string) (*Instance, error) {
+				return m.StandbyInstance(ctx, id, StandbyInstanceRequest{})
+			},
+		},
+		{
+			name:  "stop already stopped",
+			state: StateStopped,
+			action: func(ctx context.Context, m *manager, id string) (*Instance, error) {
+				return m.StopInstance(ctx, id)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, id := newLifecycleNoopManagerWithInstance(t, tt.state, now)
+			events, cancel := m.SubscribeLifecycleEvents(LifecycleEventConsumerWaitForState)
+			defer cancel()
+
+			inst, err := tt.action(context.Background(), m, id)
+			require.NoError(t, err)
+			require.NotNil(t, inst)
+			assert.Equal(t, tt.state, inst.State)
+			assertNoLifecycleEvent(t, events)
+		})
+	}
+}
+
+func TestLifecycleNoopStartWithOverridesStillRejectsActiveInstance(t *testing.T) {
+	m, id := newLifecycleNoopManagerWithInstance(t, StateRunning, time.Now().UTC())
+	events, cancel := m.SubscribeLifecycleEvents(LifecycleEventConsumerWaitForState)
+	defer cancel()
+
+	_, err := m.StartInstance(context.Background(), id, StartInstanceRequest{Cmd: []string{"echo", "hello"}})
+	require.ErrorIs(t, err, ErrInvalidState)
+	assertNoLifecycleEvent(t, events)
+}
+
+func TestLifecycleNoopStandbyWithOptionsStillRejectsStandbyInstance(t *testing.T) {
+	m, id := newLifecycleNoopManagerWithInstance(t, StateStandby, time.Now().UTC())
+	events, cancel := m.SubscribeLifecycleEvents(LifecycleEventConsumerWaitForState)
+	defer cancel()
+
+	delay := time.Second
+	_, err := m.StandbyInstance(context.Background(), id, StandbyInstanceRequest{CompressionDelay: &delay})
+	require.ErrorIs(t, err, ErrInvalidState)
+	assertNoLifecycleEvent(t, events)
+}
+
+func newLifecycleNoopManagerWithInstance(t *testing.T, state State, now time.Time) (*manager, string) {
+	t.Helper()
+
+	p := paths.New(t.TempDir())
+	m := &manager{
+		paths:           p,
+		instanceLocks:   sync.Map{},
+		bootMarkerScans: sync.Map{},
+		now: func() time.Time {
+			return now
+		},
+		lifecycleEvents: newLifecycleSubscribers(),
+	}
+
+	id := "inst-" + string(state)
+	require.NoError(t, m.ensureDirectories(id))
+
+	stored := StoredMetadata{
+		Id:             id,
+		Name:           id,
+		Image:          "test-image",
+		CreatedAt:      now,
+		HypervisorType: lifecycleNoopHypervisorType,
+		SocketPath:     p.InstanceSocket(id, "noop.sock"),
+		DataDir:        p.InstanceDir(id),
+	}
+
+	switch state {
+	case StateRunning:
+		stored.ProgramStartedAt = &now
+		stored.GuestAgentReadyAt = &now
+		writeLifecycleNoopSocket(t, stored.SocketPath, hypervisor.StateRunning)
+	case StateInitializing:
+		writeLifecycleNoopSocket(t, stored.SocketPath, hypervisor.StateRunning)
+	case StateStandby:
+		writeLifecycleNoopSnapshot(t, p, id)
+	}
+
+	require.NoError(t, m.saveMetadata(&metadata{StoredMetadata: stored}))
+	t.Cleanup(func() {
+		lifecycleNoopHypervisorStates.Delete(stored.SocketPath)
+	})
+	return m, id
+}
+
+func writeLifecycleNoopSocket(t *testing.T, socketPath string, state hypervisor.VMState) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(socketPath), 0o755))
+	require.NoError(t, os.WriteFile(socketPath, []byte("fake socket"), 0o644))
+	lifecycleNoopHypervisorStates.Store(socketPath, state)
+}
+
+func writeLifecycleNoopSnapshot(t *testing.T, p *paths.Paths, id string) {
+	t.Helper()
+	snapshotDir := p.InstanceSnapshotLatest(id)
+	require.NoError(t, os.MkdirAll(snapshotDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(snapshotDir, "memory"), []byte("snapshot"), 0o644))
+}
+
+func assertNoLifecycleEvent(t *testing.T, events <-chan LifecycleEvent) {
+	t.Helper()
+	select {
+	case event := <-events:
+		t.Fatalf("unexpected lifecycle event: %+v", event)
+	default:
+	}
+}

--- a/lib/instances/manager.go
+++ b/lib/instances/manager.go
@@ -399,6 +399,15 @@ func (m *manager) StandbyInstance(ctx context.Context, id string, req StandbyIns
 	lock := m.getInstanceLock(id)
 	lock.Lock()
 	defer lock.Unlock()
+	if !standbyRequestHasOptions(req) {
+		current, err := m.currentInstanceWithoutHydration(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if current.State == StateStandby {
+			return current, nil
+		}
+	}
 	inst, err := m.standbyInstance(ctx, id, req, false)
 	if err == nil {
 		m.notifyLifecycleEvent(ctx, LifecycleEventStandby, inst)
@@ -411,6 +420,13 @@ func (m *manager) RestoreInstance(ctx context.Context, id string) (*Instance, er
 	lock := m.getInstanceLock(id)
 	lock.Lock()
 	defer lock.Unlock()
+	current, err := m.currentInstanceWithoutHydration(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if current.State == StateRunning || current.State == StateInitializing {
+		return current, nil
+	}
 	inst, err := m.restoreInstance(ctx, id)
 	if err == nil {
 		m.notifyLifecycleEvent(ctx, LifecycleEventRestore, inst)
@@ -434,6 +450,13 @@ func (m *manager) StopInstance(ctx context.Context, id string) (*Instance, error
 	lock := m.getInstanceLock(id)
 	lock.Lock()
 	defer lock.Unlock()
+	current, err := m.currentInstanceWithoutHydration(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if current.State == StateStopped {
+		return current, nil
+	}
 	inst, err := m.stopInstance(ctx, id)
 	if err == nil {
 		m.notifyLifecycleEvent(ctx, LifecycleEventStop, inst)
@@ -446,11 +469,37 @@ func (m *manager) StartInstance(ctx context.Context, id string, req StartInstanc
 	lock := m.getInstanceLock(id)
 	lock.Lock()
 	defer lock.Unlock()
+	if !startRequestHasOverrides(req) {
+		current, err := m.currentInstanceWithoutHydration(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if current.State == StateRunning || current.State == StateInitializing {
+			return current, nil
+		}
+	}
 	inst, err := m.startInstance(ctx, id, req)
 	if err == nil {
 		m.notifyLifecycleEvent(ctx, LifecycleEventStart, inst)
 	}
 	return inst, err
+}
+
+func (m *manager) currentInstanceWithoutHydration(ctx context.Context, id string) (*Instance, error) {
+	meta, err := m.loadMetadata(id)
+	if err != nil {
+		return nil, err
+	}
+	inst := m.toInstanceWithoutHydration(ctx, meta)
+	return &inst, nil
+}
+
+func startRequestHasOverrides(req StartInstanceRequest) bool {
+	return len(req.Entrypoint) > 0 || len(req.Cmd) > 0
+}
+
+func standbyRequestHasOptions(req StandbyInstanceRequest) bool {
+	return req.Compression != nil || req.CompressionDelay != nil
 }
 
 // UpdateInstance updates mutable properties of a running instance


### PR DESCRIPTION
## Summary
- Return success for lifecycle requests that are already in the requested effective state:
  - restore on Running/Initializing
  - start on Running/Initializing when no command overrides are supplied
  - standby on Standby when no standby options are supplied
  - stop on Stopped
- Preserve existing invalid-state behavior for non-no-op cases like start with command overrides, standby with options, start from Standby, and stop from Standby.
- Avoid publishing lifecycle events for no-op responses so subscribers only see real transitions.

## Why
Clients currently see a 409 for benign races like restore on an already-running instance. Some clients retry 409s, which adds avoidable wake latency. These no-op OK responses make lifecycle calls idempotent where the requested outcome is already true.

## Tests
- `go test ./lib/instances -run 'TestLifecycleNoop'`\n- `go test ./lib/instances`\n- `go test ./cmd/api/api -run 'Test(Standby|Restore|Stop|Start)Instance'`\n\nNote: `go test ./cmd/api/api` was also attempted but local volume tests require `mkfs.ext4`, which is not installed in this macOS environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes instance lifecycle APIs (`StartInstance`, `StopInstance`, `RestoreInstance`, `StandbyInstance`) to sometimes return early based on stored state, which could affect client-visible behavior and event-driven consumers if state derivation differs from prior transition logic.
> 
> **Overview**
> Makes several instance lifecycle operations **idempotent no-ops** when the instance is already effectively in the requested state: `RestoreInstance` returns the current instance for *Running/Initializing*, `StopInstance` returns current for *Stopped*, `StartInstance` returns current for *Running/Initializing* when no command overrides are provided, and `StandbyInstance` returns current for *Standby* when no standby options are provided.
> 
> Adds lightweight state-check helpers (`currentInstanceWithoutHydration`, `startRequestHasOverrides`, `standbyRequestHasOptions`) and ensures **no lifecycle events are emitted** for these no-op responses. Adds `lifecycle_noop_test.go` with a fake hypervisor and assertions that no-op calls return success without publishing events, while override/option cases still error as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc9ae24efebb485acf6bd62f8a969fdb3925256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->