### PR TITLE
Avoid serial console readiness dependency for systemd guests

### DIFF
--- a/lib/instances/manager.go
+++ b/lib/instances/manager.go
@@ -134,6 +134,7 @@ type manager struct {
 	nativeCodecMu             sync.Mutex
 	nativeCodecPaths          map[string]string
 	imageUsageRecorder        ImageUsageRecorder
+	guestAgentReadyProbe      func(context.Context, *StoredMetadata) bool
 
 	// Shared lifecycle event subscriptions for internal consumers.
 	lifecycleEvents *lifecycleSubscribers
@@ -184,27 +185,28 @@ func NewManagerWithConfig(p *paths.Paths, imageManager images.Manager, systemMan
 	}
 
 	m := &manager{
-		paths:             p,
-		imageManager:      imageManager,
-		systemManager:     systemManager,
-		networkManager:    networkManager,
-		deviceManager:     deviceManager,
-		volumeManager:     volumeManager,
-		limits:            limits,
-		instanceLocks:     sync.Map{},
-		bootMarkerScans:   sync.Map{},
-		hostTopology:      detectHostTopology(), // Detect and cache host topology
-		vmStarters:        vmStarters,
-		defaultHypervisor: defaultHypervisor,
-		now:               time.Now,
-		writeFile:         os.WriteFile,
-		meter:             meter,
-		tracer:            tracer,
-		guestMemoryPolicy: policy,
-		snapshotDefaults:  snapshotDefaults,
-		compressionJobs:   make(map[string]*compressionJob),
-		nativeCodecPaths:  make(map[string]string),
-		lifecycleEvents:   newLifecycleSubscribersWithBufferSize(managerConfig.LifecycleEventBufferSize),
+		paths:                p,
+		imageManager:         imageManager,
+		systemManager:        systemManager,
+		networkManager:       networkManager,
+		deviceManager:        deviceManager,
+		volumeManager:        volumeManager,
+		limits:               limits,
+		instanceLocks:        sync.Map{},
+		bootMarkerScans:      sync.Map{},
+		hostTopology:         detectHostTopology(), // Detect and cache host topology
+		vmStarters:           vmStarters,
+		defaultHypervisor:    defaultHypervisor,
+		now:                  time.Now,
+		writeFile:            os.WriteFile,
+		meter:                meter,
+		tracer:               tracer,
+		guestMemoryPolicy:    policy,
+		snapshotDefaults:     snapshotDefaults,
+		compressionJobs:      make(map[string]*compressionJob),
+		nativeCodecPaths:     make(map[string]string),
+		lifecycleEvents:      newLifecycleSubscribersWithBufferSize(managerConfig.LifecycleEventBufferSize),
+		guestAgentReadyProbe: probeGuestAgentReady,
 	}
 	m.deleteSnapshotFn = m.deleteSnapshot
 

--- a/lib/instances/query.go
+++ b/lib/instances/query.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kernel/hypeman/lib/guest"
 	"github.com/kernel/hypeman/lib/healthcheck"
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/instances/phasetracking"
@@ -23,10 +24,12 @@ import (
 
 // exitSentinelPrefix is the machine-parseable prefix written by init to serial console.
 const (
-	exitSentinelPrefix         = "HYPEMAN-EXIT "
-	programStartSentinelPrefix = "HYPEMAN-PROGRAM-START "
-	agentReadySentinelPrefix   = "HYPEMAN-AGENT-READY "
-	bootMarkerRescanInterval   = 1 * time.Second
+	exitSentinelPrefix          = "HYPEMAN-EXIT "
+	programStartSentinelPrefix  = "HYPEMAN-PROGRAM-START "
+	agentReadySentinelPrefix    = "HYPEMAN-AGENT-READY "
+	bootMarkerRescanInterval    = 1 * time.Second
+	guestAgentReadyProbeWait    = 250 * time.Millisecond
+	guestAgentReadyProbeTimeout = 1 * time.Second
 	// hypervisorStateCacheTTL bounds how long a cached hypervisor state may be
 	// reused before a fresh GetVMInfo call is required. Short enough to detect
 	// guest-driven shutdowns promptly, long enough that bursty list calls
@@ -275,6 +278,8 @@ func advancePhaseIfRunning(stored *StoredMetadata) {
 }
 
 // hydrateBootMarkersFromLogs fills missing boot markers from serial logs.
+// Guest-agent readiness also falls back to a direct vsock probe so systemd
+// services do not need to forward stdout/stderr to the serial console.
 // Returns true when at least one missing marker was found and populated.
 func (m *manager) hydrateBootMarkersFromLogs(ctx context.Context, stored *StoredMetadata) bool {
 	needProgram := stored.ProgramStartedAt == nil
@@ -300,6 +305,9 @@ func (m *manager) hydrateBootMarkersFromLogs(ctx context.Context, stored *Stored
 	}
 	if needAgent && guestAgentReadyAt != nil {
 		stored.GuestAgentReadyAt = guestAgentReadyAt
+		hydrated = true
+	}
+	if needAgent && stored.GuestAgentReadyAt == nil && stored.ProgramStartedAt != nil && m.hydrateGuestAgentReadyFromProbe(ctx, stored) {
 		hydrated = true
 	}
 	if hydrated {
@@ -399,6 +407,42 @@ func (m *manager) nowUTC() time.Time {
 		return m.now().UTC()
 	}
 	return time.Now().UTC()
+}
+
+func (m *manager) hydrateGuestAgentReadyFromProbe(ctx context.Context, stored *StoredMetadata) bool {
+	if stored == nil || stored.SkipGuestAgent || stored.GuestAgentReadyAt != nil {
+		return false
+	}
+	probe := m.guestAgentReadyProbe
+	if probe == nil {
+		probe = probeGuestAgentReady
+	}
+	if !probe(ctx, stored) {
+		return false
+	}
+	readyAt := m.nowUTC()
+	stored.GuestAgentReadyAt = &readyAt
+	return true
+}
+
+func probeGuestAgentReady(ctx context.Context, stored *StoredMetadata) bool {
+	if stored == nil || stored.SkipGuestAgent {
+		return false
+	}
+	dialer, err := hypervisor.NewVsockDialer(stored.HypervisorType, stored.VsockSocket, stored.VsockCID)
+	if err != nil {
+		return false
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, guestAgentReadyProbeTimeout)
+	defer cancel()
+
+	exit, err := guest.ExecIntoInstance(probeCtx, dialer, guest.ExecOptions{
+		Command:      []string{"/bin/true"},
+		Timeout:      int32(guestAgentReadyProbeTimeout / time.Second),
+		WaitForAgent: guestAgentReadyProbeWait,
+	})
+	return err == nil && exit != nil && exit.Code == 0
 }
 
 // appLogPathsForMarkerScan returns app log paths in chronological order
@@ -652,6 +696,9 @@ func (m *manager) persistBootMarkers(ctx context.Context, id string) {
 	}
 	if needAgent && guestAgentReadyAt != nil {
 		meta.GuestAgentReadyAt = guestAgentReadyAt
+		updated = true
+	}
+	if needAgent && meta.GuestAgentReadyAt == nil && meta.ProgramStartedAt != nil && m.hydrateGuestAgentReadyFromProbe(ctx, &meta.StoredMetadata) {
 		updated = true
 	}
 	if !updated {

--- a/lib/instances/query_test.go
+++ b/lib/instances/query_test.go
@@ -1,6 +1,7 @@
 package instances
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -402,6 +403,39 @@ func TestHydrateBootMarkersFromLogs_RescanThrottle(t *testing.T) {
 	require.True(t, hydrated)
 	require.NotNil(t, meta.ProgramStartedAt)
 	require.NotNil(t, meta.GuestAgentReadyAt)
+}
+
+func TestHydrateBootMarkersUsesGuestAgentProbeWhenReadyMarkerMissing(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	readyAt := time.Date(2026, 3, 8, 12, 0, 2, 0, time.UTC)
+	probeCalls := 0
+	m := &manager{
+		paths: paths.New(tmpDir),
+		now:   func() time.Time { return readyAt },
+		guestAgentReadyProbe: func(context.Context, *StoredMetadata) bool {
+			probeCalls++
+			return true
+		},
+	}
+
+	meta := &StoredMetadata{
+		Id:             "systemd-instance",
+		SkipGuestAgent: false,
+	}
+	logPath := m.paths.InstanceAppLog(meta.Id)
+	require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0o755))
+	require.NoError(t, os.WriteFile(logPath, []byte(
+		"HYPEMAN-PROGRAM-START ts=2026-03-08T12:00:01Z mode=systemd\n",
+	), 0o644))
+
+	hydrated := m.hydrateBootMarkersFromLogs(context.Background(), meta)
+	require.True(t, hydrated)
+	require.NotNil(t, meta.ProgramStartedAt)
+	require.NotNil(t, meta.GuestAgentReadyAt)
+	assert.Equal(t, readyAt.Format(time.RFC3339Nano), meta.GuestAgentReadyAt.UTC().Format(time.RFC3339Nano))
+	assert.Equal(t, 1, probeCalls)
 }
 
 func TestParseBootMarkers_IgnoresStaleMarkersBeforeBootStart(t *testing.T) {

--- a/lib/system/init/mode_systemd.go
+++ b/lib/system/init/mode_systemd.go
@@ -94,8 +94,8 @@ ExecStart=/opt/hypeman/guest-agent
 EnvironmentFile=-/etc/hypeman/env
 Restart=always
 RestartSec=3
-StandardOutput=journal+console
-StandardError=journal+console
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target
@@ -182,8 +182,8 @@ ExecStart=/opt/hypeman/hypeman-init --headers-worker-guest
 Nice=10
 IOSchedulingClass=best-effort
 IOSchedulingPriority=7
-StandardOutput=journal+console
-StandardError=journal+console
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/system/init/mode_systemd_test.go
+++ b/lib/system/init/mode_systemd_test.go
@@ -189,4 +189,7 @@ func TestInjectAgentServiceOmitsNetworkTargetDependency(t *testing.T) {
 	data, err := os.ReadFile(servicePath)
 	assert.NoError(t, err)
 	assert.NotContains(t, string(data), "network.target")
+	assert.Contains(t, string(data), "StandardOutput=journal\n")
+	assert.Contains(t, string(data), "StandardError=journal\n")
+	assert.NotContains(t, string(data), "journal+console")
 }


### PR DESCRIPTION
## Summary
- stop forwarding Hypeman-injected systemd service stdout/stderr to the serial console
- add a guest-agent vsock readiness fallback when the serial ready marker is missing
- cover the fallback and journal-only systemd unit behavior with tests

## Validation
- go test -tags containers_image_openpgp ./lib/instances -run 'Test(HydrateBootMarkers|ParseBootMarkers|DeriveRunningState)'
- GOOS=linux GOARCH=amd64 go test -c -o /tmp/hypeman-init.test ./lib/system/init
- git diff --check
- git ls-files '*.go' | xargs gofmt -l

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when VMs transition from Initializing to Running and how readiness is persisted; incorrect probes could mark guests ready too early, though the exec path matches existing fork readiness checks.
> 
> **Overview**
> **Systemd guests** no longer mirror Hypeman-injected unit logs to the serial console: `hypeman-agent` and kernel-headers units now log to the journal only (`journal` instead of `journal+console`).
> 
> **Instance readiness** can still reach **Running** when the serial `HYPEMAN-AGENT-READY` marker is absent: after program-start is known, boot-marker hydration and persistence run a **vsock probe** (`/bin/true` via the guest agent, injectable for tests) and set `GuestAgentReadyAt` on success.
> 
> Tests cover the probe fallback and the journal-only unit definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91cd43e42abc9d95e178aa5d1cf7f88f3f8b8342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->