### PR TITLE
Use 'tc class replace' for idempotent VM class setup

### DIFF
--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -681,72 +681,47 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 	}
 	ceilStr := formatTcRate(ceilBps)
 
-	// Start with derived class ID, probe linearly on collision.
-	classIDVal := deriveClassIDVal(tapName)
+	classID := fmt.Sprintf("%04x", deriveClassIDVal(tapName))
+	fullClassID := fmt.Sprintf("1:%s", classID)
 
-	const maxAttempts = 5
-	var lastErr error
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		classID := fmt.Sprintf("%04x", classIDVal)
-		fullClassID := fmt.Sprintf("1:%s", classID)
-
-		// Try tc class add (NOT replace) so we detect collisions.
-		cmd := exec.Command("tc", "class", "add", "dev", bridgeName, "parent", htbRootClassID,
-			"classid", fullClassID, "htb", "rate", rateStr, "ceil", ceilStr, "prio", "1")
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-		}
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			// Check for "File exists" collision (exit status 2).
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && exitErr.ExitCode() == 2 && strings.Contains(string(output), "File exists") {
-				if attempt == 0 {
-					m.recordTCClassCollision(ctx, "initial")
-				} else {
-					m.recordTCClassCollision(ctx, "retry")
-				}
-				// Increment class ID, wrapping within valid 16-bit range.
-				// Skip 0 (invalid) and 1 (root class 1:1).
-				classIDVal++
-				if classIDVal == 0 || classIDVal == 1 {
-					classIDVal = 2
-				}
-				lastErr = fmt.Errorf("tc class add: %w (output: %s)", err, string(output))
-				continue
-			}
-			// Non-collision error: return immediately.
-			return "", fmt.Errorf("tc class add vm: %w (output: %s)", err, string(output))
-		}
-
-		// Success — add fq_codel and filter.
-		qdiscCmd := exec.Command("tc", "qdisc", "add", "dev", bridgeName, "parent", fullClassID, "fq_codel")
-		qdiscCmd.SysProcAttr = &syscall.SysProcAttr{
-			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-		}
-		qdiscCmd.Run() // Best effort
-
-		tapLink, linkErr := netlink.LinkByName(tapName)
-		if linkErr != nil {
-			return "", fmt.Errorf("get TAP link for filter: %w", linkErr)
-		}
-		tapIndex := tapLink.Attrs().Index
-
-		filterCmd := exec.Command("tc", "filter", "add", "dev", bridgeName, "parent", htbRootHandle,
-			"protocol", "all", "prio", "1", "basic",
-			"match", fmt.Sprintf("meta(rt_iif eq %d)", tapIndex),
-			"flowid", fullClassID)
-		filterCmd.SysProcAttr = &syscall.SysProcAttr{
-			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-		}
-		if output, filterErr := filterCmd.CombinedOutput(); filterErr != nil {
-			return "", fmt.Errorf("tc filter add: %w (output: %s)", filterErr, string(output))
-		}
-
-		return classID, nil
+	// Use `tc class replace` for idempotency. `tc class add` fails with EEXIST
+	// when an orphaned class persists from a previous failed cleanup (or, more
+	// rarely, on a 16-bit hash collision in deriveClassIDVal). `replace`
+	// creates the class if missing and updates it in place if it already
+	// exists, which is the correct behavior either way.
+	cmd := exec.Command("tc", "class", "replace", "dev", bridgeName, "parent", htbRootClassID,
+		"classid", fullClassID, "htb", "rate", rateStr, "ceil", ceilStr, "prio", "1")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+	}
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("tc class replace vm: %w (output: %s)", err, string(output))
 	}
 
