### PR TITLE
network: periodic TAP reaper + stop/create release fallbacks

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -228,6 +228,11 @@ func run() error {
 	}); ok {
 		reconciler.StartAdmissionAllocationReconciler(ctx, allocationReconcileInterval)
 	}
+	if reconciler, ok := app.InstanceManager.(interface {
+		StartTAPGCReconciler(context.Context)
+	}); ok {
+		reconciler.StartTAPGCReconciler(ctx)
+	}
 
 	// Log OTel status
 	if cfg.Otel.Enabled {

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -411,9 +411,15 @@ func (m *manager) createInstance(
 		cu.Add(func() {
 			// Network cleanup: TAP devices are removed when ReleaseAllocation is called.
 			// In case of unexpected scenarios (like power loss), TAP devices persist until host reboot.
-			if netAlloc, err := m.networkManager.GetAllocation(ctx, id); err == nil {
+			// CreateAllocation just succeeded so the TAP exists on the host. If
+			// GetAllocation can't derive a full allocation here, fall back to ID-based
+			// release rather than silently leaking the TAP.
+			netAlloc, err := m.networkManager.GetAllocation(ctx, id)
+			if err == nil && netAlloc != nil {
 				m.networkManager.ReleaseAllocation(ctx, netAlloc)
+				return
 			}
+			m.networkManager.ReleaseByInstanceID(ctx, id)
 		})
 	}
 

--- a/lib/instances/manager.go
+++ b/lib/instances/manager.go
@@ -143,6 +143,9 @@ type manager struct {
 	admissionAllocationsLoaded bool
 	admissionReconcileOnce     sync.Once
 
+	// Periodic TAP garbage collection reconciler.
+	tapGCOnce sync.Once
+
 	// Hypervisor support
 	vmStarters        map[hypervisor.Type]hypervisor.VMStarter
 	defaultHypervisor hypervisor.Type // Default hypervisor type when not specified in request

--- a/lib/instances/stop.go
+++ b/lib/instances/stop.go
@@ -173,11 +173,12 @@ func (m *manager) stopInstance(
 
 	// 3. Get network allocation BEFORE killing VMM (while we can still query it)
 	var networkAlloc *network.Allocation
+	var networkAllocErr error
 	if inst.NetworkEnabled {
 		log.DebugContext(ctx, "getting network allocation", "instance_id", id)
-		networkAlloc, err = m.networkManager.GetAllocation(ctx, id)
-		if err != nil {
-			log.WarnContext(ctx, "failed to get network allocation, will still attempt cleanup", "instance_id", id, "error", err)
+		networkAlloc, networkAllocErr = m.networkManager.GetAllocation(ctx, id)
+		if networkAllocErr != nil {
+			log.WarnContext(ctx, "failed to get network allocation, will fall back to ID-based TAP cleanup", "instance_id", id, "error", networkAllocErr)
 		}
 	}
 
@@ -241,6 +242,21 @@ func (m *manager) stopInstance(
 			releaseNetworkSpanEnd(err)
 			// Log error but continue
 			log.WarnContext(ctx, "failed to release network, continuing", "instance_id", id, "error", err)
+		} else {
+			releaseNetworkSpanEnd(nil)
+		}
+	} else if inst.NetworkEnabled && networkAllocErr != nil {
+		// GetAllocation failed earlier, so we don't have a full Allocation. Fall back
+		// to deleting the TAP by deterministic name to avoid leaking it on the host.
+		log.DebugContext(ctx, "releasing network by instance id (fallback)", "instance_id", id)
+		releaseNetworkCtx, releaseNetworkSpanEnd := m.startLifecycleStep(ctx, "release_network_fallback",
+			attribute.String("instance_id", id),
+			attribute.String("hypervisor", string(stored.HypervisorType)),
+			attribute.String("operation", "release_network_fallback"),
+		)
+		if err := m.networkManager.ReleaseByInstanceID(releaseNetworkCtx, id); err != nil {
+			releaseNetworkSpanEnd(err)
+			log.WarnContext(ctx, "failed to release network by id, continuing", "instance_id", id, "error", err)
 		} else {
 			releaseNetworkSpanEnd(nil)
 		}

--- a/lib/instances/tap_gc.go
+++ b/lib/instances/tap_gc.go
@@ -1,0 +1,72 @@
+package instances
+
+import (
+	"context"
+	"time"
+
+	"github.com/kernel/hypeman/lib/logger"
+)
+
+const (
+	tapGCInterval = 60 * time.Second
+	// tapGCMinAge must exceed the worst-case window between CreateAllocation creating
+	// a TAP and saveMetadata persisting the instance to disk. Heavy work (image pull)
+	// happens before CreateAllocation, so post-allocation work is bounded by volume
+	// attach + config disk + VM boot — well under 5 minutes in practice.
+	tapGCMinAge = 5 * time.Minute
+)
+
+// StartTAPGCReconciler starts a background goroutine that periodically deletes
+// orphaned TAP devices on the host. Orphaned means: a hype-prefixed netdev whose
+// instance ID does not correspond to any Running/Initializing/Unknown instance.
+// To avoid racing against in-flight CreateAllocation calls whose metadata hasn't
+// been persisted yet, only TAPs older than tapGCMinAge are considered.
+// The goroutine stops when ctx is cancelled.
+func (m *manager) StartTAPGCReconciler(ctx context.Context) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.tapGCOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(tapGCInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					m.reconcileTAPs(ctx)
+				}
+			}
+		}()
+	})
+}
+
+func (m *manager) reconcileTAPs(ctx context.Context) {
+	log := logger.FromContext(ctx)
+
+	// Same preservation rules as startup (cmd/api/main.go): include Running,
+	// Initializing, and Unknown. "Better to leave a stale TAP than crash a
+	// running VM."
+	insts, err := m.ListInstances(ctx, nil)
+	if err != nil {
+		log.WarnContext(ctx, "TAP GC: failed to list instances, skipping pass", "error", err)
+		return
+	}
+	preserve := make([]string, 0, len(insts))
+	for _, inst := range insts {
+		if inst.State == StateRunning || inst.State == StateInitializing || inst.State == StateUnknown {
+			preserve = append(preserve, inst.Id)
+		}
+	}
+	if len(preserve) == 0 {
+		// CleanupOrphanedTAPs short-circuits on empty preserve set to avoid
+		// clobbering TAPs from concurrent hypeman processes/tests. Mirror that here
+		// rather than calling it with an empty slice.
+		log.DebugContext(ctx, "TAP GC: no preserve candidates, skipping pass")
+		return
+	}
+	if deleted := m.networkManager.CleanupOrphanedTAPs(ctx, preserve, tapGCMinAge); deleted > 0 {
+		log.InfoContext(ctx, "TAP GC: cleaned up orphaned TAP devices", "count", deleted)
+	}
+}

