### PR TITLE
cloudhypervisor: route serial through a hypeman-owned unix socket

### DIFF
--- a/integration/systemd_test.go
+++ b/integration/systemd_test.go
@@ -3,8 +3,10 @@ package integration
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -160,6 +162,66 @@ func TestSystemdMode(t *testing.T) {
 		require.NoError(t, err, "exec should work")
 		assert.Equal(t, 0, exitCode, "journalctl should succeed")
 		t.Logf("Agent logs (last 5 lines):\n%s", output)
+	})
+
+	// Regression: serial log must survive copytruncate without leaving a
+	// sparse NUL hole. Pre-fix, Cloud Hypervisor held a non-O_APPEND fd on
+	// app.log, so post-truncate writes landed at the stale offset and the
+	// file became multi-GB sparse with NUL bytes from byte 0. After the
+	// fix, hypeman owns the writer fd with O_APPEND.
+	t.Run("SerialLogSurvivesCopytruncate", func(t *testing.T) {
+		if inst.HypervisorType != hypervisor.TypeCloudHypervisor {
+			t.Skipf("regression test is CH-specific; instance uses %s", inst.HypervisorType)
+		}
+		appLog := p.InstanceAppLog(inst.Id)
+
+		require.Eventually(t, func() bool {
+			st, err := os.Stat(appLog)
+			return err == nil && st.Size() > 1024
+		}, 30*time.Second, 200*time.Millisecond, "expected serial output to accumulate before rotation")
+
+		src, err := os.Open(appLog)
+		require.NoError(t, err)
+		dst, err := os.Create(appLog + ".1")
+		require.NoError(t, err)
+		_, err = io.Copy(dst, src)
+		_ = src.Close()
+		_ = dst.Close()
+		require.NoError(t, err)
+		require.NoError(t, os.Truncate(appLog, 0))
+
+		// Drive more serial output post-truncate.
+		_, _, err = execInInstance(ctx, inst, "sh", "-c", "for i in 1 2 3; do echo post-rotate-marker-$i > /dev/kmsg; done")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			st, err := os.Stat(appLog)
+			return err == nil && st.Size() > 0
+		}, 10*time.Second, 200*time.Millisecond)
+
+		st, err := os.Stat(appLog)
+		require.NoError(t, err)
+		sys := st.Sys().(*syscall.Stat_t)
+		allocated := int64(sys.Blocks) * 512
+		apparent := st.Size()
+		// Allow one block of slack since stat blocks granularity is 512B.
+		assert.LessOrEqualf(t, apparent, allocated+4096,
+			"post-rotation app.log is sparse: apparent=%d allocated=%d (sparse_bytes=%d)",
+			apparent, allocated, apparent-allocated)
+
+		head := make([]byte, 64)
+		f, err := os.Open(appLog)
+		require.NoError(t, err)
+		n, _ := f.Read(head)
+		_ = f.Close()
+		nulCount := 0
+		for _, b := range head[:n] {
+			if b == 0 {
+				nulCount++
+			}
+		}
+		assert.Lessf(t, nulCount, n/2,
+			"post-rotation app.log starts with too many NULs (%d/%d) — likely a sparse hole", nulCount, n)
 	})
 
 	t.Log("All systemd mode tests passed!")

