### PR TITLE
Speed up guest-agent exec readiness retries

### DIFF
--- a/lib/guest/client.go
+++ b/lib/guest/client.go
@@ -101,17 +101,23 @@ func GetOrCreateConn(ctx context.Context, dialer hypervisor.VsockDialer) (*grpc.
 	return conn, nil
 }
 
-// CloseConn removes a connection from the pool by key (call when VM is deleted).
-// We only remove from pool, not explicitly close - the connection will fail
-// naturally when the VM dies, and grpc will clean up.
+// CloseConn removes and closes a connection from the pool by key.
 func CloseConn(dialerKey string) {
 	connPool.Lock()
-	defer connPool.Unlock()
-
-	if _, ok := connPool.conns[dialerKey]; ok {
+	conn, ok := connPool.conns[dialerKey]
+	if ok {
 		delete(connPool.conns, dialerKey)
-		slog.Debug("removed gRPC connection from pool", "key", dialerKey)
 	}
+	connPool.Unlock()
+
+	if !ok {
+		return
+	}
+	if err := conn.Close(); err != nil {
+		slog.Debug("failed to close gRPC connection", "key", dialerKey, "error", err)
+		return
+	}
+	slog.Debug("closed and removed gRPC connection from pool", "key", dialerKey)
 }
 
 // ExitStatus represents command exit information

--- a/lib/guest/client.go
+++ b/lib/guest/client.go
@@ -17,6 +17,10 @@ import (
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/kernel/hypeman/lib/hypervisor"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -26,6 +30,10 @@ import (
 const (
 	// vsockGuestPort is the port the guest-agent listens on inside the guest
 	vsockGuestPort = 2222
+
+	guestExecFastRetryInterval = 25 * time.Millisecond
+	guestExecSlowRetryInterval = 250 * time.Millisecond
+	guestExecFastRetryWindow   = 2 * time.Second
 )
 
 // AgentVSockDialError indicates the vsock dial to the guest agent failed.
@@ -133,40 +141,126 @@ type ExecOptions struct {
 // ExecIntoInstance executes command in instance via vsock using gRPC.
 // The dialer is a hypervisor-specific VsockDialer that knows how to connect to the guest.
 // If WaitForAgent is set, it will retry on connection errors until the timeout.
-func ExecIntoInstance(ctx context.Context, dialer hypervisor.VsockDialer, opts ExecOptions) (*ExitStatus, error) {
-	// If no wait requested, execute immediately
+func ExecIntoInstance(ctx context.Context, dialer hypervisor.VsockDialer, opts ExecOptions) (exit *ExitStatus, err error) {
+	// If no wait requested, execute immediately. API-level exec calls already have
+	// their own exec.session span; the detailed retry spans are only useful when
+	// we are waiting for the guest-agent to become reachable.
 	if opts.WaitForAgent == 0 {
 		return execIntoInstanceOnce(ctx, dialer, opts)
 	}
 
+	ctx, span := startGuestExecSpan(ctx, opts)
+	defer func() {
+		finishGuestExecSpan(span, exit, err)
+	}()
+
 	deadline := time.Now().Add(opts.WaitForAgent)
+	start := time.Now()
+	attempts := 0
+	retryableAttempts := 0
+	firstRetryableErrorType := ""
+	lastRetryableErrorType := ""
+	lastRetryInterval := time.Duration(0)
 
 	for {
+		attempts++
 		exit, err := execIntoInstanceOnce(ctx, dialer, opts)
 
 		// Success - return immediately
 		if err == nil {
+			recordGuestExecWait(span, start, attempts, retryableAttempts, firstRetryableErrorType, lastRetryableErrorType, lastRetryInterval)
 			return exit, err
 		}
 
 		// Check if this is a retryable connection error
 		if !isRetryableConnectionError(err) {
+			recordGuestExecWait(span, start, attempts, retryableAttempts, firstRetryableErrorType, lastRetryableErrorType, lastRetryInterval)
 			return exit, err
 		}
+		retryableAttempts++
+		errType := retryableConnectionErrorType(err)
+		if firstRetryableErrorType == "" {
+			firstRetryableErrorType = errType
+		}
+		lastRetryableErrorType = errType
+		CloseConn(dialer.Key())
 
 		// Connection error - check if we should retry
 		if time.Now().After(deadline) {
+			recordGuestExecWait(span, start, attempts, retryableAttempts, firstRetryableErrorType, lastRetryableErrorType, lastRetryInterval)
 			return nil, err
 		}
+
+		retryInterval := guestExecRetryInterval(time.Since(start))
+		lastRetryInterval = retryInterval
 
 		// Wait before retrying, but respect context cancellation
 		select {
 		case <-ctx.Done():
+			recordGuestExecWait(span, start, attempts, retryableAttempts, firstRetryableErrorType, lastRetryableErrorType, lastRetryInterval)
 			return nil, ctx.Err()
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(retryInterval):
 			// Continue to retry
 		}
 	}
+}
+
+func guestExecRetryInterval(elapsed time.Duration) time.Duration {
+	if elapsed < guestExecFastRetryWindow {
+		return guestExecFastRetryInterval
+	}
+	return guestExecSlowRetryInterval
+}
+
+func recordGuestExecWait(span trace.Span, start time.Time, attempts, retryableAttempts int, firstRetryableErrorType, lastRetryableErrorType string, lastRetryInterval time.Duration) {
+	attrs := []attribute.KeyValue{
+		attribute.Int("attempts", attempts),
+		attribute.Int("retryable_attempts", retryableAttempts),
+		attribute.Int64("wait_elapsed_ms", time.Since(start).Milliseconds()),
+	}
+	if firstRetryableErrorType != "" {
+		attrs = append(attrs, attribute.String("first_retryable_error_type", firstRetryableErrorType))
+	}
+	if lastRetryableErrorType != "" {
+		attrs = append(attrs, attribute.String("last_retryable_error_type", lastRetryableErrorType))
+	}
+	if lastRetryInterval > 0 {
+		attrs = append(attrs, attribute.Int64("last_retry_interval_ms", lastRetryInterval.Milliseconds()))
+	}
+	span.SetAttributes(attrs...)
+}
+
+func startGuestExecSpan(ctx context.Context, opts ExecOptions) (context.Context, trace.Span) {
+	return otel.Tracer("hypeman/guest").Start(ctx, "guest.exec", trace.WithAttributes(
+		attribute.String("command_name", execCommandName(opts.Command)),
+		attribute.Bool("tty", opts.TTY),
+		attribute.Bool("wait_for_agent", opts.WaitForAgent > 0),
+		attribute.Int64("wait_for_agent_ms", opts.WaitForAgent.Milliseconds()),
+		attribute.Int("timeout_seconds", int(opts.Timeout)),
+		attribute.Int64("retry_fast_interval_ms", guestExecFastRetryInterval.Milliseconds()),
+		attribute.Int64("retry_slow_interval_ms", guestExecSlowRetryInterval.Milliseconds()),
+		attribute.Int64("retry_fast_window_ms", guestExecFastRetryWindow.Milliseconds()),
+	))
+}
+
+func finishGuestExecSpan(span trace.Span, exit *ExitStatus, err error) {
+	if exit != nil {
+		span.SetAttributes(attribute.Int("exit_code", exit.Code))
+	}
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, err.Error())
+	} else {
+		span.SetStatus(otelcodes.Ok, "")
+	}
+	span.End()
+}
+
+func execCommandName(command []string) string {
+	if len(command) == 0 || command[0] == "" {
+		return "/bin/sh"
+	}
+	return filepath.Base(command[0])
 }
 
 // isRetryableConnectionError returns true if the error indicates the guest agent
@@ -186,6 +280,17 @@ func isRetryableConnectionError(err error) bool {
 	}
 
 	return false
+}
+
+func retryableConnectionErrorType(err error) string {
+	var dialErr *AgentVSockDialError
+	if errors.As(err, &dialErr) {
+		return "vsock_dial"
+	}
+	if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
+		return "grpc_unavailable"
+	}
+	return fmt.Sprintf("%T", err)
 }
 
 // execIntoInstanceOnce executes command in instance via vsock using gRPC (single attempt).