--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -152,6 +152,19 @@ func (m *manager) RecreateAllocation(ctx context.Context, instanceID string, dow
 	return nil
 }
 
+// ReleaseByInstanceID is a best-effort fallback for cases where the full Allocation
+// can't be derived (e.g. metadata read failure during stop, or rollback after a
+// CreateAllocation that succeeded but where downstream metadata writes failed).
+// It deletes the TAP device using the deterministic name from the instance ID and
+// the persisted class ID if available.
+func (m *manager) ReleaseByInstanceID(ctx context.Context, instanceID string) error {
+	return m.ReleaseAllocation(ctx, &Allocation{
+		InstanceID: instanceID,
+		TAPDevice:  GenerateTAPName(instanceID),
+		ClassID:    m.loadClassID(instanceID),
+	})
+}
+
 // ReleaseAllocation cleans up network allocation (shutdown/delete)
 // Takes the allocation directly since it should be retrieved before the VMM is killed.
 // If alloc is nil, this is a no-op (network not allocated or already released).

--- a/lib/network/bridge_darwin.go
+++ b/lib/network/bridge_darwin.go
@@ -4,6 +4,7 @@ package network
 
 import (
 	"context"
+	"time"
 
 	"github.com/kernel/hypeman/lib/logger"
 )
@@ -58,7 +59,7 @@ func (m *manager) queryNetworkState(bridgeName string) (*Network, error) {
 }
 
 // CleanupOrphanedTAPs is a no-op on macOS as we don't create TAP devices.
