### PR TITLE
Bump image manifest resolve timeout to 5s

### DIFF
--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -119,8 +119,8 @@ func (m *manager) CreateImage(ctx context.Context, req CreateImageRequest) (*Ima
 	}
 
 	// Resolve to get digest (validates existence)
-	// Add a 2-second timeout to ensure fast failure on rate limits or errors
-	resolveCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	// Add a 5-second timeout to ensure fast failure on rate limits or errors
+	resolveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	ref, err := normalized.Resolve(resolveCtx, m.ociClient)


### PR DESCRIPTION
## Summary

Bump the manifest-resolve context timeout in \`(*manager).CreateImage\` from **2s to 5s** (\`lib/images/manager.go:123\`).

Docker Hub manifest fetches from \`prod-yul\` intermittently exceed the existing 2s deadline. Observed errors include:

- \`resolve manifest: fetch manifest: Get \"https://index.docker.io/v2/onkernel/chromium-headful-vgpu/manifests/016335f\": context deadline exceeded\`
- \`Get \"https://index.docker.io/v2/\": context deadline exceeded\` (registry probe)
- \`Get \"https://auth.docker.io/token?scope=...\": context deadline exceeded\` (auth token fetch)

Currently surfaces as 500 on \`POST /images\`. 5s is generous enough to ride out the long-tail without appreciably slowing the failure path under genuine rate-limit / down-registry conditions.

This is a stopgap — the longer-term fix is retry-with-backoff and/or a metro-local registry mirror, but those are bigger changes.

## Test plan

- [ ] CI green
- [ ] Manual: \`POST /images\` for an existing public image succeeds within the new budget
- [ ] Manual: \`POST /images\` for a bogus manifest fails fast (<5s + RTT) with the same error mapping

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only increases the `CreateImage` manifest-resolve context deadline from 2s to 5s, affecting request latency only when registries are slow.
> 
> **Overview**
> In `lib/images/manager.go`, increases the manifest resolve timeout in `(*manager).CreateImage` from **2s to 5s** to reduce intermittent `context deadline exceeded` failures when resolving image digests from remote registries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec38e6922ed0892801b698e402ce0809763c68ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->