--- a/lib/guest/client.go
+++ b/lib/guest/client.go
@@ -113,11 +113,13 @@ func CloseConn(dialerKey string) {
 	if !ok {
 		return
 	}
-	if err := conn.Close(); err != nil {
-		slog.Debug("failed to close gRPC connection", "key", dialerKey, "error", err)
-		return
-	}
-	slog.Debug("closed and removed gRPC connection from pool", "key", dialerKey)
+	go func() {
+		if err := conn.Close(); err != nil {
+			slog.Debug("failed to close gRPC connection", "key", dialerKey, "error", err)
+			return
+		}
+		slog.Debug("closed and removed gRPC connection from pool", "key", dialerKey)
+	}()
 }
 
 // ExitStatus represents command exit information

--- a/lib/guest/client_test.go
+++ b/lib/guest/client_test.go
@@ -177,7 +177,10 @@ func (d *trackingDialer) DialVsock(ctx context.Context, port int) (net.Conn, err
 		Conn:   client,
 		closed: make(chan struct{}),
 	}
-	d.conns <- tracked
+	select {
+	case d.conns <- tracked:
+	default:
+	}
 	go serveFakeGuest(server)
 	return tracked, nil
 }

--- a/lib/guest/client_test.go
+++ b/lib/guest/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -108,6 +109,40 @@ func TestExecIntoInstanceRetriesWithFreshConnections(t *testing.T) {
 	}
 }
 