-func (m *manager) CleanupOrphanedTAPs(ctx context.Context, runningInstanceIDs []string) int {
+func (m *manager) CleanupOrphanedTAPs(ctx context.Context, preserveInstanceIDs []string, minAge time.Duration) int {
 	return 0
 }
 

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -895,23 +895,27 @@ func (m *manager) queryNetworkState(bridgeName string) (*Network, error) {
 }
 
 // CleanupOrphanedTAPs removes TAP devices that aren't used by any running instance.
-// runningInstanceIDs is a list of instance IDs that currently have a running VMM.
-// Pass nil or an empty list to skip cleanup entirely (used when we couldn't
+// preserveInstanceIDs is the authoritative set of instance IDs whose TAPs must be
+// kept. Pass nil or an empty list to skip cleanup entirely (used when we couldn't
 // determine an authoritative list of running instances for this host).
+// minAge>0 skips TAPs whose sysfs ctime is younger than minAge. This avoids racing
+// against in-flight CreateAllocation calls whose instance metadata hasn't been
+// persisted yet. Pass 0 to disable the age filter (e.g. for the startup pass which
+// runs before any concurrent creates can be in flight).
 // Returns the number of TAPs deleted.
-func (m *manager) CleanupOrphanedTAPs(ctx context.Context, runningInstanceIDs []string) int {
+func (m *manager) CleanupOrphanedTAPs(ctx context.Context, preserveInstanceIDs []string, minAge time.Duration) int {
 	log := logger.FromContext(ctx)
 
 	// Skip cleanup when we don't have an authoritative running set.
 	// This avoids deleting TAPs created by other concurrent hypeman processes/tests.
-	if len(runningInstanceIDs) == 0 {
+	if len(preserveInstanceIDs) == 0 {
 		log.DebugContext(ctx, "skipping TAP cleanup (empty instance list)")
 		return 0
 	}
 
 	// Build set of expected TAP names for running instances
 	expectedTAPs := make(map[string]bool)
-	for _, id := range runningInstanceIDs {
+	for _, id := range preserveInstanceIDs {
 		tapName := GenerateTAPName(id)
 		expectedTAPs[tapName] = true
 	}
@@ -924,6 +928,7 @@ func (m *manager) CleanupOrphanedTAPs(ctx context.Context, runningInstanceIDs []
 	}
 
 	deleted := 0
+	now := time.Now()
 	for _, link := range links {
 		name := link.Attrs().Name
 
@@ -937,16 +942,50 @@ func (m *manager) CleanupOrphanedTAPs(ctx context.Context, runningInstanceIDs []
 			continue
 		}
 
+		// Age filter: avoid clobbering TAPs from in-flight CreateAllocation calls
+		// whose instance metadata hasn't been persisted yet. sysfs ctime resets on
+		// host reboot, which is fine because the startup pass runs without an age
+		// filter at a time when no concurrent creates exist.
+		if minAge > 0 {
+			age, err := tapDeviceAge(name, now)
+			if err != nil {
+				log.WarnContext(ctx, "failed to stat TAP for age check, skipping", "tap", name, "error", err)
+				continue
+			}
+			if age < minAge {
+				log.DebugContext(ctx, "TAP younger than minAge, skipping", "tap", name, "age", age, "min_age", minAge)
+				continue
+			}
+		}
+
 		// Orphaned TAP - delete it (no stored classID available, falls back to deriveClassID)
 		if err := m.deleteTAPDevice(name, ""); err != nil {
 			log.WarnContext(ctx, "failed to delete orphaned TAP", "tap", name, "error", err)
 			continue
 		}
 		log.InfoContext(ctx, "deleted orphaned TAP device", "tap", name)
+		m.recordTAPOperation(ctx, "cleanup_orphan")
 		deleted++
 	}
 
 	return deleted
+}
+
+// tapDeviceAge returns how long the given netdev has existed in the current
+// kernel, derived from the ctime of /sys/class/net/<name>. The clock resets on
+// host reboot, but the startup CleanupOrphanedTAPs pass runs once at boot with
+// no age filter, so the reset is safe.
+func tapDeviceAge(name string, now time.Time) (time.Duration, error) {
+	info, err := os.Stat("/sys/class/net/" + name)
+	if err != nil {
+		return 0, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("unexpected stat type for %s", name)
+	}
+	ctime := time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec)
+	return now.Sub(ctime), nil
 }
 
 // CleanupOrphanedClasses removes HTB classes on the bridge that don't have matching TAP devices.

--- a/lib/network/manager.go
+++ b/lib/network/manager.go
@@ -21,6 +21,10 @@ type Manager interface {
 	CreateAllocation(ctx context.Context, req AllocateRequest) (*NetworkConfig, error)
 	RecreateAllocation(ctx context.Context, instanceID string, downloadBps, uploadBps int64) error
 	ReleaseAllocation(ctx context.Context, alloc *Allocation) error
+	// ReleaseByInstanceID is a best-effort cleanup fallback when the full Allocation
+	// can't be derived (e.g. metadata read failed). Deletes the TAP device using the
+	// deterministic name from the instance ID.
+	ReleaseByInstanceID(ctx context.Context, instanceID string) error
 
 	// SetupHTB initializes HTB qdisc on the bridge for upload fair sharing.
 	// Should be called during network initialization with the total network capacity.
@@ -30,6 +34,11 @@ type Manager interface {
 	GetAllocation(ctx context.Context, instanceID string) (*Allocation, error)
 	ListAllocations(ctx context.Context) ([]Allocation, error)
 	NameExists(ctx context.Context, name string, excludeInstanceID string) (bool, error)
+
+	// CleanupOrphanedTAPs removes TAP devices not associated with any preserved
+	// instance. Pass minAge>0 to skip TAPs younger than that, which avoids racing
+	// against in-flight CreateAllocation calls whose metadata hasn't been persisted.
+	CleanupOrphanedTAPs(ctx context.Context, preserveInstanceIDs []string, minAge time.Duration) int
 
 	// GetUploadBurstMultiplier returns the configured multiplier for upload burst ceiling.
 	GetUploadBurstMultiplier() int
@@ -96,8 +105,10 @@ func (m *manager) Initialize(ctx context.Context, runningInstanceIDs []string) e
 		return fmt.Errorf("setup default network: %w", err)
 	}
 
-	// Cleanup orphaned TAP devices from previous runs (crashes, power loss, etc.)
-	if deleted := m.CleanupOrphanedTAPs(ctx, runningInstanceIDs); deleted > 0 {
+	// Cleanup orphaned TAP devices from previous runs (crashes, power loss, etc.).
+	// Startup runs before any concurrent CreateAllocation can be in flight, so no
+	// age filter is needed here. The periodic reaper passes a non-zero minAge.
+	if deleted := m.CleanupOrphanedTAPs(ctx, runningInstanceIDs, 0); deleted > 0 {
 		log.InfoContext(ctx, "cleaned up orphaned TAP devices", "count", deleted)
 	}
 


### PR DESCRIPTION
## Summary

- Add a `ReleaseByInstanceID` best-effort fallback on the network manager and wire it into `stop.go` and `create.go` rollback. Both currently rely on `GetAllocation` succeeding; when it fails, the existing nil-guard silently skips TAP release despite the warning claiming cleanup will be attempted.
- Add a periodic TAP garbage collector that calls the existing `CleanupOrphanedTAPs` every 60s with a 5-minute age filter (sysfs ctime). Same preservation rules as the startup pass: Running, Initializing, Unknown.
- `CleanupOrphanedTAPs` now takes a `minAge time.Duration`; startup passes 0 (no concurrent creates can be in flight at boot).

## Why

`CleanupOrphanedTAPs` was startup-only. While hypeman runs, TAPs leak from:
- `stop.go` nil-guard: `GetAllocation` errors → `networkAlloc = nil` → `ReleaseAllocation` is skipped at the `!= nil` guard despite the warning log claiming otherwise.
- `create.go` rollback: same pattern; if `GetAllocation` fails after `CreateAllocation`, the just-created TAP is never released.
- VMM crashes outside hypeman: nothing triggers `ReleaseAllocation`.

These leaks contributed to a recent bridge-full incident (orphan TAPs accumulated until `vmbr0` hit `BR_MAX_PORTS = 1024`).

## Race avoidance

The reaper uses sysfs `ctime` of `/sys/class/net/<dev>` to skip TAPs younger than 5 minutes. Heavy create work (image pull, etc.) happens *before* `CreateAllocation`; post-allocation work is bounded by volume attach + config disk + boot, which is well under 5 minutes in practice. `ctime` resets on host reboot, but the startup `CleanupOrphanedTAPs` pass runs once at boot with no age filter at a time when no concurrent creates exist, so the reset is safe.

The reaper also short-circuits when the preserve set is empty (matches startup behavior, prevents clobbering TAPs from concurrent hypeman processes/tests) and skips when `ListInstances` errors.

## Observability

`hypeman_network_tap_operations_total{operation="cleanup_orphan"}` is now incremented for each GC delete (the existing metric counter already tracked create/delete; orphan cleanup wasn't counted before).

## Test plan

- [ ] CI green
- [ ] Manual: deploy to `dev-yul-hypeman-0`, leave a deliberately-orphaned TAP (`ip tuntap add hype-fake mode tap`), wait ~6 min, confirm it's reaped via `ip link show | grep hype-` and the new metric counter
- [ ] Manual: confirm the reaper does not touch a TAP for an `Unknown`-state instance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Linux networking/TAP lifecycle and adds a background reconciler, so mistakes could delete the wrong interface or leave orphaned devices, impacting VM networking on hosts.
> 
> **Overview**
> Adds a periodic TAP garbage-collection loop in the instances manager (`StartTAPGCReconciler`) and wires it into API startup to reap orphaned `hype-` TAP devices every 60s, using a 5-minute minimum-age filter and preserving Running/Initializing/Unknown instances.
> 
> Hardens TAP cleanup paths by introducing `network.Manager.ReleaseByInstanceID` and using it as a fallback during instance `create` rollback and `stop` when `GetAllocation` fails, so TAPs don’t silently leak.
> 
> Extends `CleanupOrphanedTAPs` to accept a `minAge` parameter (startup passes `0`; periodic GC passes a non-zero age) and on Linux derives TAP age from sysfs ctime while incrementing the existing TAP operation metric for orphan cleanups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c5737d7bbbe36c8d26055e2b877d376c468132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->