### PR TITLE
List valid actions in invalid_state errors

### DIFF
--- a/lib/instances/fork.go
+++ b/lib/instances/fork.go
@@ -49,7 +49,7 @@ func (m *manager) forkInstance(ctx context.Context, id string, req ForkInstanceR
 	switch source.State {
 	case StateRunning:
 		if !req.FromRunning {
-			return nil, "", fmt.Errorf("%w: cannot fork from state %s (set from_running=true to allow standby+restore flow)", ErrInvalidState, source.State)
+			return nil, "", fmt.Errorf("%w (set from_running=true to allow standby+restore flow)", NewInvalidStateError("fork", source.State))
 		}
 
 		if err := m.validateForkSupport(ctx, source.HypervisorType); err != nil {
@@ -110,7 +110,7 @@ func (m *manager) forkInstance(ctx context.Context, id string, req ForkInstanceR
 		}
 		return forked, targetState, nil
 	default:
-		return nil, "", fmt.Errorf("%w: cannot fork from state %s (must be Stopped or Standby, or Running with from_running=true)", ErrInvalidState, source.State)
+		return nil, "", NewInvalidStateError("fork", source.State)
 	}
 }
 
@@ -207,7 +207,7 @@ func (m *manager) forkInstanceFromStoppedOrStandby(ctx context.Context, id strin
 	case StateStopped, StateStandby:
 		// allowed
 	default:
-		return nil, fmt.Errorf("%w: cannot fork from state %s (must be Stopped or Standby)", ErrInvalidState, source.State)
+		return nil, NewInvalidStateError("fork", source.State)
 	}
 
 	if !supportValidated {

--- a/lib/instances/restore.go
+++ b/lib/instances/restore.go
@@ -50,7 +50,7 @@ func (m *manager) restoreInstance(
 	// 2. Validate state
 	if inst.State != StateStandby {
 		log.ErrorContext(ctx, "invalid state for restore", "instance_id", id, "state", inst.State)
-		return nil, fmt.Errorf("%w: cannot restore from state %s", ErrInvalidState, inst.State)
+		return nil, fmt.Errorf("%w: cannot restore from state %s, must be %s", ErrInvalidState, inst.State, StateStandby)
 	}
 
 	if !inst.HasSnapshot {

--- a/lib/instances/restore.go
+++ b/lib/instances/restore.go
@@ -50,7 +50,7 @@ func (m *manager) restoreInstance(
 	// 2. Validate state
 	if inst.State != StateStandby {
 		log.ErrorContext(ctx, "invalid state for restore", "instance_id", id, "state", inst.State)
-		return nil, fmt.Errorf("%w: cannot restore from state %s, must be %s", ErrInvalidState, inst.State, StateStandby)
+		return nil, NewInvalidStateError("restore", inst.State)
 	}
 
 	if !inst.HasSnapshot {

--- a/lib/instances/snapshot.go
+++ b/lib/instances/snapshot.go
@@ -117,7 +117,7 @@ func (m *manager) createSnapshot(ctx context.Context, id string, req CreateSnaps
 				return nil, fmt.Errorf("prepare source snapshot memory for copy: %w", err)
 			}
 		default:
-			return nil, fmt.Errorf("%w: standby snapshot requires source in %s or %s, got %s", ErrInvalidState, StateRunning, StateStandby, inst.State)
+			return nil, NewInvalidStateError("snapshot", inst.State)
 		}
 
 		copyErr := m.copySnapshotPayload(id, snapshotGuestDir)
@@ -186,7 +186,7 @@ func (m *manager) createSnapshot(ctx context.Context, id string, req CreateSnaps
 
 	case SnapshotKindStopped:
 		if inst.State != StateStopped {
-			return nil, fmt.Errorf("%w: stopped snapshot requires source in %s, got %s", ErrInvalidState, StateStopped, inst.State)
+			return nil, NewInvalidStateError("snapshot", inst.State)
 		}
 		if err := m.copySnapshotPayload(id, snapshotGuestDir); err != nil {
 			return nil, err
@@ -261,7 +261,7 @@ func (m *manager) restoreSnapshot(ctx context.Context, id string, snapshotID str
 	}
 	sourceInst := m.toInstance(ctx, sourceMeta)
 	if sourceInst.State == StateRunning {
-		return nil, fmt.Errorf("%w: cannot restore snapshot while source is %s", ErrInvalidState, sourceInst.State)
+		return nil, NewInvalidStateError("restore_snapshot", sourceInst.State)
 	}
 
 	targetState, err := resolveSnapshotTargetState(rec.Snapshot.Kind, req.TargetState)

--- a/lib/instances/snapshot_schedule.go
+++ b/lib/instances/snapshot_schedule.go
@@ -409,6 +409,6 @@ func scheduledSnapshotKindForState(state State) (SnapshotKind, error) {
 	case StateRunning, StateStandby:
 		return SnapshotKindStandby, nil
 	default:
-		return "", fmt.Errorf("%w: scheduled snapshot requires source in %s, %s, or %s, got %s", ErrInvalidState, StateRunning, StateStandby, StateStopped, state)
+		return "", NewInvalidStateError("snapshot", state)
 	}
 }

--- a/lib/instances/standby.go
+++ b/lib/instances/standby.go
@@ -51,7 +51,7 @@ func (m *manager) standbyInstance(
 	// 2. Validate state transition (must be Running to start standby flow)
 	if inst.State != StateRunning {
 		log.ErrorContext(ctx, "invalid state for standby", "instance_id", id, "state", inst.State)
-		return nil, fmt.Errorf("%w: cannot standby from state %s", ErrInvalidState, inst.State)
+		return nil, NewInvalidStateError("standby", inst.State)
 	}
 
 	// 2b. Block standby for vGPU instances (driver limitation - NVIDIA vGPU doesn't support snapshots)

--- a/lib/instances/start.go
+++ b/lib/instances/start.go
@@ -45,7 +45,7 @@ func (m *manager) startInstance(
 	// 2. Validate state (must be Stopped to start)
 	if inst.State != StateStopped {
 		log.ErrorContext(ctx, "invalid state for start", "instance_id", id, "state", inst.State)
-		return nil, fmt.Errorf("%w: cannot start from state %s, must be Stopped", ErrInvalidState, inst.State)
+		return nil, NewInvalidStateError("start", inst.State)
 	}
 
 	// 2a. Clear stale exit info from previous run and apply command overrides

--- a/lib/instances/state.go
+++ b/lib/instances/state.go
@@ -1,6 +1,44 @@
 package instances
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+// userActionsByState lists the user-facing API actions a caller can invoke
+// when the instance is in the given state. Used to build self-describing
+// ErrInvalidState messages.
+var userActionsByState = map[State][]string{
+	StateInitializing: {"stop", "update"},
+	StateRunning:      {"stop", "standby", "snapshot", "fork (with from_running=true)", "update"},
+	StateStandby:      {"restore", "fork", "snapshot", "restore_snapshot"},
+	StateStopped:      {"start", "fork", "snapshot", "restore_snapshot"},
+}
+
+// UserActions returns the user-facing API actions a caller can invoke from
+// the current state. Returns nil for states with no caller-invocable actions
+// (transient states like Created/Paused/Shutdown, or StateUnknown).
+func (s State) UserActions() []string {
+	actions := userActionsByState[s]
+	if len(actions) == 0 {
+		return nil
+	}
+	out := make([]string, len(actions))
+	copy(out, actions)
+	return out
+}
+
+// NewInvalidStateError builds an ErrInvalidState that names the attempted
+// action, the current state, and the actions valid from the current state.
+// Use this for caller-facing state-rejection errors so the response tells
+// the caller what they can do next.
+func NewInvalidStateError(action string, current State) error {
+	actions := current.UserActions()
+	if len(actions) == 0 {
+		return fmt.Errorf("%w: cannot %s from state %s (no actions valid from this state)", ErrInvalidState, action, current)
+	}
+	return fmt.Errorf("%w: cannot %s from state %s, valid actions from %s: %s", ErrInvalidState, action, current, current, strings.Join(actions, ", "))
+}
 
 // ValidTransitions defines allowed single-hop state transitions
 // Based on Cloud Hypervisor's actual state machine plus our additions

--- a/lib/instances/stop.go
+++ b/lib/instances/stop.go
@@ -168,7 +168,7 @@ func (m *manager) stopInstance(
 	// 2. Validate state transition (must be active to stop)
 	if inst.State != StateRunning && inst.State != StateInitializing {
 		log.ErrorContext(ctx, "invalid state for stop", "instance_id", id, "state", inst.State)
-		return nil, fmt.Errorf("%w: cannot stop from state %s, must be Running or Initializing", ErrInvalidState, inst.State)
+		return nil, NewInvalidStateError("stop", inst.State)
 	}
 
 	// 3. Get network allocation BEFORE killing VMM (while we can still query it)

--- a/lib/instances/update.go
+++ b/lib/instances/update.go
@@ -41,7 +41,7 @@ func (m *manager) updateInstance(ctx context.Context, id string, req UpdateInsta
 		return nil, err
 	}
 	if len(req.Env) > 0 && inst.State != StateRunning && inst.State != StateInitializing {
-		return nil, fmt.Errorf("%w: instance must be running or initializing to update env (current state: %s)", ErrInvalidState, inst.State)
+		return nil, NewInvalidStateError("update env", inst.State)
 	}
 	nextMeta := deepCopyMetadata(meta)
 	if req.AutoStandby != nil {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -740,7 +740,7 @@ components:
           type: string
           nullable: true
           description: Last schedule run error, if any.
-          example: "invalid state transition: stopped snapshot requires source in Stopped, got Running"
+          example: "invalid state transition: cannot snapshot from state Paused (no actions valid from this state)"
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary

Caller hit \`invalid state transition: cannot restore from state Paused\` and had no way to know what they were allowed to do instead. Now every caller-facing \`ErrInvalidState\` message names the current state and the user-facing API actions valid from it.

Before:
\`\`\`
invalid state transition: cannot restore from state Paused
invalid state transition: cannot start from state Running, must be Stopped
invalid state transition: stopped snapshot requires source in Stopped, got Running
\`\`\`

After:
\`\`\`
invalid state transition: cannot restore from state Paused (no actions valid from this state)
invalid state transition: cannot start from state Running, valid actions from Running: stop, standby, snapshot, fork (with from_running=true), update
invalid state transition: cannot snapshot from state Running, valid actions from Running: stop, standby, snapshot, fork (with from_running=true), update
\`\`\`

## Approach

- New \`State.UserActions()\` returns the user-facing verbs callable from a given state. Backed by a single map so the matrix lives in one place.
- New \`NewInvalidStateError(action, state)\` constructs an \`ErrInvalidState\` with the attempted action, current state, and the action list.
- Routed all caller-facing state-rejection sites through the helper: \`start\`, \`stop\`, \`standby\`, \`restore\`, \`fork\` (3 sites), \`snapshot\` (3 sites incl. \`restore_snapshot\` and the scheduler), \`update env\`.
- Kept the \`fork\` \"set from_running=true\" hint on the specific Running-without-flag case by wrapping the helper output.
- Updated the OpenAPI example for snapshot-schedule \`last_error\` to match the new format.

## Test plan

- [ ] Hit each rejected path (e.g. restore from Paused, start from Running, snapshot from Paused) and confirm the response message lists the actions valid from the current state.