### PR TITLE
Bump Cloud Hypervisor default to v51.1

### DIFF
--- a/lib/vmm/binaries_darwin.go
+++ b/lib/vmm/binaries_darwin.go
@@ -16,7 +16,7 @@ const (
 	V51_1 CHVersion = "v51.1"
 )
 
-const DefaultVersion = V49_0
+const DefaultVersion = V51_1
 
 // SupportedVersions lists supported Cloud Hypervisor versions.
 // On macOS, Cloud Hypervisor is not supported (use vz instead).

--- a/lib/vmm/binaries_linux.go
+++ b/lib/vmm/binaries_linux.go
@@ -26,7 +26,7 @@ const (
 	V51_1 CHVersion = "v51.1"
 )
 
-const DefaultVersion = V49_0
+const DefaultVersion = V51_1
 
 var SupportedVersions = []CHVersion{V49_0, V51_1}
 


### PR DESCRIPTION
## Summary

- Bumps `DefaultVersion` from `V49_0` to `V51_1` in `binaries_linux.go` and `binaries_darwin.go`
- Both v49.0 and v51.1 binaries remain embedded for standby restore compatibility
- New instances get v51.1; existing v49.0 standbys restore using their stored version

## Rollout plan

1. **Staging**: Deploy this branch to a staging hypeman host, validate create/standby/restore/fork end-to-end
2. **Production**: Merge and deploy after staging validation
3. **Cleanup**: Remove v49.0 from `SupportedVersions` and embeds after all v49.0 standbys drain

## Test plan

- Deploy this to staging per https://github.com/kernel/infra/actions/runs/26472165413/job/77948212446
- SSH into a host and start an instance:
```
root@dev-yul-hypeman-0:~# curl -s -X POST "https://hypeman.dev-yul-hypeman-0.kernel.sh/instances" \
  -H "Authorization: Bearer ${TOKEN}" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "ch-v51-test",
    "image": "docker.io/library/alpine:latest",
    "size": "512MB",
    "vcpus": 1,
    "network": {"enabled": false}
  }'
  ```
- See that event get logged in [Signoz](https://tough-gecko.us.signoz.cloud/logs/logs-explorer?compositeQuery=%257B%2522queryType%2522%253A%2522builder%2522%252C%2522builder%2522%253A%257B%2522queryData%2522%253A%255B%257B%2522dataSource%2522%253A%2522logs%2522%252C%2522queryName%2522%253A%2522A%2522%252C%2522aggregateOperator%2522%253A%2522count%2522%252C%2522aggregateAttribute%2522%253A%257B%2522id%2522%253A%2522----%2522%252C%2522dataType%2522%253A%2522%2522%252C%2522key%2522%253A%2522%2522%252C%2522type%2522%253A%2522%2522%257D%252C%2522timeAggregation%2522%253A%2522rate%2522%252C%2522spaceAggregation%2522%253A%2522sum%2522%252C%2522filter%2522%253A%257B%2522expression%2522%253A%2522service.name%2520%253D%2520%27hypeman%27%2520deployment.environment%2520%253D%2520%27staging%27%2520version%2520%253D%2520%27v51.1%27%2522%257D%252C%2522aggregations%2522%253A%255B%257B%2522expression%2522%253A%2522count%28%29%2520%2522%257D%255D%252C%2522functions%2522%253A%255B%255D%252C%2522filters%2522%253A%257B%2522items%2522%253A%255B%255D%252C%2522op%2522%253A%2522AND%2522%257D%252C%2522expression%2522%253A%2522A%2522%252C%2522disabled%2522%253Afalse%252C%2522stepInterval%2522%253Anull%252C%2522having%2522%253A%257B%2522expression%2522%253A%2522%2522%257D%252C%2522limit%2522%253Anull%252C%2522orderBy%2522%253A%255B%255D%252C%2522groupBy%2522%253A%255B%255D%252C%2522legend%2522%253A%2522%2522%252C%2522reduceTo%2522%253A%2522avg%2522%252C%2522source%2522%253A%2522%2522%257D%255D%252C%2522queryFormulas%2522%253A%255B%255D%252C%2522queryTraceOperator%2522%253A%255B%255D%257D%252C%2522promql%2522%253A%255B%257B%2522name%2522%253A%2522A%2522%252C%2522query%2522%253A%2522%2522%252C%2522legend%2522%253A%2522%2522%252C%2522disabled%2522%253Afalse%257D%255D%252C%2522clickhouse_sql%2522%253A%255B%257B%2522name%2522%253A%2522A%2522%252C%2522legend%2522%253A%2522%2522%252C%2522disabled%2522%253Afalse%252C%2522query%2522%253A%2522%2522%257D%255D%252C%2522id%2522%253A%2522442b8f6e-381b-42be-9444-1830d609aed0%2522%252C%2522unit%2522%253A%2522%2522%257D&options=%7B%22selectColumns%22%3A%5B%7B%22name%22%3A%22timestamp%22%2C%22signal%22%3A%22logs%22%2C%22fieldContext%22%3A%22log%22%2C%22fieldDataType%22%3A%22%22%2C%22isIndexed%22%3Afalse%7D%2C%7B%22name%22%3A%22body%22%2C%22signal%22%3A%22logs%22%2C%22fieldContext%22%3A%22log%22%2C%22fieldDataType%22%3A%22%22%2C%22isIndexed%22%3Afalse%7D%5D%2C%22maxLines%22%3A2%2C%22format%22%3A%22raw%22%2C%22fontSize%22%3A%22small%22%7D&panelTypes=%22list%22&viewName=%22%22&viewKey=%22%22&relativeTime=5m) under "service.name = 'hypeman' deployment.environment = 'staging' version = 'v51.1'  

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hypervisor binary used for all new Linux CH instances; rollback and standby compatibility depend on keeping v49.0 embeds until old standbys drain.
> 
> **Overview**
> Sets **`DefaultVersion`** to **`V51_1`** in `lib/vmm/binaries_linux.go` and `lib/vmm/binaries_darwin.go`, so new Cloud Hypervisor instances that do not specify a version launch **v51.1** instead of **v49.0**.
> 
> Embedded **v49.0** and **v51.1** binaries and **`SupportedVersions`** are unchanged; standby restore, cold boot, and fork still use the version stored on the instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd009c155117aac12e6411514cb621738f335a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->