--- a/lib/hypervisor/cloudhypervisor/cloudhypervisor.go
+++ b/lib/hypervisor/cloudhypervisor/cloudhypervisor.go
@@ -15,6 +15,11 @@ import (
 type CloudHypervisor struct {
 	client     *vmm.VMM
 	socketPath string
+	// serial is set on the Starter path (StartVM/RestoreVM) so Shutdown
+	// can stop the reader explicitly. When the client is constructed via
+	// the reconnect factory (New), there is no reader to own — the
+	// goroutine from the original process exited with that process.
+	serial *serialReader
 }
 
 var balloonTargetCache hypervisor.BalloonTargetCache
@@ -73,10 +78,13 @@ func (c *CloudHypervisor) DeleteVM(ctx context.Context) error {
 // Shutdown stops the VMM process gracefully.
 func (c *CloudHypervisor) Shutdown(ctx context.Context) error {
 	resp, err := c.client.ShutdownVMMWithResponse(ctx)
+	// Stop the serial reader regardless of API outcome — once Shutdown
+	// has been requested the VM is going away and the reader has no
+	// further work.
+	c.serial.Close()
 	if err != nil {
 		return fmt.Errorf("shutdown vmm: %w", err)
 	}
-	// ShutdownVMM may return various codes, 204 is success
 	if resp.StatusCode() != 204 {
 		return fmt.Errorf("shutdown vmm failed with status %d", resp.StatusCode())
 	}

--- a/lib/hypervisor/cloudhypervisor/config.go
+++ b/lib/hypervisor/cloudhypervisor/config.go
@@ -8,8 +8,10 @@ import (
 )
 
 // serialSocketPath returns the unix socket path that Cloud Hypervisor
-// connects to for serial output. The socket lives next to the serial log
-// file in the instance directory.
+// binds for serial output. The socket lives at the instance directory
+// level, next to ch.sock and vsock.sock — not under logs/ — so the
+// total path stays under the 108-byte sun_path limit on Linux (104 on
+// macOS) when long test temp prefixes are involved.
 //
 // We route serial through a hypeman-owned socket reader (see serial.go)
 // rather than letting CH open the file directly, because CH's File-mode
@@ -20,7 +22,7 @@ func serialSocketPath(logPath string) string {
 	if logPath == "" {
 		return ""
 	}
-	return filepath.Join(filepath.Dir(logPath), "serial.sock")
+	return filepath.Join(filepath.Dir(filepath.Dir(logPath)), "serial.sock")
 }
 
 // ToVMConfig converts hypervisor.VMConfig to Cloud Hypervisor's vmm.VmConfig.

--- a/lib/hypervisor/cloudhypervisor/config.go
+++ b/lib/hypervisor/cloudhypervisor/config.go
@@ -1,9 +1,27 @@
 package cloudhypervisor
 
 import (
+	"path/filepath"
+
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/vmm"
 )
+
+// serialSocketPath returns the unix socket path that Cloud Hypervisor
+// connects to for serial output. The socket lives next to the serial log
+// file in the instance directory.
+//
+// We route serial through a hypeman-owned socket reader (see serial.go)
+// rather than letting CH open the file directly, because CH's File-mode
+// serial opens without O_APPEND. Combined with copytruncate-style log
+// rotation that leaves CH's fd offset stale, the next write lands past
+// EOF and creates a sparse hole of NUL bytes from byte 0 onward.
+func serialSocketPath(logPath string) string {
+	if logPath == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(logPath), "serial.sock")
+}
 
 // ToVMConfig converts hypervisor.VMConfig to Cloud Hypervisor's vmm.VmConfig.
 func ToVMConfig(cfg hypervisor.VMConfig) vmm.VmConfig {
@@ -66,10 +84,12 @@ func ToVMConfig(cfg hypervisor.VMConfig) vmm.VmConfig {
 		disks = append(disks, disk)
 	}
 
-	// Serial console configuration
+	// Serial console configuration. We route serial through a unix socket
+	// that hypeman listens on (see startSerialReader) instead of letting
+	// CH write to the file directly — see serialSocketPath for rationale.
 	serial := vmm.ConsoleConfig{
-		Mode: vmm.ConsoleConfigMode("File"),
-		File: ptr(cfg.SerialLogPath),
+		Mode:   vmm.ConsoleConfigModeSocket,
+		Socket: ptr(serialSocketPath(cfg.SerialLogPath)),
 	}
 
 	// Console off (we use serial)

--- a/lib/hypervisor/cloudhypervisor/fork_snapshot.go
+++ b/lib/hypervisor/cloudhypervisor/fork_snapshot.go
@@ -88,7 +88,12 @@ func updateSerialConfig(config map[string]any, logPath string) {
 	if !ok || serial == nil {
 		return
 	}
-	serial["file"] = logPath
+	// Forks always use the socket-based serial reader (see config.go), so
+	// rewrite to the new shape regardless of the source snapshot's mode.
+	// This also migrates legacy File-mode snapshots to Socket on fork.
+	delete(serial, "file")
+	serial["mode"] = "Socket"
+	serial["socket"] = serialSocketPath(logPath)
 }
 
 func updateNetworkConfig(config map[string]any, netCfg *hypervisor.ForkNetworkConfig) {

--- a/lib/hypervisor/cloudhypervisor/fork_snapshot.go
+++ b/lib/hypervisor/cloudhypervisor/fork_snapshot.go
@@ -96,6 +96,31 @@ func updateSerialConfig(config map[string]any, logPath string) {
 	serial["socket"] = serialSocketPath(logPath)
 }
 
+// rewriteSerialConfigForRestore migrates the on-disk snapshot config so
+// CH binds the socket-mode reader on restore. Pre-fix snapshots embed
+// serial.mode=File, which keeps the original copytruncate sparse-hole
+// bug alive after restore. New snapshots are already mode=Socket, so
+// this is a cheap no-op for them.
+func rewriteSerialConfigForRestore(configPath, logPath string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read snapshot config: %w", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("unmarshal snapshot config: %w", err)
+	}
+	updateSerialConfig(config, logPath)
+	updated, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal snapshot config: %w", err)
+	}
+	if err := os.WriteFile(configPath, updated, 0644); err != nil {
+		return fmt.Errorf("write snapshot config: %w", err)
+	}
+	return nil
+}
+
 func updateNetworkConfig(config map[string]any, netCfg *hypervisor.ForkNetworkConfig) {
 	nets, ok := config["net"].([]any)
 	if !ok {

--- a/lib/hypervisor/cloudhypervisor/fork_snapshot_test.go
+++ b/lib/hypervisor/cloudhypervisor/fork_snapshot_test.go
@@ -77,3 +77,62 @@ func TestRewriteSnapshotConfigForFork(t *testing.T) {
 	metadata := updated["metadata"].(map[string]any)
 	assert.Equal(t, "keep-/src/guests/a-as-substring", metadata["note"])
 }
+
+func TestRewriteSerialConfigForRestore(t *testing.T) {
+	t.Run("FileToSocket", func(t *testing.T) {
+		path := writeSnapshotConfig(t, map[string]any{
+			"serial": map[string]any{"mode": "File", "file": "/old/logs/app.log"},
+		})
+		require.NoError(t, rewriteSerialConfigForRestore(path, "/inst/logs/app.log"))
+
+		serial := readSerialConfig(t, path)
+		assert.Equal(t, "Socket", serial["mode"])
+		assert.Equal(t, "/inst/serial.sock", serial["socket"])
+		_, hasFile := serial["file"]
+		assert.False(t, hasFile, "legacy file field must be removed")
+	})
+
+	t.Run("AlreadySocketIsIdempotent", func(t *testing.T) {
+		path := writeSnapshotConfig(t, map[string]any{
+			"serial": map[string]any{"mode": "Socket", "socket": "/inst/serial.sock"},
+		})
+		require.NoError(t, rewriteSerialConfigForRestore(path, "/inst/logs/app.log"))
+
+		serial := readSerialConfig(t, path)
+		assert.Equal(t, "Socket", serial["mode"])
+		assert.Equal(t, "/inst/serial.sock", serial["socket"])
+	})
+
+	t.Run("NoSerialBlockIsNoOp", func(t *testing.T) {
+		path := writeSnapshotConfig(t, map[string]any{
+			"disks": []any{map[string]any{"path": "/x"}},
+		})
+		require.NoError(t, rewriteSerialConfigForRestore(path, "/inst/logs/app.log"))
+
+		var cfg map[string]any
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &cfg))
+		_, hasSerial := cfg["serial"]
+		assert.False(t, hasSerial, "should not synthesize a serial block")
+	})
+}
+
+func writeSnapshotConfig(t *testing.T, cfg map[string]any) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0644))
+	return path
+}
+
+func readSerialConfig(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var cfg map[string]any
+	require.NoError(t, json.Unmarshal(data, &cfg))
+	return cfg["serial"].(map[string]any)
+}