+func TestCloseConnClosesPooledConnection(t *testing.T) {
+	dialer := &trackingDialer{
+		key:   "close-conn-test",
+		conns: make(chan *closeTrackingConn, 1),
+	}
+
+	conn, err := GetOrCreateConn(context.Background(), dialer)
+	if err != nil {
+		t.Fatalf("GetOrCreateConn failed: %v", err)
+	}
+	conn.Connect()
+
+	tracked := waitForTrackedConn(t, dialer.conns)
+	CloseConn(dialer.Key())
+
+	select {
+	case <-tracked.closed:
+	case <-time.After(time.Second):
+		t.Fatal("CloseConn did not close the underlying connection")
+	}
+}
+
+func waitForTrackedConn(t *testing.T, conns <-chan *closeTrackingConn) *closeTrackingConn {
+	t.Helper()
+
+	select {
+	case conn := <-conns:
+		return conn
+	case <-time.After(time.Second):
+		t.Fatal("gRPC connection was not dialed")
+		return nil
+	}
+}
+
 type delayedDialer struct {
 	key      string
 	readyAt  time.Time
@@ -128,6 +163,39 @@ func (d *delayedDialer) DialVsock(ctx context.Context, port int) (net.Conn, erro
 }
 
 var _ hypervisor.VsockDialer = (*delayedDialer)(nil)
+
+type trackingDialer struct {
+	key   string
+	conns chan *closeTrackingConn
+}
+
+func (d *trackingDialer) Key() string { return d.key }
+
+func (d *trackingDialer) DialVsock(ctx context.Context, port int) (net.Conn, error) {
+	client, server := net.Pipe()
+	tracked := &closeTrackingConn{
+		Conn:   client,
+		closed: make(chan struct{}),
+	}
+	d.conns <- tracked
+	go serveFakeGuest(server)
+	return tracked, nil
+}
+
+var _ hypervisor.VsockDialer = (*trackingDialer)(nil)
+
+type closeTrackingConn struct {
+	net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.once.Do(func() {
+		close(c.closed)
+	})
+	return c.Conn.Close()
+}
 
 type fakeGuestServer struct {
 	UnimplementedGuestServiceServer

--- a/lib/guest/client_test.go
+++ b/lib/guest/client_test.go
@@ -1,0 +1,178 @@
+package guest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+	"google.golang.org/grpc"
+)
+
+func TestExecCommandName(t *testing.T) {
+	tests := []struct {
+		name    string
+		command []string
+		want    string
+	}{
+		{
+			name:    "empty command defaults to shell",
+			command: nil,
+			want:    "/bin/sh",
+		},
+		{
+			name:    "empty binary defaults to shell",
+			command: []string{""},
+			want:    "/bin/sh",
+		},
+		{
+			name:    "uses basename",
+			command: []string{"/usr/bin/ip", "addr", "show"},
+			want:    "ip",
+		},
+		{
+			name:    "does not include arguments",
+			command: []string{"/bin/bash", "-lc", "secret-bearing command"},
+			want:    "bash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := execCommandName(tt.command); got != tt.want {
+				t.Fatalf("execCommandName(%v) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGuestExecRetryInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		elapsed time.Duration
+		want    time.Duration
+	}{
+		{
+			name:    "fast path",
+			elapsed: 500 * time.Millisecond,
+			want:    guestExecFastRetryInterval,
+		},
+		{
+			name:    "boundary",
+			elapsed: guestExecFastRetryWindow,
+			want:    guestExecSlowRetryInterval,
+		},
+		{
+			name:    "slow path",
+			elapsed: 3 * time.Second,
+			want:    guestExecSlowRetryInterval,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := guestExecRetryInterval(tt.elapsed); got != tt.want {
+				t.Fatalf("guestExecRetryInterval(%s) = %s, want %s", tt.elapsed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecIntoInstanceRetriesWithFreshConnections(t *testing.T) {
+	dialer := &delayedDialer{
+		key:     "retry-fresh-connection-test",
+		readyAt: time.Now().Add(100 * time.Millisecond),
+	}
+
+	start := time.Now()
+	exit, err := ExecIntoInstance(context.Background(), dialer, ExecOptions{
+		Command:      []string{"true"},
+		WaitForAgent: 2 * time.Second,
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("ExecIntoInstance failed: %v", err)
+	}
+	if exit.Code != 0 {
+		t.Fatalf("exit code = %d, want 0", exit.Code)
+	}
+	if attempts := dialer.attempts.Load(); attempts < 2 {
+		t.Fatalf("dial attempts = %d, want retry", attempts)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("ExecIntoInstance took %s, want under 500ms", elapsed)
+	}
+}
+
+type delayedDialer struct {
+	key      string
+	readyAt  time.Time
+	attempts atomic.Int32
+}
+
+func (d *delayedDialer) Key() string { return d.key }
+
+func (d *delayedDialer) DialVsock(ctx context.Context, port int) (net.Conn, error) {
+	d.attempts.Add(1)
+	if time.Now().Before(d.readyAt) {
+		return nil, errors.New("not ready")
+	}
+
+	client, server := net.Pipe()
+	go serveFakeGuest(server)
+	return client, nil
+}
+
+var _ hypervisor.VsockDialer = (*delayedDialer)(nil)
+
+type fakeGuestServer struct {
+	UnimplementedGuestServiceServer
+}
+
+func (s *fakeGuestServer) Exec(stream GuestService_ExecServer) error {
+	if _, err := stream.Recv(); err != nil {
+		return err
+	}
+	if err := stream.Send(&ExecResponse{Response: &ExecResponse_ExitCode{ExitCode: 0}}); err != nil {
+		return err
+	}
+	for {
+		if _, err := stream.Recv(); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func serveFakeGuest(conn net.Conn) {
+	s := grpc.NewServer()
+	RegisterGuestServiceServer(s, &fakeGuestServer{})
+	_ = s.Serve(&singleConnListener{conn: conn})
+}
+
+type singleConnListener struct {
+	conn net.Conn
+	done atomic.Bool
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	if l.done.Swap(true) {
+		return nil, net.ErrClosed
+	}
+	return l.conn, nil
+}
+
+func (l *singleConnListener) Close() error { return nil }
+
+func (l *singleConnListener) Addr() net.Addr { return dummyAddr{} }
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "pipe" }
+func (dummyAddr) String() string  { return "pipe" }

--- a/lib/instances/exec_test.go
+++ b/lib/instances/exec_test.go
@@ -58,10 +58,9 @@ func waitForExecAgent(ctx context.Context, mgr *manager, instanceID string, time
 
 		var stdout, stderr bytes.Buffer
 		exit, err := guest.ExecIntoInstance(ctx, dialer, guest.ExecOptions{
-			Command:      []string{"true"},
-			Stdout:       &stdout,
-			Stderr:       &stderr,
-			WaitForAgent: 1 * time.Second,
+			Command: []string{"true"},
+			Stdout:  &stdout,
+			Stderr:  &stderr,
 		})
 		if err == nil && exit.Code == 0 {
 			return nil

--- a/lib/instances/manager_darwin_test.go
+++ b/lib/instances/manager_darwin_test.go
@@ -454,6 +454,8 @@ func TestVZStandbyAndRestore(t *testing.T) {
 	// Wait for guest agent to be ready
 	err = waitForExecAgent(ctx, mgr, inst.Id, 30*time.Second)
 	require.NoError(t, err, "guest agent should be ready")
+	inst, err = waitForInstanceState(ctx, mgr, inst.Id, StateRunning, 30*time.Second)
+	require.NoError(t, err, "instance should be running before standby")
 	t.Log("Guest agent ready")
 
 	// Exec before standby


### PR DESCRIPTION
## Summary
- add guest exec tracing for WaitForAgent readiness paths so restore/fork hot paths expose total wait time, retry counts, retry interval config, and first/last retryable error type
- keep normal no-wait execs out of this new tracing path because API exec already has its own session span
- keep one retry behavior; no fast/slow mode
- replace the old fixed 500ms wait-for-agent retry sleep with 25ms retries for the first 2s, then 250ms retries until the existing timeout
- drop the pooled grpc connection after retryable guest-agent connection failures so retries create a fresh vsock/grpc path instead of reusing a connection in grpc backoff
- aggregate retry data on the parent guest.exec span instead of emitting a child span per retry attempt
- keep the shared test exec-readiness helper on explicit test-level polling instead of using WaitForAgent internally
- update the VZ standby test to wait for instance state Running before calling standby, instead of relying on exec readiness as a lifecycle-state proxy
- record only the command basename in trace attributes to avoid capturing shell arguments or env content
- add coverage for retry interval selection, command-name sanitization, and fresh-connection retry behavior

## Testing
- go test ./lib/guest ./lib/hypervisor
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core guest vsock/gRPC exec and connection pooling on boot/restore hot paths; behavior change is intentional but affects all WaitForAgent callers.
> 
> **Overview**
> **Guest exec readiness** is faster and easier to observe when `WaitForAgent` is set (restore/fork/API paths that wait for the agent).
> 
> Retry backoff replaces a fixed **500ms** sleep with **25ms** for the first **2s**, then **250ms** until the existing deadline. On retryable vsock/gRPC-unavailable errors, the pooled connection is **removed and closed** so the next attempt dials fresh instead of sitting in gRPC backoff.
> 
> **OpenTelemetry** adds a `guest.exec` span only for `WaitForAgent > 0` (single-attempt exec stays untraced to avoid duplicating API `exec.session` spans). The span records wait time, attempt counts, retry intervals, first/last retryable error types, and **command basename only** (no argv/env).
> 
> **Tests:** new unit tests for retry timing, sanitized command names, fresh-connection retries, and `CloseConn` behavior; integration helpers stop nesting `WaitForAgent` inside `waitForExecAgent`, and the VZ standby test waits for **Running** before standby.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d53eb8597bbe2791b39c128b315534e2b04c3151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->