-	return "", fmt.Errorf("tc class add failed after %d attempts: %w", maxAttempts, lastErr)
+	qdiscCmd := exec.Command("tc", "qdisc", "add", "dev", bridgeName, "parent", fullClassID, "fq_codel")
+	qdiscCmd.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+	}
+	qdiscCmd.Run() // Best effort
+
+	tapLink, linkErr := netlink.LinkByName(tapName)
+	if linkErr != nil {
+		return "", fmt.Errorf("get TAP link for filter: %w", linkErr)
+	}
+	tapIndex := tapLink.Attrs().Index
+
+	filterCmd := exec.Command("tc", "filter", "add", "dev", bridgeName, "parent", htbRootHandle,
+		"protocol", "all", "prio", "1", "basic",
+		"match", fmt.Sprintf("meta(rt_iif eq %d)", tapIndex),
+		"flowid", fullClassID)
+	filterCmd.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+	}
+	if output, filterErr := filterCmd.CombinedOutput(); filterErr != nil {
+		return "", fmt.Errorf("tc filter add: %w (output: %s)", filterErr, string(output))
+	}
+
+	return classID, nil
 }
 
 // removeVMClass removes the HTB class for a VM from the bridge.


### PR DESCRIPTION
## Summary

Resurrects the fix from the previously-closed [#178](https://github.com/kernel/hypeman/pull/178). Changes \`addVMClass\` (\`lib/network/bridge_linux.go\`) from \`tc class add\` to \`tc class replace\`, and removes the now-unnecessary 5-attempt collision-probing retry loop.

## Why

The 5-attempt retry approach currently in main fails all five attempts in production — observed 17 \`tc class add failed after 5 attempts: ... RTNETLINK answers: File exists\` errors over an 18h window on \`prod-yul-hypeman-2\`, all surfacing as 500s on \`POST /instances\`.

Root causes (per #178):
1. **Orphaned tc classes** from best-effort cleanup paths in \`removeVMClass\` — when filter or class deletion fails silently (fragile string parsing of \`tc filter show\`), the class persists after the TAP is torn down. Sequential probing doesn't help if many slots are leaked.
2. **16-bit hash collisions** in \`deriveClassIDVal\` (FNV-1a → 16 bits = 65,536 IDs). At ~256 concurrent TAPs/host, birthday-paradox collision probability is ~50%.

\`tc class replace\` is idempotent — creates the class if missing, updates in place if present — and is the correct behavior on both code paths.

## Companion work

[#222](https://github.com/kernel/hypeman/pull/222) addresses orphan TAP accumulation via a periodic reaper + create/stop rollback fallbacks. That fix is complementary: this PR makes the per-allocation path resilient to leftovers; #222 reduces how often leftovers accumulate.

## Notes

\`recordTCClassCollision\` in \`lib/network/metrics.go\` is now dead code — left in place to keep this diff focused. Remove in a follow-up if desired.

## Test plan

- [ ] CI green
- [ ] Manual: on a host with a deliberately-orphaned tc class (\`tc class add dev <bridge> classid 1:<id> ...\` matching a derived class ID), confirm \`POST /instances\` for a TAP that maps to that ID succeeds rather than 500ing
- [ ] Manual: confirm fresh-host allocation still works (no orphan present)
- [ ] Monitor \`prod-yul-hypeman-2\` after deploy — the 17 \`failed to allocate network\` 500s should drop to zero

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `tc` invocation used to provision per-VM HTB classes, which directly affects instance network/rate-limit setup and could alter behavior on hosts with existing classes/filters. Scope is small and should mainly reduce EEXIST failures, but mistakes would surface as instance-create errors or missing shaping.
> 
> **Overview**
> Makes per-VM upload shaping setup resilient to pre-existing `tc` state by switching `addVMClass` from `tc class add` (with a 5-attempt collision/probing loop) to a single idempotent `tc class replace`.
> 
> This removes the collision-metrics/retry path and relies on `replace` to handle both orphaned leftover classes and rare hash collisions, while keeping the subsequent `fq_codel` qdisc and `tc filter add` behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d747ac3e361e5d78dfad5f6597bff5e6d6e01b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->