--- a/lib/hypervisor/cloudhypervisor/fork_snapshot_test.go
+++ b/lib/hypervisor/cloudhypervisor/fork_snapshot_test.go
@@ -17,7 +17,7 @@ func TestRewriteSnapshotConfigForFork(t *testing.T) {
 
 	orig := map[string]any{
 		"disks":  []any{map[string]any{"path": "/src/guests/a/overlay.raw"}},
-		"serial": map[string]any{"mode": "Socket", "socket": "/src/guests/a/logs/serial.sock"},
+		"serial": map[string]any{"mode": "Socket", "socket": "/src/guests/a/serial.sock"},
 		"vsock":  map[string]any{"cid": float64(100), "socket": "/src/guests/a/vsock.sock"},
 		"metadata": map[string]any{
 			"note": "keep-/src/guests/a-as-substring",
@@ -60,7 +60,7 @@ func TestRewriteSnapshotConfigForFork(t *testing.T) {
 
 	serial := updated["serial"].(map[string]any)
 	assert.Equal(t, "Socket", serial["mode"])
-	assert.Equal(t, "/dst/guests/b/logs/serial.sock", serial["socket"])
+	assert.Equal(t, "/dst/guests/b/serial.sock", serial["socket"])
 	_, hasFile := serial["file"]
 	assert.False(t, hasFile, "fork rewrite should drop legacy serial.file")
 

--- a/lib/hypervisor/cloudhypervisor/fork_snapshot_test.go
+++ b/lib/hypervisor/cloudhypervisor/fork_snapshot_test.go
@@ -17,7 +17,7 @@ func TestRewriteSnapshotConfigForFork(t *testing.T) {
 
 	orig := map[string]any{
 		"disks":  []any{map[string]any{"path": "/src/guests/a/overlay.raw"}},
-		"serial": map[string]any{"file": "/src/guests/a/logs/app.log"},
+		"serial": map[string]any{"mode": "Socket", "socket": "/src/guests/a/logs/serial.sock"},
 		"vsock":  map[string]any{"cid": float64(100), "socket": "/src/guests/a/vsock.sock"},
 		"metadata": map[string]any{
 			"note": "keep-/src/guests/a-as-substring",
@@ -59,7 +59,10 @@ func TestRewriteSnapshotConfigForFork(t *testing.T) {
 	assert.Equal(t, "/dst/guests/b/overlay.raw", disk0["path"])
 
 	serial := updated["serial"].(map[string]any)
-	assert.Equal(t, "/dst/guests/b/logs/app.log", serial["file"])
+	assert.Equal(t, "Socket", serial["mode"])
+	assert.Equal(t, "/dst/guests/b/logs/serial.sock", serial["socket"])
+	_, hasFile := serial["file"]
+	assert.False(t, hasFile, "fork rewrite should drop legacy serial.file")
 
 	vsock := updated["vsock"].(map[string]any)
 	assert.Equal(t, float64(100), vsock["cid"])

--- a/lib/hypervisor/cloudhypervisor/process.go
+++ b/lib/hypervisor/cloudhypervisor/process.go
@@ -146,6 +146,14 @@ func (s *Starter) RestoreVM(ctx context.Context, p *paths.Paths, version string,
 		return 0, nil, fmt.Errorf("start serial reader: %w", err)
 	}
 
+	// Migrate legacy serial.mode=File snapshots to Socket so CH binds the
+	// reader's socket on restore. New snapshots are already Socket; the
+	// rewrite is idempotent.
+	if err := rewriteSerialConfigForRestore(filepath.Join(snapshotPath, "config.json"), logPath); err != nil {
+		sr.Close()
+		return 0, nil, fmt.Errorf("rewrite snapshot serial config: %w", err)
+	}
+
 	// 1. Start the Cloud Hypervisor process
 	processStartTime := time.Now()
 	processCtx, processSpan := hypervisor.StartProcessSpan(ctx, hypervisor.TypeCloudHypervisor)

--- a/lib/hypervisor/cloudhypervisor/process.go
+++ b/lib/hypervisor/cloudhypervisor/process.go
@@ -69,17 +69,26 @@ func (s *Starter) StartVM(ctx context.Context, p *paths.Paths, version string, s
 		return 0, nil, fmt.Errorf("unsupported cloud-hypervisor version: %s", version)
 	}
 
+	// 0. Start the serial reader before CH so the unix socket is bound by
+	// the time CH boots and tries to connect.
+	sr, err := startSerialReader(ctx, serialSocketPath(config.SerialLogPath), config.SerialLogPath)
+	if err != nil {
+		return 0, nil, fmt.Errorf("start serial reader: %w", err)
+	}
+
 	// 1. Start the Cloud Hypervisor process
 	processCtx, processSpan := hypervisor.StartProcessSpan(ctx, hypervisor.TypeCloudHypervisor)
 	pid, err := vmm.StartProcess(processCtx, p, chVersion, socketPath)
 	hypervisor.FinishTraceSpan(processSpan, err)
 	if err != nil {
+		sr.Close()
 		return 0, nil, fmt.Errorf("start process: %w", err)
 	}
 
 	// Setup cleanup to kill the process if subsequent steps fail
 	cu := cleanup.Make(func() {
 		syscall.Kill(pid, syscall.SIGKILL)
+		sr.Close()
 	})
 	defer cu.Clean()
 
@@ -129,12 +138,21 @@ func (s *Starter) RestoreVM(ctx context.Context, p *paths.Paths, version string,
 		return 0, nil, fmt.Errorf("unsupported cloud-hypervisor version: %s", version)
 	}
 
+	// 0. Start the serial reader before CH. The serial log path lives at
+	// a fixed offset from the CH API socket within the instance directory.
+	logPath := filepath.Join(filepath.Dir(socketPath), "logs", "app.log")
+	sr, err := startSerialReader(ctx, serialSocketPath(logPath), logPath)
+	if err != nil {
+		return 0, nil, fmt.Errorf("start serial reader: %w", err)
+	}
+
 	// 1. Start the Cloud Hypervisor process
 	processStartTime := time.Now()
 	processCtx, processSpan := hypervisor.StartProcessSpan(ctx, hypervisor.TypeCloudHypervisor)
 	pid, err := vmm.StartProcess(processCtx, p, chVersion, socketPath)
 	hypervisor.FinishTraceSpan(processSpan, err)
 	if err != nil {
+		sr.Close()
 		return 0, nil, fmt.Errorf("start process: %w", err)
 	}
 	log.DebugContext(ctx, "CH process started", "pid", pid, "duration_ms", time.Since(processStartTime).Milliseconds())
@@ -142,6 +160,7 @@ func (s *Starter) RestoreVM(ctx context.Context, p *paths.Paths, version string,
 	// Setup cleanup to kill the process if subsequent steps fail
 	cu := cleanup.Make(func() {
 		syscall.Kill(pid, syscall.SIGKILL)
+		sr.Close()
 	})
 	defer cu.Clean()
 

--- a/lib/hypervisor/cloudhypervisor/process.go
+++ b/lib/hypervisor/cloudhypervisor/process.go
@@ -121,7 +121,10 @@ func (s *Starter) StartVM(ctx context.Context, p *paths.Paths, version string, s
 		return 0, nil, fmt.Errorf("boot vm failed with status %d: %s", bootResp.StatusCode(), string(bootResp.Body))
 	}
 
-	// Success - release cleanup to prevent killing the process
+	// Success - release cleanup to prevent killing the process. Hand
+	// ownership of the serial reader to the client so Shutdown can
+	// stop it.
+	hv.serial = sr
 	cu.Release()
 	return pid, hv, nil
 }
@@ -194,7 +197,10 @@ func (s *Starter) RestoreVM(ctx context.Context, p *paths.Paths, version string,
 	}
 	log.DebugContext(ctx, "CH restore API complete", "duration_ms", time.Since(restoreAPIStart).Milliseconds())
 
-	// Success - release cleanup to prevent killing the process
+	// Success - release cleanup to prevent killing the process. Hand
+	// ownership of the serial reader to the client so Shutdown can
+	// stop it.
+	hv.serial = sr
 	cu.Release()
 	log.DebugContext(ctx, "CH restore complete", "pid", pid, "total_duration_ms", time.Since(startTime).Milliseconds())
 	return pid, hv, nil

--- a/lib/hypervisor/cloudhypervisor/serial.go
+++ b/lib/hypervisor/cloudhypervisor/serial.go
@@ -77,6 +77,11 @@ func startSerialReader(ctx context.Context, socketPath, logPath string) (*serial
 func (s *serialReader) run(ctx context.Context, log *slog.Logger) {
 	defer close(s.done)
 	defer s.logFile.Close()
+	// Drop the socket file when the goroutine exits so it doesn't persist
+	// on disk after the VM is gone, regardless of whether Close was
+	// called explicitly. CH normally unlinks the path itself on Drop,
+	// but this is belt-and-suspenders for the leak-on-success case.
+	defer func() { _ = os.Remove(s.socketPath) }()
 
 	conn, err := dialUnixWithRetry(ctx, s.socketPath, 60*time.Second)
 	if err != nil {

--- a/lib/hypervisor/cloudhypervisor/serial.go
+++ b/lib/hypervisor/cloudhypervisor/serial.go
@@ -89,7 +89,16 @@ func (s *serialReader) run(ctx context.Context, log *slog.Logger) {
 		// did. Either way, nothing more to do.
 		return
 	}
+	// Re-check ctx under the lock before publishing the conn. If Close
+	// fired between dial returning and us taking the lock, it would have
+	// observed s.conn == nil and given up — without this check we'd
+	// publish the conn afterward and io.Copy would block forever.
 	s.mu.Lock()
+	if ctx.Err() != nil {
+		s.mu.Unlock()
+		_ = conn.Close()
+		return
+	}
 	s.conn = conn
 	s.mu.Unlock()
 
@@ -109,6 +118,7 @@ func (s *serialReader) run(ctx context.Context, log *slog.Logger) {
 // connection or the last dial error after timeout.
 func dialUnixWithRetry(ctx context.Context, path string, timeout time.Duration) (net.Conn, error) {
 	deadline := time.Now().Add(timeout)
+	var dialer net.Dialer
 	var lastErr error
 	for {
 		if err := ctx.Err(); err != nil {
@@ -117,7 +127,7 @@ func dialUnixWithRetry(ctx context.Context, path string, timeout time.Duration) 
 			}
 			return nil, err
 		}
-		conn, err := net.Dial("unix", path)
+		conn, err := dialer.DialContext(ctx, "unix", path)
 		if err == nil {
 			return conn, nil
 		}

--- a/lib/hypervisor/cloudhypervisor/serial.go
+++ b/lib/hypervisor/cloudhypervisor/serial.go
@@ -5,33 +5,43 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/kernel/hypeman/lib/logger"
 )
 
-// serialReader owns the listener for the per-instance unix socket that
-// Cloud Hypervisor connects to for serial output, and copies bytes from
-// the connection into the serial log file with O_APPEND. Owning the
-// writer fd lets copytruncate log rotation work safely: O_APPEND
+// serialReader connects to the per-instance unix socket that Cloud
+// Hypervisor binds for serial output (mode=Socket), and copies bytes
+// from that connection into the serial log file with O_APPEND. Owning
+// the writer fd lets copytruncate log rotation work safely: O_APPEND
 // atomically seeks to EOF on every write, so writes after a truncate
 // land at byte 0 instead of the writer's stale offset.
+//
+// CH is the server here — it calls UnixListener::bind(socket) during
+// VM creation. Hypeman is the client and dials with retry, since the
+// reader is started before CH has had a chance to bind.
 type serialReader struct {
-	ln         net.Listener
 	socketPath string
 	logPath    string
-	done       chan struct{}
+	logFile    *os.File
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu   sync.Mutex
+	conn net.Conn
 }
 
-// startSerialReader binds the unix socket at socketPath, removing any
-// stale predecessor, and starts a goroutine that accepts CH's connection
-// and pipes serial output into logPath. The listener is closed after the
-// first accept (CH only ever opens one connection per VM). Callers must
-// call Close on failure paths to release the listener if CH never
-// connects.
+// startSerialReader removes any stale socket left over from a prior
+// run, opens the log file with O_APPEND, and spawns a goroutine that
+// dials the socket once CH binds it and pipes serial output into the
+// log. Callers must call Close on failure paths and on shutdown.
 func startSerialReader(ctx context.Context, socketPath, logPath string) (*serialReader, error) {
 	if socketPath == "" || logPath == "" {
 		return nil, errors.New("serial: socket and log path are required")
@@ -41,62 +51,97 @@ func startSerialReader(ctx context.Context, socketPath, logPath string) (*serial
 		return nil, fmt.Errorf("serial: create log dir: %w", err)
 	}
 
+	// CH refuses to start if the socket path already exists (it calls
+	// bind() on it). Wipe any leftover from a prior run.
 	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("serial: remove stale socket: %w", err)
 	}
 
-	ln, err := net.Listen("unix", socketPath)
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
-		return nil, fmt.Errorf("serial: listen %s: %w", socketPath, err)
+		return nil, fmt.Errorf("serial: open log: %w", err)
 	}
 
+	runCtx, cancel := context.WithCancel(context.Background())
 	sr := &serialReader{
-		ln:         ln,
 		socketPath: socketPath,
 		logPath:    logPath,
+		logFile:    f,
+		cancel:     cancel,
 		done:       make(chan struct{}),
 	}
-	go sr.run(ctx)
+	go sr.run(runCtx, logger.FromContext(ctx))
 	return sr, nil
 }
 
-func (s *serialReader) run(ctx context.Context) {
+func (s *serialReader) run(ctx context.Context, log *slog.Logger) {
 	defer close(s.done)
-	defer os.Remove(s.socketPath)
+	defer s.logFile.Close()
 
-	conn, err := s.ln.Accept()
-	// CH only opens one connection per VM, so close the listener now.
-	_ = s.ln.Close()
+	conn, err := dialUnixWithRetry(ctx, s.socketPath, 60*time.Second)
 	if err != nil {
-		// Closed before CH connected (e.g. boot failed) — nothing to do.
+		// Caller closed us before CH bound the socket, or CH never
+		// did. Either way, nothing more to do.
 		return
 	}
-	defer conn.Close()
+	s.mu.Lock()
+	s.conn = conn
+	s.mu.Unlock()
 
-	f, err := os.OpenFile(s.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		logger.FromContext(ctx).ErrorContext(ctx, "serial: open log",
-			"path", s.logPath, "err", err)
-		return
-	}
-	defer f.Close()
-
-	if _, err := io.Copy(f, conn); err != nil &&
+	if _, err := io.Copy(s.logFile, conn); err != nil &&
 		!errors.Is(err, io.EOF) &&
 		!errors.Is(err, net.ErrClosed) &&
 		!errors.Is(err, syscall.EPIPE) {
-		logger.FromContext(ctx).WarnContext(ctx, "serial: copy ended with error",
+		log.WarnContext(ctx, "serial: copy ended with error",
 			"path", s.logPath, "err", err)
+	}
+	_ = conn.Close()
+}
+
+// dialUnixWithRetry polls for the CH listener to come up. The socket
+// path is created by CH inside vm.create, which happens after the
+// reader is started, so we must wait. Returns the first successful
+// connection or the last dial error after timeout.
+func dialUnixWithRetry(ctx context.Context, path string, timeout time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			return nil, err
+		}
+		conn, err := net.Dial("unix", path)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("serial: dial %s: %w", path, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
 	}
 }
 
-// Close releases the listener if it is still open. Safe to call multiple
-// times. Once CH has connected and closed the socket the goroutine exits
-// on its own; Close is a best-effort signal for the failure path where
-// CH never boots.
+// Close stops the reader. Safe to call multiple times.
 func (s *serialReader) Close() {
 	if s == nil {
 		return
 	}
-	_ = s.ln.Close()
+	s.cancel()
+	s.mu.Lock()
+	if s.conn != nil {
+		_ = s.conn.Close()
+	}
+	s.mu.Unlock()
+	select {
+	case <-s.done:
+	case <-time.After(2 * time.Second):
+	}
+	_ = os.Remove(s.socketPath)
 }

--- a/lib/hypervisor/cloudhypervisor/serial.go
+++ b/lib/hypervisor/cloudhypervisor/serial.go
@@ -1,0 +1,102 @@
+package cloudhypervisor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/kernel/hypeman/lib/logger"
+)
+
+// serialReader owns the listener for the per-instance unix socket that
+// Cloud Hypervisor connects to for serial output, and copies bytes from
+// the connection into the serial log file with O_APPEND. Owning the
+// writer fd lets copytruncate log rotation work safely: O_APPEND
+// atomically seeks to EOF on every write, so writes after a truncate
+// land at byte 0 instead of the writer's stale offset.
+type serialReader struct {
+	ln         net.Listener
+	socketPath string
+	logPath    string
+	done       chan struct{}
+}
+
+// startSerialReader binds the unix socket at socketPath, removing any
+// stale predecessor, and starts a goroutine that accepts CH's connection
+// and pipes serial output into logPath. The listener is closed after the
+// first accept (CH only ever opens one connection per VM). Callers must
+// call Close on failure paths to release the listener if CH never
+// connects.
+func startSerialReader(ctx context.Context, socketPath, logPath string) (*serialReader, error) {
+	if socketPath == "" || logPath == "" {
+		return nil, errors.New("serial: socket and log path are required")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+		return nil, fmt.Errorf("serial: create log dir: %w", err)
+	}
+
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("serial: remove stale socket: %w", err)
+	}
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("serial: listen %s: %w", socketPath, err)
+	}
+
+	sr := &serialReader{
+		ln:         ln,
+		socketPath: socketPath,
+		logPath:    logPath,
+		done:       make(chan struct{}),
+	}
+	go sr.run(ctx)
+	return sr, nil
+}
+
+func (s *serialReader) run(ctx context.Context) {
+	defer close(s.done)
+	defer os.Remove(s.socketPath)
+
+	conn, err := s.ln.Accept()
+	// CH only opens one connection per VM, so close the listener now.
+	_ = s.ln.Close()
+	if err != nil {
+		// Closed before CH connected (e.g. boot failed) — nothing to do.
+		return
+	}
+	defer conn.Close()
+
+	f, err := os.OpenFile(s.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		logger.FromContext(ctx).ErrorContext(ctx, "serial: open log",
+			"path", s.logPath, "err", err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, conn); err != nil &&
+		!errors.Is(err, io.EOF) &&
+		!errors.Is(err, net.ErrClosed) &&
+		!errors.Is(err, syscall.EPIPE) {
+		logger.FromContext(ctx).WarnContext(ctx, "serial: copy ended with error",
+			"path", s.logPath, "err", err)
+	}
+}
+
+// Close releases the listener if it is still open. Safe to call multiple
+// times. Once CH has connected and closed the socket the goroutine exits
+// on its own; Close is a best-effort signal for the failure path where
+// CH never boots.
+func (s *serialReader) Close() {
+	if s == nil {
+		return
+	}
+	_ = s.ln.Close()
+}

--- a/lib/hypervisor/cloudhypervisor/serial_test.go
+++ b/lib/hypervisor/cloudhypervisor/serial_test.go
@@ -1,0 +1,110 @@
+package cloudhypervisor
+
+import (
+	"context"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerialReader_CopiesBytesToLog(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "logs", "app.log")
+	sockPath := serialSocketPath(logPath)
+
+	sr, err := startSerialReader(context.Background(), sockPath, logPath)
+	require.NoError(t, err)
+	t.Cleanup(sr.Close)
+
+	conn, err := net.Dial("unix", sockPath)
+	require.NoError(t, err)
+
+	payload := []byte("hello from cloud hypervisor\n")
+	_, err = conn.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.Eventually(t, func() bool {
+		data, err := os.ReadFile(logPath)
+		return err == nil && len(data) == len(payload)
+	}, 2*time.Second, 10*time.Millisecond, "expected reader to flush bytes to log")
+
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Equal(t, payload, data)
+}
+
+// TestSerialReader_NoSparseHoleAfterCopytruncate is the regression test
+// for the bug that motivated this fix: copytruncate against a file whose
+// writer holds a non-O_APPEND fd creates a sparse hole of NUL bytes from
+// byte 0 to the writer's stale offset. Hypeman now owns the writer fd
+// with O_APPEND, so post-truncate writes correctly resume at byte 0.
+func TestSerialReader_NoSparseHoleAfterCopytruncate(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "logs", "app.log")
+	sockPath := serialSocketPath(logPath)
+
+	sr, err := startSerialReader(context.Background(), sockPath, logPath)
+	require.NoError(t, err)
+	t.Cleanup(sr.Close)
+
+	conn, err := net.Dial("unix", sockPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	pre := []byte("pre-rotate line\n")
+	_, err = conn.Write(pre)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		st, err := os.Stat(logPath)
+		return err == nil && st.Size() == int64(len(pre))
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Mimic rotateLogIfNeeded: copy then truncate the file out from under
+	// the writer.
+	require.NoError(t, copyFile(logPath, logPath+".1"))
+	require.NoError(t, os.Truncate(logPath, 0))
+
+	post := []byte("post-rotate line\n")
+	_, err = conn.Write(post)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		st, err := os.Stat(logPath)
+		return err == nil && st.Size() == int64(len(post))
+	}, 2*time.Second, 10*time.Millisecond)
+
+	st, err := os.Stat(logPath)
+	require.NoError(t, err)
+	sys := st.Sys().(*syscall.Stat_t)
+	allocated := int64(sys.Blocks) * 512
+	apparent := st.Size()
+	assert.LessOrEqual(t, apparent, allocated, "post-truncate file is sparse: apparent=%d allocated=%d", apparent, allocated)
+
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Equal(t, post, data, "post-truncate writes should land at byte 0, not at the writer's stale offset")
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/lib/hypervisor/cloudhypervisor/serial_test.go
+++ b/lib/hypervisor/cloudhypervisor/serial_test.go
@@ -14,16 +14,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// shortTempDir returns a temp dir with a short prefix so unix socket
+// paths stay under the platform sun_path limit (108 bytes on Linux,
+// 104 on macOS). t.TempDir() under /var/folders on macOS overflows.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ch")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func TestSerialReader_CopiesBytesToLog(t *testing.T) {
-	tmp := t.TempDir()
+	tmp := shortTempDir(t)
 	logPath := filepath.Join(tmp, "logs", "app.log")
 	sockPath := serialSocketPath(logPath)
 
+	// Reader starts first (mirrors production order: hypeman starts the
+	// reader, then CH binds the socket during vm.create). The reader
+	// dials with retry until the listener comes up.
 	sr, err := startSerialReader(context.Background(), sockPath, logPath)
 	require.NoError(t, err)
 	t.Cleanup(sr.Close)
 
-	conn, err := net.Dial("unix", sockPath)
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	conn, err := ln.Accept()
 	require.NoError(t, err)
 
 	payload := []byte("hello from cloud hypervisor\n")
@@ -47,7 +65,7 @@ func TestSerialReader_CopiesBytesToLog(t *testing.T) {
 // byte 0 to the writer's stale offset. Hypeman now owns the writer fd
 // with O_APPEND, so post-truncate writes correctly resume at byte 0.
 func TestSerialReader_NoSparseHoleAfterCopytruncate(t *testing.T) {
-	tmp := t.TempDir()
+	tmp := shortTempDir(t)
 	logPath := filepath.Join(tmp, "logs", "app.log")
 	sockPath := serialSocketPath(logPath)
 
@@ -55,7 +73,11 @@ func TestSerialReader_NoSparseHoleAfterCopytruncate(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(sr.Close)
 
-	conn, err := net.Dial("unix", sockPath)
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	conn, err := ln.Accept()
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 


### PR DESCRIPTION
## Summary

Switch CH's serial console from `mode=File` to `mode=Socket`. CH binds a unix socket in the instance directory and hypeman dials it as a client; a goroutine in the `cloudhypervisor` package copies bytes from the socket into the log file opened with `O_APPEND`.

This is the CH-side counterpart to the QEMU O_APPEND fix. CH's `ConsoleConfig` has no append flag, so we can't ask it to open the file correctly — the only way to get an O_APPEND writer is to make hypeman the writer.

## Why

CH's `serial.mode=File` opens with plain `O_WRONLY|O_CREAT`, no O_APPEND, and never reopens on signal. When `rotateLogIfNeeded` truncates the log file out from under it, CH's next write lands at its stale fd offset and creates a sparse hole of NUL bytes from byte 0 onward. Downstream log readers chunk those NULs, JSON-encode them at ~6× expansion, and choke when batches exceed receiver body limits.

With hypeman owning the writer fd, `O_APPEND` atomically seeks to EOF on every write, so post-truncate writes correctly resume at byte 0.

## Changes

- `cloudhypervisor/config.go` — `serial.mode` is now `Socket` with a derived socket path (one level above `logs/`, kept short for `sun_path`).
- `cloudhypervisor/serial.go` — new `serialReader` dials CH's bound socket with retry (CH is the server in `mode=Socket`) and copies bytes into `app.log` opened with `O_APPEND`. The reader is owned by the `CloudHypervisor` client so `Shutdown` can stop it.
- `cloudhypervisor/process.go` — wire the reader into `StartVM` and `RestoreVM`. Reader is started before CH so it's ready to dial as soon as CH binds during `vm.create`. Cleanup paths close it on failure.
- `cloudhypervisor/fork_snapshot.go` — fork rewrites and `RestoreVM` both migrate snapshot configs from File-mode to Socket-mode so legacy snapshots get the fix on the next restore.

## Tests

- `TestSerialReader_CopiesBytesToLog` — basic socket → file copy.
- `TestSerialReader_NoSparseHoleAfterCopytruncate` — regression: write bytes, copytruncate, write more, assert the post-truncate file is non-sparse and content is exactly the post-truncate bytes.
- `TestRewriteSerialConfigForRestore` — covers File→Socket migration, idempotence on already-Socket configs, and no-op when no serial block is present.
- `TestRewriteSnapshotConfigForFork` — updated for new shape, asserts legacy `serial.file` is dropped on fork rewrite.
- Integration: `TestSystemdMode/SerialLogSurvivesCopytruncate` — boots a real CH VM with the existing systemd image, waits for serial output to accumulate, performs copytruncate against `app.log` mid-run, drives more serial output via `/dev/kmsg`, then asserts the post-rotation file is non-sparse (allocated blocks ≈ apparent size) and does not start with mostly NUL bytes.

## Backward compatibility

Snapshots taken with the old File-mode config are migrated in place on restore (and on fork), so the next time a legacy snapshot is restored or forked it switches to Socket mode and gets the fix. The rewrite is idempotent on already-Socket configs.

## Test plan

- [x] `go test ./lib/hypervisor/cloudhypervisor/...` passes locally
- [x] `go vet ./lib/hypervisor/cloudhypervisor/... ./integration/...` clean
- [x] gofmt clean
- [ ] Linux integration job (self-hosted KVM runner) green — `TestSystemdMode/SerialLogSurvivesCopytruncate` runs end-to-end on CH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Cloud Hypervisor VM bring-up/restore/shutdown and snapshot config rewriting to route serial through a new socket reader goroutine; failures could impact VM startup, restore, or log capture. Risk is mitigated by unit tests plus an end-to-end integration regression test for the sparse-log issue.
> 
> **Overview**
> Cloud Hypervisor serial logging is switched from `mode=File` to **socket-based serial** with a hypeman-owned writer opened using `O_APPEND`, preventing copytruncate rotation from creating sparse NUL holes in `app.log`.
> 
> This wires a new `serialReader` into CH `StartVM`/`RestoreVM` (started before CH and closed on cleanup/`Shutdown`), and adds snapshot migration logic so both forked and restored legacy snapshots are rewritten from File-mode serial to Socket-mode.
> 
> Adds focused unit tests for socket→file copying and the copytruncate regression, updates fork snapshot tests for the new serial config shape, and adds an integration regression test that performs a real copytruncate against a running CH VM and asserts the post-rotation log is non-sparse and not NUL-prefixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02bb2de116b01e7aa3ed7f6102f9948d12fe46e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->