### PR TITLE
Return 404 on restore when instance not found

### DIFF
--- a/cmd/api/api/instances.go
+++ b/cmd/api/api/instances.go
@@ -593,6 +593,11 @@ func (s *ApiService) RestoreInstance(ctx context.Context, request oapi.RestoreIn
 	result, err := s.InstanceManager.RestoreInstance(ctx, inst.Id)
 	if err != nil {
 		switch {
+		case errors.Is(err, instances.ErrNotFound):
+			return oapi.RestoreInstance404JSONResponse{
+				Code:    "not_found",
+				Message: "instance not found",
+			}, nil
 		case errors.Is(err, instances.ErrInvalidState):
 			return oapi.RestoreInstance409JSONResponse{
 				Code:    "invalid_state",


### PR DESCRIPTION
## Summary

Map `instances.ErrNotFound` to `404` in the `RestoreInstance` handler. Previously this surfaced as `500 internal_error` because the handler's `switch` only checked for `ErrInvalidState`, with everything else falling through to the default 500 path.

This matches the existing pattern in `ForkInstance` and the other handlers in the same file. The `RestoreInstance404JSONResponse` type is already declared in `openapi.yaml` (line 2287) and generated into `lib/oapi/oapi.go` — no regen needed.

Observed in production: ~2 cases over the last 18h, all on \`POST /instances/{id}/restore\` with the error attribute \`instance not found\`. These should be 404, not 500.

## Test plan

- [ ] CI green
- [ ] Manual: POST /instances/{nonexistent-id}/restore and confirm 404 with \`{\"code\":\"not_found\",\"message\":\"instance not found\"}\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts HTTP error mapping in the `RestoreInstance` handler, with no changes to restore behavior or state transitions.
> 
> **Overview**
> `POST /instances/{id}/restore` now maps `instances.ErrNotFound` to a `404 not_found` response instead of falling through to the generic `500 internal_error` path. Other error mappings (e.g., `ErrInvalidState` → 409) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7082b537857abf624d5cc626e761fc1f1855777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->