### PR TITLE
qemu: open serial log with O_APPEND via chardev

### DIFF
--- a/lib/hypervisor/qemu/config.go
+++ b/lib/hypervisor/qemu/config.go
@@ -100,9 +100,16 @@ func BuildArgs(cfg hypervisor.VMConfig) []string {
 		args = append(args, "-device", deviceArg)
 	}
 
-	// Serial console output to file
+	// Serial console output to file. Use a chardev with append=on so QEMU
+	// opens the file with O_APPEND. Without it, QEMU writes at its internal
+	// fd offset; if the file is externally truncated (e.g. log rotation via
+	// copytruncate) subsequent writes leave a sparse hole of NUL bytes from
+	// byte 0 to the stale offset, which downstream log readers will pick up.
 	if cfg.SerialLogPath != "" {
-		args = append(args, "-serial", fmt.Sprintf("file:%s", cfg.SerialLogPath))
+		args = append(args,
+			"-chardev", fmt.Sprintf("file,id=serial0,path=%s,append=on", cfg.SerialLogPath),
+			"-serial", "chardev:serial0",
+		)
 	} else {
 		args = append(args, "-serial", "stdio")
 	}

--- a/lib/hypervisor/qemu/config_test.go
+++ b/lib/hypervisor/qemu/config_test.go
@@ -144,8 +144,10 @@ func TestBuildArgs_SerialLog(t *testing.T) {
 
 	args := BuildArgs(cfg)
 
+	assert.Contains(t, args, "-chardev")
+	assert.Contains(t, args, "file,id=serial0,path=/var/log/app.log,append=on")
 	assert.Contains(t, args, "-serial")
-	assert.Contains(t, args, "file:/var/log/app.log")
+	assert.Contains(t, args, "chardev:serial0")
 }
 
 func TestBuildArgs_NoSerialLog(t *testing.T) {


### PR DESCRIPTION
## Summary

Switch the QEMU serial console from `-serial file:<path>` to a chardev with `append=on`:

```
-chardev file,id=serial0,path=<path>,append=on -serial chardev:serial0
```

`-serial file:` opens the path with plain `O_WRONLY|O_CREAT`, so QEMU writes at its internal fd offset. If the file is externally truncated (e.g. by `rotateLogIfNeeded`'s copytruncate), the next write lands at the stale offset, creating a sparse hole of NUL bytes from byte 0 to that offset. Downstream log readers chunk those NULs and choke.

`append=on` makes QEMU pass `O_APPEND`, so every write atomically seeks to EOF — post-truncate writes correctly resume at byte 0.

This only addresses QEMU. Cloud Hypervisor's `serial.mode=File` does not expose an append flag and needs a separate fix (likely switching to `Socket`/`Pipe` mode with hypeman owning the file fd).

## Test plan

- [x] `go test ./lib/hypervisor/qemu/...` passes
- [x] Updated `TestBuildArgs_SerialLog` to assert the new chardev args
- [ ] Boot a VM with this build, run for long enough to trigger `rotateLogIfNeeded`, verify the post-rotation `app.log` has no sparse NUL hole

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only QEMU CLI argument construction for serial logging and updates unit tests; main risk is QEMU arg compatibility/behavior differences across versions.
> 
> **Overview**
> Switches QEMU serial logging from `-serial file:<path>` to a `-chardev file,...,append=on` plus `-serial chardev:serial0`, ensuring writes use `O_APPEND` and don’t create sparse NUL holes after external log truncation/rotation.
> 
> Updates `TestBuildArgs_SerialLog` to assert the new `-chardev` and `chardev:serial0` arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d90aac80c718e405e8e2be373781d99e29a5b3fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->