### PR TITLE
Parallelize fork network setup

### DIFF
--- a/lib/network/README.md
+++ b/lib/network/README.md
@@ -192,17 +192,23 @@ sudo setcap 'cap_net_admin,cap_net_bind_service=+eip' /path/to/hypeman
 
 ### CreateAllocation
 1. Get default network details
-2. Check name uniqueness globally
-3. Allocate next available IP (starting from .2, after gateway at .1)
-4. Generate unused MAC (02:00:00:... format - locally administered)
-5. Generate TAP name (tap-{first8chars-of-instance-id})
-6. Create TAP device and attach to bridge
+2. Reserve name/IP/MAC/TAP identity under the allocation mutex
+3. Create the TAP device and attach it to the bridge
+4. Return once the VM can attach to the TAP
+5. Apply tc rate limits asynchronously when rate limits are configured
 
 ### RecreateAllocation (for restore from standby)
 1. Derive allocation from snapshot config.json
 2. Recreate TAP device with same name
 3. Attach to bridge with isolation mode
-4. Reapply rate limits from instance metadata
+4. Return once the VM can attach to the TAP
+5. Reapply rate limits from instance metadata asynchronously
+
+The fork/restore hot path only waits for the network identity reservation and
+TAP creation because those are required before the VMM can start. tc shaping is
+serialized in the background so concurrent forks do not queue behind bridge tc
+updates. The async tc spans are emitted as detached traces, so request/restore
+root spans show only the blocking network work.
 
 ### ReleaseAllocation (for shutdown/delete)
 1. Derive current allocation
@@ -289,20 +295,23 @@ Note: In case of unexpected scenarios like power loss, straggler TAP devices may
 
 ## Concurrency & Locking
 
-The network manager uses a single mutex to protect allocation operations:
+The network manager keeps the allocation mutex short and only uses it for
+identity reservation.
 
 ### Locked Operations
-- **CreateAllocation**: Prevents concurrent IP allocation
+- **CreateAllocation identity reservation**: Prevents duplicate names, IPs, MACs, and TAP names
+- **tc updates**: Serialized separately because upload shaping mutates shared bridge state
 
 ### Unlocked Operations  
-- **RecreateAllocation**: Safe without lock - protected by instance-level locking, doesn't allocate IPs
-- **ReleaseAllocation**: Safe without lock - only deletes TAP device
+- **TAP creation**: Runs outside the allocation mutex so concurrent forks can create TAPs in parallel
+- **RecreateAllocation**: Safe without allocation lock - protected by instance-level locking, doesn't allocate IPs
+- **ReleaseAllocation**: Safe without allocation lock - deletes TAP device and serializes with tc updates
 - **Read operations** (GetAllocation, ListAllocations, NameExists): No lock needed - eventual consistency is acceptable
 
 ### Why This Works
-- Write operations are serialized to prevent race conditions
-- Read operations can run concurrently for better performance
-- Internal calls (e.g., CreateAllocation → ListAllocations) work because reads don't lock
+- Pending reservations are visible to reads until metadata is persisted
+- TAP creation does not choose identity, so it can run outside the allocation mutex
+- tc work is not required for the VMM attach point and can complete after the fork response
 - Instance manager already provides per-instance locking for state transitions
 
 ## Security

--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -62,8 +62,13 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 	err = m.createTAPDevice(tapCtx, netConfig.TAPDevice, network.Bridge, network.Isolated)
 	tapSpanEnd(err)
 	if err != nil {
-		m.forgetPendingAllocation(req.InstanceID)
-		_ = m.deleteTAPDeviceSerialized(netConfig.TAPDevice, "")
+		cleanupErr := m.deleteTAPDeviceSerialized(netConfig.TAPDevice, "")
+		if cleanupErr != nil {
+			log.WarnContext(ctx, "failed to clean up TAP after create failure", "tap", netConfig.TAPDevice, "error", cleanupErr)
+		}
+		if cleanupErr == nil || !m.tapDeviceExists(netConfig.TAPDevice) {
+			m.forgetPendingAllocation(req.InstanceID)
+		}
 		return nil, fmt.Errorf("create TAP device: %w", err)
 	}
 	m.recordTAPOperation(ctx, "create")

--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -384,7 +384,7 @@ func (m *manager) ReleaseAllocation(ctx context.Context, alloc *Allocation) erro
 	// 1. Delete TAP device (best effort), using stored class ID for correct HTB cleanup.
 	// Serialize with async tc setup so queued rate-limit work cannot race with
 	// class removal and leave stale bridge state behind.
-	if err := m.deleteTAPDeviceSerialized(alloc.TAPDevice, alloc.ClassID); err != nil {
+	if err := m.deleteTAPDeviceForInstanceSerialized(alloc.InstanceID, alloc.TAPDevice, alloc.ClassID); err != nil {
 		log.WarnContext(ctx, "failed to delete TAP device", "tap", alloc.TAPDevice, "error", err)
 	} else {
 		m.recordTAPOperation(ctx, "delete")
@@ -402,6 +402,22 @@ func (m *manager) deleteTAPDeviceSerialized(tapName, classID string) error {
 	m.tcMu.Lock()
 	defer m.tcMu.Unlock()
 	return m.deleteTAPDevice(tapName, classID)
+}
+
+func (m *manager) deleteTAPDeviceForInstanceSerialized(instanceID, tapName, classID string) error {
+	m.tcMu.Lock()
+	defer m.tcMu.Unlock()
+	return m.deleteTAPDevice(tapName, m.classIDForDelete(instanceID, classID))
+}
+
+func (m *manager) classIDForDelete(instanceID, fallback string) string {
+	if instanceID == "" {
+		return fallback
+	}
+	if classID := m.loadClassID(instanceID); classID != "" {
+		return classID
+	}
+	return fallback
 }
 
 // getOrInitDefaultNetwork resolves the default network and self-heals by running

--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kernel/hypeman/lib/logger"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // CreateAllocation allocates IP/MAC/TAP for instance on the default network
@@ -19,7 +20,12 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 
 	// Resolve bridge/default network before taking allocation lock so
 	// self-heal retries don't block other allocation/release operations.
-	network, err := m.getOrInitDefaultNetwork(ctx)
+	networkCtx, networkSpanEnd := startNetworkStep(ctx, "network.get_default_network",
+		attribute.String("operation", "get_default_network"),
+		attribute.String("instance_id", req.InstanceID),
+	)
+	network, err := m.getOrInitDefaultNetwork(networkCtx)
+	networkSpanEnd(err)
 	if err != nil {
 		return nil, err
 	}
@@ -27,19 +33,40 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 	// Acquire lock to prevent concurrent allocations from:
 	// 1. Picking the same IP address
 	// 2. Creating duplicate instance names
+	waitCtx, waitSpanEnd := startNetworkStep(ctx, "network.create_allocation.wait_for_mutex",
+		attribute.String("operation", "wait_for_mutex"),
+		attribute.String("instance_id", req.InstanceID),
+	)
 	m.mu.Lock()
+	waitSpanEnd(nil)
 	defer m.mu.Unlock()
 
-	allocations, err := m.ListAllocations(ctx)
+	lockedCtx, lockedSpanEnd := startNetworkStep(waitCtx, "network.create_allocation.locked",
+		attribute.String("operation", "create_allocation_locked"),
+		attribute.String("instance_id", req.InstanceID),
+	)
+	var lockedErr error
+	defer func() {
+		lockedSpanEnd(lockedErr)
+	}()
+
+	listCtx, listSpanEnd := startNetworkStep(lockedCtx, "network.list_allocations",
+		attribute.String("operation", "list_allocations"),
+		attribute.String("caller", "create_allocation"),
+	)
+	allocations, err := m.ListAllocations(listCtx)
+	listSpanEnd(err)
 	if err != nil {
+		lockedErr = err
 		return nil, fmt.Errorf("list allocations: %w", err)
 	}
 
 	// 1. Check name uniqueness (exclude current instance to allow restarts)
 	exists := nameExistsInAllocations(allocations, req.InstanceName, req.InstanceID)
 	if exists {
-		return nil, fmt.Errorf("%w: instance name '%s' already exists, can't assign into same network: %s",
+		lockedErr = fmt.Errorf("%w: instance name '%s' already exists, can't assign into same network: %s",
 			ErrNameExists, req.InstanceName, network.Name)
+		return nil, lockedErr
 	}
 
 	// 2. Allocate random available IP
@@ -48,12 +75,14 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 	// moving standby VMs across hosts.
 	ip, err := allocateNextIPFromAllocations(network.Subnet, allocations)
 	if err != nil {
+		lockedErr = err
 		return nil, fmt.Errorf("allocate IP: %w", err)
 	}
 
 	// 3. Generate unused MAC (02:00:00:... format - locally administered)
 	mac, err := allocateUniqueMACFromAllocations(allocations, generateMAC)
 	if err != nil {
+		lockedErr = err
 		return nil, fmt.Errorf("allocate MAC: %w", err)
 	}
 
@@ -61,21 +90,39 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 	tap := GenerateTAPName(req.InstanceID)
 
 	// 5. Create TAP device with bidirectional rate limiting
-	classID, err := m.createTAPDevice(ctx, tap, network.Bridge, network.Isolated, req.DownloadBps, req.UploadBps, req.UploadCeilBps)
+	tapCtx, tapSpanEnd := startNetworkStep(lockedCtx, "network.create_tap",
+		attribute.String("operation", "create_tap"),
+		attribute.String("instance_id", req.InstanceID),
+		attribute.String("tap", tap),
+		attribute.Bool("isolated", network.Isolated),
+		attribute.Bool("download_rate_limit", req.DownloadBps > 0),
+		attribute.Bool("upload_rate_limit", req.UploadBps > 0),
+	)
+	classID, err := m.createTAPDevice(tapCtx, tap, network.Bridge, network.Isolated, req.DownloadBps, req.UploadBps, req.UploadCeilBps)
+	tapSpanEnd(err)
 	if err != nil {
+		lockedErr = err
 		return nil, fmt.Errorf("create TAP device: %w", err)
 	}
 	m.recordTAPOperation(ctx, "create")
 
 	// Persist assigned tc class ID so removal uses the correct ID after collisions.
 	// Clear any stale file when no rate limiting was applied.
+	_, saveClassSpanEnd := startNetworkStep(lockedCtx, "network.save_class_id",
+		attribute.String("operation", "save_class_id"),
+		attribute.String("instance_id", req.InstanceID),
+		attribute.Bool("has_class_id", classID != ""),
+	)
 	if classID != "" {
 		if err := m.saveClassID(req.InstanceID, classID); err != nil {
+			saveClassSpanEnd(err)
+			lockedErr = err
 			return nil, fmt.Errorf("save class ID: %w", err)
 		}
 	} else {
 		m.clearClassID(req.InstanceID)
 	}
+	saveClassSpanEnd(nil)
 
 	log.InfoContext(ctx, "allocated network",
 		"instance_id", req.InstanceID,
@@ -227,11 +274,30 @@ func (m *manager) getOrInitDefaultNetwork(ctx context.Context) (*Network, error)
 // allocateNextIP picks a random available IP in the subnet
 // Retries up to 5 times if conflicts occur
 func (m *manager) allocateNextIP(ctx context.Context, subnet string) (string, error) {
-	allocations, err := m.ListAllocations(ctx)
+	chooseCtx, chooseSpanEnd := startNetworkStep(ctx, "network.allocate_ip",
+		attribute.String("operation", "allocate_ip"),
+	)
+	var chooseErr error
+	defer func() {
+		chooseSpanEnd(chooseErr)
+	}()
+
+	listCtx, listSpanEnd := startNetworkStep(chooseCtx, "network.list_allocations",
+		attribute.String("operation", "list_allocations"),
+		attribute.String("caller", "allocate_ip"),
+	)
+	allocations, err := m.ListAllocations(listCtx)
+	listSpanEnd(err)
 	if err != nil {
+		chooseErr = err
 		return "", fmt.Errorf("list allocations: %w", err)
 	}
-	return allocateNextIPFromAllocations(subnet, allocations)
+
+	ip, err := allocateNextIPFromAllocations(subnet, allocations)
+	if err != nil {
+		chooseErr = err
+	}
+	return ip, err
 }
 
 func allocateNextIPFromAllocations(subnet string, allocations []Allocation) (string, error) {
@@ -323,12 +389,30 @@ const (
 
 // allocateUniqueMAC picks an unused locally administered MAC address.
 func (m *manager) allocateUniqueMAC(ctx context.Context) (string, error) {
-	allocations, err := m.ListAllocations(ctx)
+	chooseCtx, chooseSpanEnd := startNetworkStep(ctx, "network.allocate_mac",
+		attribute.String("operation", "allocate_mac"),
+	)
+	var chooseErr error
+	defer func() {
+		chooseSpanEnd(chooseErr)
+	}()
+
+	listCtx, listSpanEnd := startNetworkStep(chooseCtx, "network.list_allocations",
+		attribute.String("operation", "list_allocations"),
+		attribute.String("caller", "allocate_mac"),
+	)
+	allocations, err := m.ListAllocations(listCtx)
+	listSpanEnd(err)
 	if err != nil {
+		chooseErr = err
 		return "", fmt.Errorf("list allocations: %w", err)
 	}
 
-	return allocateUniqueMACFromAllocations(allocations, generateMAC)
+	mac, err := allocateUniqueMACFromAllocations(allocations, generateMAC)
+	if err != nil {
+		chooseErr = err
+	}
+	return mac, err
 }
 
 func allocateUniqueMACFromAllocations(allocations []Allocation, generate func() (string, error)) (string, error) {

--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -30,123 +30,68 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 		return nil, err
 	}
 
-	// Acquire lock to prevent concurrent allocations from:
-	// 1. Picking the same IP address
-	// 2. Creating duplicate instance names
+	// Reserve network identity under a short lock, then create host devices
+	// outside it so concurrent forks do not queue behind TAP setup.
 	waitCtx, waitSpanEnd := startNetworkStep(ctx, "network.create_allocation.wait_for_mutex",
 		attribute.String("operation", "wait_for_mutex"),
 		attribute.String("instance_id", req.InstanceID),
 	)
 	m.mu.Lock()
 	waitSpanEnd(nil)
-	defer m.mu.Unlock()
 
 	lockedCtx, lockedSpanEnd := startNetworkStep(waitCtx, "network.create_allocation.locked",
 		attribute.String("operation", "create_allocation_locked"),
 		attribute.String("instance_id", req.InstanceID),
 	)
-	var lockedErr error
-	defer func() {
-		lockedSpanEnd(lockedErr)
-	}()
-
-	listCtx, listSpanEnd := startNetworkStep(lockedCtx, "network.list_allocations",
-		attribute.String("operation", "list_allocations"),
-		attribute.String("caller", "create_allocation"),
-	)
-	allocations, err := m.ListAllocations(listCtx)
-	listSpanEnd(err)
+	netConfig, err := m.reserveAllocationIdentityLocked(lockedCtx, network, req)
+	lockedSpanEnd(err)
+	m.mu.Unlock()
 	if err != nil {
-		lockedErr = err
-		return nil, fmt.Errorf("list allocations: %w", err)
+		return nil, err
 	}
 
-	// 1. Check name uniqueness (exclude current instance to allow restarts)
-	exists := nameExistsInAllocations(allocations, req.InstanceName, req.InstanceID)
-	if exists {
-		lockedErr = fmt.Errorf("%w: instance name '%s' already exists, can't assign into same network: %s",
-			ErrNameExists, req.InstanceName, network.Name)
-		return nil, lockedErr
-	}
-
-	// 2. Allocate random available IP
-	// Random selection reduces predictability and helps distribute IPs across the subnet.
-	// This is especially useful for large /16 networks and reduces conflicts when
-	// moving standby VMs across hosts.
-	ip, err := allocateNextIPFromAllocations(network.Subnet, allocations)
-	if err != nil {
-		lockedErr = err
-		return nil, fmt.Errorf("allocate IP: %w", err)
-	}
-
-	// 3. Generate unused MAC (02:00:00:... format - locally administered)
-	mac, err := allocateUniqueMACFromAllocations(allocations, generateMAC)
-	if err != nil {
-		lockedErr = err
-		return nil, fmt.Errorf("allocate MAC: %w", err)
-	}
-
-	// 4. Generate TAP name (tap-{first8chars-of-id})
-	tap := GenerateTAPName(req.InstanceID)
-
-	// 5. Create TAP device with bidirectional rate limiting
-	tapCtx, tapSpanEnd := startNetworkStep(lockedCtx, "network.create_tap",
+	// Create the TAP synchronously because the VMM restore depends on it.
+	tapCtx, tapSpanEnd := startNetworkStep(ctx, "network.create_tap",
 		attribute.String("operation", "create_tap"),
 		attribute.String("instance_id", req.InstanceID),
-		attribute.String("tap", tap),
+		attribute.String("tap", netConfig.TAPDevice),
 		attribute.Bool("isolated", network.Isolated),
 		attribute.Bool("download_rate_limit", req.DownloadBps > 0),
 		attribute.Bool("upload_rate_limit", req.UploadBps > 0),
 	)
-	classID, err := m.createTAPDevice(tapCtx, tap, network.Bridge, network.Isolated, req.DownloadBps, req.UploadBps, req.UploadCeilBps)
+	err = m.createTAPDevice(tapCtx, netConfig.TAPDevice, network.Bridge, network.Isolated)
 	tapSpanEnd(err)
 	if err != nil {
-		lockedErr = err
+		m.forgetPendingAllocation(req.InstanceID)
+		_ = m.deleteTAPDevice(netConfig.TAPDevice, "")
 		return nil, fmt.Errorf("create TAP device: %w", err)
 	}
 	m.recordTAPOperation(ctx, "create")
 
-	// Persist assigned tc class ID so removal uses the correct ID after collisions.
-	// Clear any stale file when no rate limiting was applied.
-	_, saveClassSpanEnd := startNetworkStep(lockedCtx, "network.save_class_id",
-		attribute.String("operation", "save_class_id"),
-		attribute.String("instance_id", req.InstanceID),
-		attribute.Bool("has_class_id", classID != ""),
-	)
-	if classID != "" {
-		if err := m.saveClassID(req.InstanceID, classID); err != nil {
-			saveClassSpanEnd(err)
-			lockedErr = err
-			return nil, fmt.Errorf("save class ID: %w", err)
-		}
+	if req.DownloadBps > 0 || req.UploadBps > 0 {
+		m.enqueueRateLimit(ctx, rateLimitRequest{
+			instanceID:    req.InstanceID,
+			tapName:       netConfig.TAPDevice,
+			bridgeName:    network.Bridge,
+			downloadBps:   req.DownloadBps,
+			uploadBps:     req.UploadBps,
+			uploadCeilBps: req.UploadCeilBps,
+		})
 	} else {
 		m.clearClassID(req.InstanceID)
 	}
-	saveClassSpanEnd(nil)
 
 	log.InfoContext(ctx, "allocated network",
 		"instance_id", req.InstanceID,
 		"instance_name", req.InstanceName,
 		"network", "default",
-		"ip", ip,
-		"mac", mac,
-		"tap", tap,
+		"ip", netConfig.IP,
+		"mac", netConfig.MAC,
+		"tap", netConfig.TAPDevice,
 		"download_bps", req.DownloadBps,
 		"upload_bps", req.UploadBps)
 
-	// 6. Calculate netmask from subnet
-	_, ipNet, _ := net.ParseCIDR(network.Subnet)
-	netmask := fmt.Sprintf("%d.%d.%d.%d", ipNet.Mask[0], ipNet.Mask[1], ipNet.Mask[2], ipNet.Mask[3])
-
-	// 7. Return config (will be used in CH VmConfig)
-	return &NetworkConfig{
-		IP:        ip,
-		MAC:       mac,
-		Gateway:   network.Gateway,
-		Netmask:   netmask,
-		DNS:       m.config.Network.DNSServer,
-		TAPDevice: tap,
-	}, nil
+	return netConfig, nil
 }
 
 // RecreateAllocation recreates TAP for restore from standby
@@ -175,18 +120,21 @@ func (m *manager) RecreateAllocation(ctx context.Context, instanceID string, dow
 
 	// 3. Recreate TAP device with same name and rate limits from instance metadata
 	uploadCeilBps := uploadBps * int64(m.GetUploadBurstMultiplier())
-	classID, err := m.createTAPDevice(ctx, alloc.TAPDevice, network.Bridge, network.Isolated, downloadBps, uploadBps, uploadCeilBps)
-	if err != nil {
+	if err := m.createTAPDevice(ctx, alloc.TAPDevice, network.Bridge, network.Isolated); err != nil {
+		_ = m.deleteTAPDevice(alloc.TAPDevice, alloc.ClassID)
 		return fmt.Errorf("create TAP device: %w", err)
 	}
 	m.recordTAPOperation(ctx, "create")
 
-	// Persist assigned tc class ID so removal uses the correct ID after collisions.
-	// Clear any stale file when no rate limiting was applied.
-	if classID != "" {
-		if err := m.saveClassID(instanceID, classID); err != nil {
-			return fmt.Errorf("save class ID: %w", err)
-		}
+	if downloadBps > 0 || uploadBps > 0 {
+		m.enqueueRateLimit(ctx, rateLimitRequest{
+			instanceID:    instanceID,
+			tapName:       alloc.TAPDevice,
+			bridgeName:    network.Bridge,
+			downloadBps:   downloadBps,
+			uploadBps:     uploadBps,
+			uploadCeilBps: uploadCeilBps,
+		})
 	} else {
 		m.clearClassID(instanceID)
 	}
@@ -199,6 +147,182 @@ func (m *manager) RecreateAllocation(ctx context.Context, instanceID string, dow
 		"upload_bps", uploadBps)
 
 	return nil
+}
+
+func (m *manager) reserveAllocationIdentityLocked(ctx context.Context, network *Network, req AllocateRequest) (*NetworkConfig, error) {
+	listCtx, listSpanEnd := startNetworkStep(ctx, "network.list_allocations",
+		attribute.String("operation", "list_allocations"),
+		attribute.String("caller", "create_allocation"),
+	)
+	allocations, err := m.listAllocationsWithPendingLocked(listCtx)
+	listSpanEnd(err)
+	if err != nil {
+		return nil, fmt.Errorf("list allocations: %w", err)
+	}
+
+	_, nameSpanEnd := startNetworkStep(ctx, "network.name_exists",
+		attribute.String("operation", "name_exists"),
+		attribute.String("instance_id", req.InstanceID),
+	)
+	exists := nameExistsInAllocations(allocations, req.InstanceName, req.InstanceID)
+	nameSpanEnd(nil)
+	if exists {
+		return nil, fmt.Errorf("%w: instance name '%s' already exists, can't assign into same network: %s",
+			ErrNameExists, req.InstanceName, network.Name)
+	}
+
+	_, ipSpanEnd := startNetworkStep(ctx, "network.allocate_ip",
+		attribute.String("operation", "allocate_ip"),
+		attribute.String("instance_id", req.InstanceID),
+	)
+	ip, err := allocateNextIPFromAllocations(network.Subnet, allocations)
+	ipSpanEnd(err)
+	if err != nil {
+		return nil, fmt.Errorf("allocate IP: %w", err)
+	}
+
+	_, macSpanEnd := startNetworkStep(ctx, "network.allocate_mac",
+		attribute.String("operation", "allocate_mac"),
+		attribute.String("instance_id", req.InstanceID),
+	)
+	mac, err := allocateUniqueMACFromAllocations(allocations, generateMAC)
+	macSpanEnd(err)
+	if err != nil {
+		return nil, fmt.Errorf("allocate MAC: %w", err)
+	}
+
+	tap := GenerateTAPName(req.InstanceID)
+	_, ipNet, _ := net.ParseCIDR(network.Subnet)
+	netmask := fmt.Sprintf("%d.%d.%d.%d", ipNet.Mask[0], ipNet.Mask[1], ipNet.Mask[2], ipNet.Mask[3])
+
+	m.rememberPendingAllocationLocked(Allocation{
+		InstanceID:   req.InstanceID,
+		InstanceName: req.InstanceName,
+		Network:      "default",
+		IP:           ip,
+		MAC:          mac,
+		TAPDevice:    tap,
+		Gateway:      network.Gateway,
+		Netmask:      netmask,
+		DNS:          m.config.Network.DNSServer,
+		State:        "pending",
+	})
+
+	return &NetworkConfig{
+		IP:        ip,
+		MAC:       mac,
+		Gateway:   network.Gateway,
+		Netmask:   netmask,
+		DNS:       m.config.Network.DNSServer,
+		TAPDevice: tap,
+	}, nil
+}
+
+type rateLimitRequest struct {
+	instanceID    string
+	tapName       string
+	bridgeName    string
+	downloadBps   int64
+	uploadBps     int64
+	uploadCeilBps int64
+}
+
+func (m *manager) enqueueRateLimit(ctx context.Context, req rateLimitRequest) {
+	go m.applyRateLimitAsync(ctx, req)
+}
+
+func (m *manager) applyRateLimitAsync(ctx context.Context, req rateLimitRequest) {
+	waitCtx, waitSpanEnd := startDetachedNetworkStep(ctx, "network.rate_limit.wait_for_tc_mutex",
+		attribute.String("operation", "wait_for_tc_mutex"),
+		attribute.String("instance_id", req.instanceID),
+		attribute.String("tap", req.tapName),
+	)
+	ctx = waitCtx
+	log := logger.FromContext(ctx)
+
+	m.tcMu.Lock()
+	waitSpanEnd(nil)
+	defer m.tcMu.Unlock()
+
+	applyCtx, applySpanEnd := startNetworkStep(waitCtx, "network.rate_limit.apply",
+		attribute.String("operation", "apply_rate_limit"),
+		attribute.String("instance_id", req.instanceID),
+		attribute.String("tap", req.tapName),
+		attribute.String("bridge", req.bridgeName),
+		attribute.Bool("download_rate_limit", req.downloadBps > 0),
+		attribute.Bool("upload_rate_limit", req.uploadBps > 0),
+	)
+	var applyErr error
+	defer func() {
+		applySpanEnd(applyErr)
+	}()
+
+	if req.downloadBps > 0 {
+		downloadCtx, downloadEnd := startNetworkStep(applyCtx, "network.rate_limit.download",
+			attribute.String("operation", "download_rate_limit"),
+			attribute.String("instance_id", req.instanceID),
+			attribute.String("tap", req.tapName),
+		)
+		if err := m.applyDownloadRateLimit(downloadCtx, req.tapName, req.downloadBps); err != nil {
+			downloadEnd(err)
+			applyErr = err
+			log.ErrorContext(ctx, "failed to apply async download rate limit",
+				"instance_id", req.instanceID,
+				"tap", req.tapName,
+				"error", err)
+		} else {
+			downloadEnd(nil)
+		}
+	}
+
+	if req.uploadBps > 0 {
+		uploadCtx, uploadEnd := startNetworkStep(applyCtx, "network.rate_limit.upload",
+			attribute.String("operation", "upload_rate_limit"),
+			attribute.String("instance_id", req.instanceID),
+			attribute.String("tap", req.tapName),
+			attribute.String("bridge", req.bridgeName),
+		)
+		classID, err := m.addVMClass(uploadCtx, req.bridgeName, req.tapName, req.uploadBps, req.uploadCeilBps)
+		uploadEnd(err)
+		if err != nil {
+			applyErr = err
+			log.ErrorContext(ctx, "failed to apply async upload rate limit",
+				"instance_id", req.instanceID,
+				"tap", req.tapName,
+				"bridge", req.bridgeName,
+				"error", err)
+			return
+		}
+
+		_, saveEnd := startNetworkStep(applyCtx, "network.save_class_id",
+			attribute.String("operation", "save_class_id"),
+			attribute.String("instance_id", req.instanceID),
+			attribute.Bool("has_class_id", classID != ""),
+		)
+		if classID != "" {
+			if err := m.saveClassID(req.instanceID, classID); err != nil {
+				saveEnd(err)
+				applyErr = err
+				log.ErrorContext(ctx, "failed to persist async tc class id",
+					"instance_id", req.instanceID,
+					"tap", req.tapName,
+					"class_id", classID,
+					"error", err)
+				return
+			}
+		} else {
+			m.clearClassID(req.instanceID)
+		}
+		saveEnd(nil)
+	} else {
+		m.clearClassID(req.instanceID)
+	}
+
+	log.DebugContext(ctx, "async network rate limits applied",
+		"instance_id", req.instanceID,
+		"tap", req.tapName,
+		"download_bps", req.downloadBps,
+		"upload_bps", req.uploadBps)
 }
 
 // ReleaseByInstanceID is a best-effort fallback for cases where the full Allocation
@@ -228,8 +352,13 @@ func (m *manager) ReleaseAllocation(ctx context.Context, alloc *Allocation) erro
 	if alloc == nil {
 		return nil
 	}
+	m.forgetPendingAllocation(alloc.InstanceID)
 
-	// 1. Delete TAP device (best effort), using stored class ID for correct HTB cleanup
+	// 1. Delete TAP device (best effort), using stored class ID for correct HTB cleanup.
+	// Serialize with async tc setup so a queued rate-limit job cannot race with
+	// class removal and leave stale bridge state behind.
+	m.tcMu.Lock()
+	defer m.tcMu.Unlock()
 	if err := m.deleteTAPDevice(alloc.TAPDevice, alloc.ClassID); err != nil {
 		log.WarnContext(ctx, "failed to delete TAP device", "tap", alloc.TAPDevice, "error", err)
 	} else {
@@ -247,8 +376,13 @@ func (m *manager) ReleaseAllocation(ctx context.Context, alloc *Allocation) erro
 // getOrInitDefaultNetwork resolves the default network and self-heals by running
 // Initialize if bridge state is missing, then retries briefly to absorb netlink propagation delay.
 func (m *manager) getOrInitDefaultNetwork(ctx context.Context) (*Network, error) {
+	if network := m.cachedDefaultNetwork(); network != nil {
+		return network, nil
+	}
+
 	network, err := m.getDefaultNetwork(ctx)
 	if err == nil {
+		m.setDefaultNetwork(network)
 		return network, nil
 	}
 
@@ -263,6 +397,7 @@ func (m *manager) getOrInitDefaultNetwork(ctx context.Context) (*Network, error)
 	for i := 0; i < retries; i++ {
 		network, err = m.getDefaultNetwork(ctx)
 		if err == nil {
+			m.setDefaultNetwork(network)
 			return network, nil
 		}
 		time.Sleep(retryDelay)
@@ -282,6 +417,7 @@ func (m *manager) allocateNextIP(ctx context.Context, subnet string) (string, er
 		chooseSpanEnd(chooseErr)
 	}()
 
+	// Get all currently allocated IPs
 	listCtx, listSpanEnd := startNetworkStep(chooseCtx, "network.list_allocations",
 		attribute.String("operation", "list_allocations"),
 		attribute.String("caller", "allocate_ip"),
@@ -425,18 +561,6 @@ func allocateUniqueMACFromAllocations(allocations []Allocation, generate func() 
 	}
 
 	return allocateUniqueMACFromSet(usedMACs, generate)
-}
-
-func nameExistsInAllocations(allocations []Allocation, name string, excludeInstanceID string) bool {
-	for _, alloc := range allocations {
-		if excludeInstanceID != "" && alloc.InstanceID == excludeInstanceID {
-			continue
-		}
-		if alloc.InstanceName == name {
-			return true
-		}
-	}
-	return false
 }
 
 func allocateUniqueMACFromSet(usedMACs map[string]bool, generate func() (string, error)) (string, error) {

--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -63,7 +63,7 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 	tapSpanEnd(err)
 	if err != nil {
 		m.forgetPendingAllocation(req.InstanceID)
-		_ = m.deleteTAPDevice(netConfig.TAPDevice, "")
+		_ = m.deleteTAPDeviceSerialized(netConfig.TAPDevice, "")
 		return nil, fmt.Errorf("create TAP device: %w", err)
 	}
 	m.recordTAPOperation(ctx, "create")
@@ -141,7 +141,7 @@ func (m *manager) RecreateAllocation(ctx context.Context, instanceID string, dow
 	err = m.createTAPDevice(tapCtx, alloc.TAPDevice, network.Bridge, network.Isolated)
 	tapSpanEnd(err)
 	if err != nil {
-		_ = m.deleteTAPDevice(alloc.TAPDevice, alloc.ClassID)
+		_ = m.deleteTAPDeviceSerialized(alloc.TAPDevice, alloc.ClassID)
 		return fmt.Errorf("create TAP device: %w", err)
 	}
 	m.recordTAPOperation(ctx, "create")
@@ -264,6 +264,13 @@ func (m *manager) applyRateLimitAsync(ctx context.Context, req rateLimitRequest)
 	waitSpanEnd(nil)
 	defer m.tcMu.Unlock()
 
+	if !m.tapDeviceExists(req.tapName) {
+		log.DebugContext(ctx, "skipping async network rate limits for released TAP",
+			"instance_id", req.instanceID,
+			"tap", req.tapName)
+		return
+	}
+
 	applyCtx, applySpanEnd := startNetworkStep(waitCtx, "network.rate_limit.apply",
 		attribute.String("operation", "apply_rate_limit"),
 		attribute.String("instance_id", req.instanceID),
@@ -375,11 +382,9 @@ func (m *manager) ReleaseAllocation(ctx context.Context, alloc *Allocation) erro
 	m.forgetPendingAllocation(alloc.InstanceID)
 
 	// 1. Delete TAP device (best effort), using stored class ID for correct HTB cleanup.
-	// Serialize with async tc setup so a queued rate-limit job cannot race with
+	// Serialize with async tc setup so queued rate-limit work cannot race with
 	// class removal and leave stale bridge state behind.
-	m.tcMu.Lock()
-	defer m.tcMu.Unlock()
-	if err := m.deleteTAPDevice(alloc.TAPDevice, alloc.ClassID); err != nil {
+	if err := m.deleteTAPDeviceSerialized(alloc.TAPDevice, alloc.ClassID); err != nil {
 		log.WarnContext(ctx, "failed to delete TAP device", "tap", alloc.TAPDevice, "error", err)
 	} else {
 		m.recordTAPOperation(ctx, "delete")
@@ -391,6 +396,12 @@ func (m *manager) ReleaseAllocation(ctx context.Context, alloc *Allocation) erro
 		"ip", alloc.IP)
 
 	return nil
+}
+
+func (m *manager) deleteTAPDeviceSerialized(tapName, classID string) error {
+	m.tcMu.Lock()
+	defer m.tcMu.Unlock()
+	return m.deleteTAPDevice(tapName, classID)
 }
 
 // getOrInitDefaultNetwork resolves the default network and self-heals by running

--- a/lib/network/bridge_darwin.go
+++ b/lib/network/bridge_darwin.go
@@ -54,6 +54,10 @@ func (m *manager) deleteTAPDevice(tapName, classID string) error {
 	return nil
 }
 
+func (m *manager) tapDeviceExists(tapName string) bool {
+	return true
+}
+
 // queryNetworkState returns a stub network state for macOS.
 // On macOS, we use NAT which doesn't have a physical bridge.
 func (m *manager) queryNetworkState(bridgeName string) (*Network, error) {

--- a/lib/network/bridge_darwin.go
+++ b/lib/network/bridge_darwin.go
@@ -36,8 +36,16 @@ func (m *manager) setupBridgeHTB(ctx context.Context, bridgeName string, capacit
 
 // createTAPDevice is a no-op on macOS as we use NAT networking.
 // Virtualization.framework creates virtual network interfaces internally.
-func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName string, isolated bool, downloadBps, uploadBps, uploadCeilBps int64) (string, error) {
+func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName string, isolated bool) error {
 	// On macOS with vz, network devices are created by the VMM itself
+	return nil
+}
+
+func (m *manager) applyDownloadRateLimit(ctx context.Context, tapName string, rateLimitBps int64) error {
+	return nil
+}
+
+func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, rateBps, ceilBps int64) (string, error) {
 	return "", nil
 }
 

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kernel/hypeman/lib/logger"
 	"github.com/vishvananda/netlink"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sys/unix"
 )
 
@@ -500,9 +501,21 @@ func (m *manager) lastHypemanForwardRulePosition() int {
 // Returns the tc class ID actually assigned (empty if no upload rate limiting).
 func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName string, isolated bool, downloadBps, uploadBps, uploadCeilBps int64) (string, error) {
 	// 1. Check if TAP already exists
-	if _, err := netlink.LinkByName(tapName); err == nil {
+	_, linkLookupEnd := startNetworkStep(ctx, "network.create_tap.link_lookup_existing",
+		attribute.String("operation", "link_lookup_existing"),
+		attribute.String("tap", tapName),
+	)
+	_, err := netlink.LinkByName(tapName)
+	linkLookupEnd(nil)
+	if err == nil {
 		// TAP already exists, delete it first
-		if err := m.deleteTAPDevice(tapName, ""); err != nil {
+		_, deleteEnd := startNetworkStep(ctx, "network.create_tap.delete_existing",
+			attribute.String("operation", "delete_existing"),
+			attribute.String("tap", tapName),
+		)
+		err := m.deleteTAPDevice(tapName, "")
+		deleteEnd(err)
+		if err != nil {
 			return "", fmt.Errorf("delete existing TAP: %w", err)
 		}
 	}
@@ -521,37 +534,73 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 		Group: uint32(gid),
 	}
 
-	if err := netlink.LinkAdd(tap); err != nil {
+	_, linkAddEnd := startNetworkStep(ctx, "network.create_tap.link_add",
+		attribute.String("operation", "link_add"),
+		attribute.String("tap", tapName),
+	)
+	err = netlink.LinkAdd(tap)
+	linkAddEnd(err)
+	if err != nil {
 		return "", fmt.Errorf("create TAP device: %w", err)
 	}
 
 	// 3. Set TAP up
 	tapLink := tap
 
-	if err := netlink.LinkSetUp(tapLink); err != nil {
+	_, setUpEnd := startNetworkStep(ctx, "network.create_tap.link_set_up",
+		attribute.String("operation", "link_set_up"),
+		attribute.String("tap", tapName),
+	)
+	err = netlink.LinkSetUp(tapLink)
+	setUpEnd(err)
+	if err != nil {
 		return "", fmt.Errorf("set TAP up: %w", err)
 	}
 
 	// 4. Attach TAP to bridge
+	_, bridgeLookupEnd := startNetworkStep(ctx, "network.create_tap.link_lookup_bridge",
+		attribute.String("operation", "link_lookup_bridge"),
+		attribute.String("bridge", bridgeName),
+	)
 	bridge, err := netlink.LinkByName(bridgeName)
+	bridgeLookupEnd(err)
 	if err != nil {
 		return "", fmt.Errorf("get bridge: %w", err)
 	}
 
-	if err := netlink.LinkSetMaster(tapLink, bridge); err != nil {
+	_, setMasterEnd := startNetworkStep(ctx, "network.create_tap.link_set_master",
+		attribute.String("operation", "link_set_master"),
+		attribute.String("tap", tapName),
+		attribute.String("bridge", bridgeName),
+	)
+	err = netlink.LinkSetMaster(tapLink, bridge)
+	setMasterEnd(err)
+	if err != nil {
 		return "", fmt.Errorf("attach TAP to bridge: %w", err)
 	}
 
 	// 5. Enable port isolation so isolated TAPs can't directly talk to each other (requires kernel support and capabilities)
 	if isolated {
-		if err := netlink.LinkSetIsolated(tapLink, true); err != nil {
+		_, isolationEnd := startNetworkStep(ctx, "network.create_tap.set_isolation",
+			attribute.String("operation", "set_isolation"),
+			attribute.String("tap", tapName),
+		)
+		err = netlink.LinkSetIsolated(tapLink, true)
+		isolationEnd(err)
+		if err != nil {
 			return "", fmt.Errorf("set isolation mode: %w", err)
 		}
 	}
 
 	// 6. Apply download rate limiting (TBF on TAP egress)
 	if downloadBps > 0 {
-		if err := m.applyDownloadRateLimit(tapName, downloadBps); err != nil {
+		_, downloadEnd := startNetworkStep(ctx, "network.create_tap.download_rate_limit",
+			attribute.String("operation", "download_rate_limit"),
+			attribute.String("tap", tapName),
+		)
+		err := m.applyDownloadRateLimit(ctx, tapName, downloadBps)
+		downloadEnd(err)
+		if err != nil {
 			return "", fmt.Errorf("apply download rate limit: %w", err)
 		}
 	}
@@ -560,7 +609,13 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 	var classID string
 	if uploadBps > 0 {
 		var err error
-		classID, err = m.addVMClass(ctx, bridgeName, tapName, uploadBps, uploadCeilBps)
+		uploadCtx, uploadEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit",
+			attribute.String("operation", "upload_rate_limit"),
+			attribute.String("tap", tapName),
+			attribute.String("bridge", bridgeName),
+		)
+		classID, err = m.addVMClass(uploadCtx, bridgeName, tapName, uploadBps, uploadCeilBps)
+		uploadEnd(err)
 		if err != nil {
 			return "", fmt.Errorf("apply upload rate limit: %w", err)
 		}
@@ -570,7 +625,7 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 }
 
 // applyDownloadRateLimit applies download (external→VM) rate limiting using TBF on TAP egress.
-func (m *manager) applyDownloadRateLimit(tapName string, rateLimitBps int64) error {
+func (m *manager) applyDownloadRateLimit(ctx context.Context, tapName string, rateLimitBps int64) error {
 	rateStr := formatTcRate(rateLimitBps)
 
 	// Use Token Bucket Filter (tbf) for download shaping
@@ -590,7 +645,12 @@ func (m *manager) applyDownloadRateLimit(tapName string, rateLimitBps int64) err
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 	}
+	_, tcEnd := startNetworkStep(ctx, "network.create_tap.download_rate_limit.tc_qdisc_tbf",
+		attribute.String("operation", "tc_qdisc_tbf"),
+		attribute.String("tap", tapName),
+	)
 	output, err := cmd.CombinedOutput()
+	tcEnd(err)
 	if err != nil {
 		return fmt.Errorf("tc qdisc add tbf: %w (output: %s)", err, string(output))
 	}
@@ -685,7 +745,15 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 		}
+		_, classAddEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit.tc_class_add",
+			attribute.String("operation", "tc_class_add"),
+			attribute.String("tap", tapName),
+			attribute.String("bridge", bridgeName),
+			attribute.String("class_id", fullClassID),
+			attribute.Int("attempt", attempt+1),
+		)
 		output, err := cmd.CombinedOutput()
+		classAddEnd(err)
 		if err != nil {
 			// Check for "File exists" collision (exit status 2).
 			var exitErr *exec.ExitError
@@ -713,9 +781,21 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 		qdiscCmd.SysProcAttr = &syscall.SysProcAttr{
 			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 		}
-		qdiscCmd.Run() // Best effort
+		_, fqCodelEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit.tc_qdisc_fq_codel",
+			attribute.String("operation", "tc_qdisc_fq_codel"),
+			attribute.String("tap", tapName),
+			attribute.String("bridge", bridgeName),
+			attribute.String("class_id", fullClassID),
+		)
+		fqCodelErr := qdiscCmd.Run() // Best effort
+		fqCodelEnd(fqCodelErr)
 
+		_, filterLinkEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit.link_lookup_filter",
+			attribute.String("operation", "link_lookup_filter"),
+			attribute.String("tap", tapName),
+		)
 		tapLink, linkErr := netlink.LinkByName(tapName)
+		filterLinkEnd(linkErr)
 		if linkErr != nil {
 			return "", fmt.Errorf("get TAP link for filter: %w", linkErr)
 		}
@@ -728,7 +808,15 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 		filterCmd.SysProcAttr = &syscall.SysProcAttr{
 			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 		}
-		if output, filterErr := filterCmd.CombinedOutput(); filterErr != nil {
+		_, filterEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit.tc_filter_add",
+			attribute.String("operation", "tc_filter_add"),
+			attribute.String("tap", tapName),
+			attribute.String("bridge", bridgeName),
+			attribute.String("class_id", fullClassID),
+		)
+		output, filterErr := filterCmd.CombinedOutput()
+		filterEnd(filterErr)
+		if filterErr != nil {
 			return "", fmt.Errorf("tc filter add: %w (output: %s)", filterErr, string(output))
 		}
 

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -510,7 +510,7 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 			attribute.String("operation", "delete_existing"),
 			attribute.String("tap", tapName),
 		)
-		err := m.deleteTAPDevice(tapName, "")
+		err := m.deleteTAPDeviceSerialized(tapName, "")
 		deleteEnd(err)
 		if err != nil {
 			return fmt.Errorf("delete existing TAP: %w", err)
@@ -886,6 +886,11 @@ func (m *manager) deleteTAPDevice(tapName, classID string) error {
 	return nil
 }
 
+func (m *manager) tapDeviceExists(tapName string) bool {
+	_, err := netlink.LinkByName(tapName)
+	return err == nil
+}
+
 // queryNetworkState queries kernel for bridge state
 func (m *manager) queryNetworkState(bridgeName string) (*Network, error) {
 	link, err := netlink.LinkByName(bridgeName)
@@ -987,7 +992,7 @@ func (m *manager) CleanupOrphanedTAPs(ctx context.Context, preserveInstanceIDs [
 		}
 
 		// Orphaned TAP - delete it (no stored classID available, falls back to deriveClassID)
-		if err := m.deleteTAPDevice(name, ""); err != nil {
+		if err := m.deleteTAPDeviceSerialized(name, ""); err != nil {
 			log.WarnContext(ctx, "failed to delete orphaned TAP", "tap", name, "error", err)
 			continue
 		}

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -495,11 +495,8 @@ func (m *manager) lastHypemanForwardRulePosition() int {
 	return lastPos
 }
 
-// createTAPDevice creates TAP device and attaches to bridge.
-// downloadBps: rate limit for download (external→VM), applied as TBF on TAP egress
-// uploadBps/uploadCeilBps: rate limit for upload (VM→external), applied as HTB class on bridge
-// Returns the tc class ID actually assigned (empty if no upload rate limiting).
-func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName string, isolated bool, downloadBps, uploadBps, uploadCeilBps int64) (string, error) {
+// createTAPDevice creates TAP device and attaches it to the bridge.
+func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName string, isolated bool) error {
 	// 1. Check if TAP already exists
 	_, linkLookupEnd := startNetworkStep(ctx, "network.create_tap.link_lookup_existing",
 		attribute.String("operation", "link_lookup_existing"),
@@ -516,7 +513,7 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 		err := m.deleteTAPDevice(tapName, "")
 		deleteEnd(err)
 		if err != nil {
-			return "", fmt.Errorf("delete existing TAP: %w", err)
+			return fmt.Errorf("delete existing TAP: %w", err)
 		}
 	}
 
@@ -541,7 +538,7 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 	err = netlink.LinkAdd(tap)
 	linkAddEnd(err)
 	if err != nil {
-		return "", fmt.Errorf("create TAP device: %w", err)
+		return fmt.Errorf("create TAP device: %w", err)
 	}
 
 	// 3. Set TAP up
@@ -554,7 +551,7 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 	err = netlink.LinkSetUp(tapLink)
 	setUpEnd(err)
 	if err != nil {
-		return "", fmt.Errorf("set TAP up: %w", err)
+		return fmt.Errorf("set TAP up: %w", err)
 	}
 
 	// 4. Attach TAP to bridge
@@ -565,7 +562,7 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 	bridge, err := netlink.LinkByName(bridgeName)
 	bridgeLookupEnd(err)
 	if err != nil {
-		return "", fmt.Errorf("get bridge: %w", err)
+		return fmt.Errorf("get bridge: %w", err)
 	}
 
 	_, setMasterEnd := startNetworkStep(ctx, "network.create_tap.link_set_master",
@@ -576,7 +573,7 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 	err = netlink.LinkSetMaster(tapLink, bridge)
 	setMasterEnd(err)
 	if err != nil {
-		return "", fmt.Errorf("attach TAP to bridge: %w", err)
+		return fmt.Errorf("attach TAP to bridge: %w", err)
 	}
 
 	// 5. Enable port isolation so isolated TAPs can't directly talk to each other (requires kernel support and capabilities)
@@ -588,40 +585,11 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 		err = netlink.LinkSetIsolated(tapLink, true)
 		isolationEnd(err)
 		if err != nil {
-			return "", fmt.Errorf("set isolation mode: %w", err)
+			return fmt.Errorf("set isolation mode: %w", err)
 		}
 	}
 
-	// 6. Apply download rate limiting (TBF on TAP egress)
-	if downloadBps > 0 {
-		_, downloadEnd := startNetworkStep(ctx, "network.create_tap.download_rate_limit",
-			attribute.String("operation", "download_rate_limit"),
-			attribute.String("tap", tapName),
-		)
-		err := m.applyDownloadRateLimit(ctx, tapName, downloadBps)
-		downloadEnd(err)
-		if err != nil {
-			return "", fmt.Errorf("apply download rate limit: %w", err)
-		}
-	}
-
-	// 7. Apply upload rate limiting (HTB class on bridge)
-	var classID string
-	if uploadBps > 0 {
-		var err error
-		uploadCtx, uploadEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit",
-			attribute.String("operation", "upload_rate_limit"),
-			attribute.String("tap", tapName),
-			attribute.String("bridge", bridgeName),
-		)
-		classID, err = m.addVMClass(uploadCtx, bridgeName, tapName, uploadBps, uploadCeilBps)
-		uploadEnd(err)
-		if err != nil {
-			return "", fmt.Errorf("apply upload rate limit: %w", err)
-		}
-	}
-
-	return classID, nil
+	return nil
 }
 
 // applyDownloadRateLimit applies download (external→VM) rate limiting using TBF on TAP egress.
@@ -645,7 +613,7 @@ func (m *manager) applyDownloadRateLimit(ctx context.Context, tapName string, ra
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 	}
-	_, tcEnd := startNetworkStep(ctx, "network.create_tap.download_rate_limit.tc_qdisc_tbf",
+	_, tcEnd := startNetworkStep(ctx, "network.rate_limit.download.tc_qdisc_tbf",
 		attribute.String("operation", "tc_qdisc_tbf"),
 		attribute.String("tap", tapName),
 	)
@@ -745,7 +713,7 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 		}
-		_, classAddEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit.tc_class_add",
+		_, classAddEnd := startNetworkStep(ctx, "network.rate_limit.upload.tc_class_add",
 			attribute.String("operation", "tc_class_add"),
 			attribute.String("tap", tapName),
 			attribute.String("bridge", bridgeName),
@@ -781,7 +749,7 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 		qdiscCmd.SysProcAttr = &syscall.SysProcAttr{
 			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 		}
-		_, fqCodelEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit.tc_qdisc_fq_codel",
+		_, fqCodelEnd := startNetworkStep(ctx, "network.rate_limit.upload.tc_qdisc_fq_codel",
 			attribute.String("operation", "tc_qdisc_fq_codel"),
 			attribute.String("tap", tapName),
 			attribute.String("bridge", bridgeName),
@@ -790,7 +758,7 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 		fqCodelErr := qdiscCmd.Run() // Best effort
 		fqCodelEnd(fqCodelErr)
 
-		_, filterLinkEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit.link_lookup_filter",
+		_, filterLinkEnd := startNetworkStep(ctx, "network.rate_limit.upload.link_lookup_filter",
 			attribute.String("operation", "link_lookup_filter"),
 			attribute.String("tap", tapName),
 		)
@@ -808,7 +776,7 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 		filterCmd.SysProcAttr = &syscall.SysProcAttr{
 			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 		}
-		_, filterEnd := startNetworkStep(ctx, "network.create_tap.upload_rate_limit.tc_filter_add",
+		_, filterEnd := startNetworkStep(ctx, "network.rate_limit.upload.tc_filter_add",
 			attribute.String("operation", "tc_filter_add"),
 			attribute.String("tap", tapName),
 			attribute.String("bridge", bridgeName),
@@ -897,23 +865,6 @@ func deriveClassIDVal(tapName string) uint16 {
 // deriveClassID derives a unique HTB class ID string from a TAP name.
 func deriveClassID(tapName string) string {
 	return fmt.Sprintf("%04x", deriveClassIDVal(tapName))
-}
-
-// formatTcRate formats bytes per second as a tc rate string.
-// It uses the largest unit that exactly represents the value to avoid
-// truncation from integer division (e.g., 2.5 Gbps becomes "2500mbit" not "2gbit").
-func formatTcRate(bytesPerSec int64) string {
-	bitsPerSec := bytesPerSec * 8
-	switch {
-	case bitsPerSec >= 1000000000 && bitsPerSec%1000000000 == 0:
-		return fmt.Sprintf("%dgbit", bitsPerSec/1000000000)
-	case bitsPerSec >= 1000000 && bitsPerSec%1000000 == 0:
-		return fmt.Sprintf("%dmbit", bitsPerSec/1000000)
-	case bitsPerSec >= 1000 && bitsPerSec%1000 == 0:
-		return fmt.Sprintf("%dkbit", bitsPerSec/1000)
-	default:
-		return fmt.Sprintf("%dbit", bitsPerSec)
-	}
 }
 
 // deleteTAPDevice removes TAP device and its associated HTB class on the bridge.

--- a/lib/network/derive.go
+++ b/lib/network/derive.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/logger"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // instanceMetadata is the minimal metadata we need to derive allocations
@@ -123,8 +124,22 @@ func (m *manager) ListAllocations(ctx context.Context) ([]Allocation, error) {
 // excludeInstanceID allows excluding a specific instance from the check (used when
 // starting an existing instance to avoid it conflicting with itself).
 func (m *manager) NameExists(ctx context.Context, name string, excludeInstanceID string) (bool, error) {
-	allocations, err := m.ListAllocations(ctx)
+	checkCtx, checkSpanEnd := startNetworkStep(ctx, "network.name_exists",
+		attribute.String("operation", "name_exists"),
+	)
+	var checkErr error
+	defer func() {
+		checkSpanEnd(checkErr)
+	}()
+
+	listCtx, listSpanEnd := startNetworkStep(checkCtx, "network.list_allocations",
+		attribute.String("operation", "list_allocations"),
+		attribute.String("caller", "name_exists"),
+	)
+	allocations, err := m.ListAllocations(listCtx)
+	listSpanEnd(err)
 	if err != nil {
+		checkErr = err
 		return false, err
 	}
 

--- a/lib/network/derive.go
+++ b/lib/network/derive.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"time"
 
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/logger"
@@ -106,9 +105,11 @@ func (m *manager) GetAllocation(ctx context.Context, instanceID string) (*Alloca
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.prunePendingAllocationsLocked(time.Now())
 	if pending, ok := m.pendingAllocations[instanceID]; ok {
 		alloc := pending.allocation
+		if alloc.ClassID == "" {
+			alloc.ClassID = m.loadClassID(instanceID)
+		}
 		return &alloc, nil
 	}
 	return alloc, err
@@ -172,16 +173,20 @@ func (m *manager) listAllocationsWithPendingLocked(ctx context.Context) ([]Alloc
 		return nil, err
 	}
 
-	m.prunePendingAllocationsLocked(time.Now())
 	seen := make(map[string]struct{}, len(allocations))
 	for _, alloc := range allocations {
 		seen[alloc.InstanceID] = struct{}{}
+		delete(m.pendingAllocations, alloc.InstanceID)
 	}
 	for id, pending := range m.pendingAllocations {
 		if _, ok := seen[id]; ok {
 			continue
 		}
-		allocations = append(allocations, pending.allocation)
+		alloc := pending.allocation
+		if alloc.ClassID == "" {
+			alloc.ClassID = m.loadClassID(id)
+		}
+		allocations = append(allocations, alloc)
 	}
 	return allocations, nil
 }
@@ -192,7 +197,6 @@ func (m *manager) rememberPendingAllocationLocked(alloc Allocation) {
 	}
 	m.pendingAllocations[alloc.InstanceID] = pendingAllocation{
 		allocation: alloc,
-		expiresAt:  time.Now().Add(pendingAllocationTTL),
 	}
 }
 
@@ -200,14 +204,6 @@ func (m *manager) forgetPendingAllocation(instanceID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.pendingAllocations, instanceID)
-}
-
-func (m *manager) prunePendingAllocationsLocked(now time.Time) {
-	for id, pending := range m.pendingAllocations {
-		if now.After(pending.expiresAt) {
-			delete(m.pendingAllocations, id)
-		}
-	}
 }
 
 func nameExistsInAllocations(allocations []Allocation, name, excludeInstanceID string) bool {

--- a/lib/network/derive.go
+++ b/lib/network/derive.go
@@ -3,9 +3,11 @@ package network
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/logger"
@@ -94,7 +96,22 @@ func (m *manager) deriveAllocation(ctx context.Context, instanceID string) (*All
 
 // GetAllocation gets the allocation for a specific instance
 func (m *manager) GetAllocation(ctx context.Context, instanceID string) (*Allocation, error) {
-	return m.deriveAllocation(ctx, instanceID)
+	alloc, err := m.deriveAllocation(ctx, instanceID)
+	if err == nil && alloc != nil {
+		return alloc, nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.prunePendingAllocationsLocked(time.Now())
+	if pending, ok := m.pendingAllocations[instanceID]; ok {
+		alloc := pending.allocation
+		return &alloc, nil
+	}
+	return alloc, err
 }
 
 // ListAllocations scans all guest directories and derives allocations
@@ -124,6 +141,9 @@ func (m *manager) ListAllocations(ctx context.Context) ([]Allocation, error) {
 // excludeInstanceID allows excluding a specific instance from the check (used when
 // starting an existing instance to avoid it conflicting with itself).
 func (m *manager) NameExists(ctx context.Context, name string, excludeInstanceID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	checkCtx, checkSpanEnd := startNetworkStep(ctx, "network.name_exists",
 		attribute.String("operation", "name_exists"),
 	)
@@ -136,23 +156,70 @@ func (m *manager) NameExists(ctx context.Context, name string, excludeInstanceID
 		attribute.String("operation", "list_allocations"),
 		attribute.String("caller", "name_exists"),
 	)
-	allocations, err := m.ListAllocations(listCtx)
+	allocations, err := m.listAllocationsWithPendingLocked(listCtx)
 	listSpanEnd(err)
 	if err != nil {
 		checkErr = err
 		return false, err
 	}
 
+	return nameExistsInAllocations(allocations, name, excludeInstanceID), nil
+}
+
+func (m *manager) listAllocationsWithPendingLocked(ctx context.Context) ([]Allocation, error) {
+	allocations, err := m.ListAllocations(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.prunePendingAllocationsLocked(time.Now())
+	seen := make(map[string]struct{}, len(allocations))
 	for _, alloc := range allocations {
-		// Skip the excluded instance (e.g., when restarting an instance)
+		seen[alloc.InstanceID] = struct{}{}
+	}
+	for id, pending := range m.pendingAllocations {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		allocations = append(allocations, pending.allocation)
+	}
+	return allocations, nil
+}
+
+func (m *manager) rememberPendingAllocationLocked(alloc Allocation) {
+	if m.pendingAllocations == nil {
+		m.pendingAllocations = make(map[string]pendingAllocation)
+	}
+	m.pendingAllocations[alloc.InstanceID] = pendingAllocation{
+		allocation: alloc,
+		expiresAt:  time.Now().Add(pendingAllocationTTL),
+	}
+}
+
+func (m *manager) forgetPendingAllocation(instanceID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.pendingAllocations, instanceID)
+}
+
+func (m *manager) prunePendingAllocationsLocked(now time.Time) {
+	for id, pending := range m.pendingAllocations {
+		if now.After(pending.expiresAt) {
+			delete(m.pendingAllocations, id)
+		}
+	}
+}
+
+func nameExistsInAllocations(allocations []Allocation, name, excludeInstanceID string) bool {
+	for _, alloc := range allocations {
 		if excludeInstanceID != "" && alloc.InstanceID == excludeInstanceID {
 			continue
 		}
 		if alloc.InstanceName == name {
-			return true, nil
+			return true
 		}
 	}
-	return false, nil
+	return false
 }
 
 // loadInstanceMetadata loads minimal instance metadata

--- a/lib/network/manager.go
+++ b/lib/network/manager.go
@@ -49,18 +49,30 @@ type Manager interface {
 
 // manager implements the Manager interface
 type manager struct {
-	paths   *paths.Paths
-	config  *config.Config
-	mu      sync.Mutex // Protects network allocation operations (IP allocation)
-	metrics *Metrics
+	paths              *paths.Paths
+	config             *config.Config
+	mu                 sync.Mutex // Protects network identity reservation.
+	networkMu          sync.RWMutex
+	defaultNetwork     *Network
+	pendingAllocations map[string]pendingAllocation
+	tcMu               sync.Mutex // Serializes shared bridge tc mutations.
+	metrics            *Metrics
 }
+
+type pendingAllocation struct {
+	allocation Allocation
+	expiresAt  time.Time
+}
+
+const pendingAllocationTTL = 10 * time.Minute
 
 // NewManager creates a new network manager.
 // If meter is nil, metrics are disabled.
 func NewManager(p *paths.Paths, cfg *config.Config, meter metric.Meter) Manager {
 	m := &manager{
-		paths:  p,
-		config: cfg,
+		paths:              p,
+		config:             cfg,
+		pendingAllocations: make(map[string]pendingAllocation),
 	}
 
 	// Initialize metrics if meter is provided
@@ -104,6 +116,15 @@ func (m *manager) Initialize(ctx context.Context, runningInstanceIDs []string) e
 	if err := m.createBridge(ctx, m.config.Network.BridgeName, gateway, m.config.Network.SubnetCIDR); err != nil {
 		return fmt.Errorf("setup default network: %w", err)
 	}
+	m.setDefaultNetwork(&Network{
+		Name:    "default",
+		Subnet:  m.config.Network.SubnetCIDR,
+		Gateway: gateway,
+		Bridge:  m.config.Network.BridgeName,
+		// Per-TAP port isolation is the default network policy used by createTAPDevice.
+		Isolated: true,
+		Default:  true,
+	})
 
 	// Cleanup orphaned TAP devices from previous runs (crashes, power loss, etc.).
 	// Startup runs before any concurrent CreateAllocation can be in flight, so no
@@ -119,6 +140,26 @@ func (m *manager) Initialize(ctx context.Context, runningInstanceIDs []string) e
 
 	log.InfoContext(ctx, "network manager initialized")
 	return nil
+}
+
+func cloneNetwork(network *Network) *Network {
+	if network == nil {
+		return nil
+	}
+	cloned := *network
+	return &cloned
+}
+
+func (m *manager) cachedDefaultNetwork() *Network {
+	m.networkMu.RLock()
+	defer m.networkMu.RUnlock()
+	return cloneNetwork(m.defaultNetwork)
+}
+
+func (m *manager) setDefaultNetwork(network *Network) {
+	m.networkMu.Lock()
+	defer m.networkMu.Unlock()
+	m.defaultNetwork = cloneNetwork(network)
 }
 
 // getDefaultNetwork gets the default network details from kernel state

--- a/lib/network/manager.go
+++ b/lib/network/manager.go
@@ -61,10 +61,7 @@ type manager struct {
 
 type pendingAllocation struct {
 	allocation Allocation
-	expiresAt  time.Time
 }
-
-const pendingAllocationTTL = 10 * time.Minute
 
 // NewManager creates a new network manager.
 // If meter is nil, metrics are disabled.

--- a/lib/network/manager_test.go
+++ b/lib/network/manager_test.go
@@ -127,6 +127,21 @@ func TestPendingAllocationLoadsPersistedClassID(t *testing.T) {
 	assert.Equal(t, "00ab", alloc.ClassID)
 }
 
+func TestClassIDForDeletePrefersPersistedClassID(t *testing.T) {
+	m := &manager{
+		paths:  paths.New(t.TempDir()),
+		config: &config.Config{},
+	}
+
+	const instanceID = "inst-delete"
+	require.NoError(t, os.MkdirAll(m.paths.InstanceDir(instanceID), 0755))
+	require.NoError(t, m.saveClassID(instanceID, "00ab"))
+
+	assert.Equal(t, "00ab", m.classIDForDelete(instanceID, "0010"))
+	assert.Equal(t, "0010", m.classIDForDelete("missing", "0010"))
+	assert.Equal(t, "0010", m.classIDForDelete("", "0010"))
+}
+
 func TestDefaultNetworkCacheReturnsCopy(t *testing.T) {
 	m := &manager{}
 	m.setDefaultNetwork(&Network{

--- a/lib/network/manager_test.go
+++ b/lib/network/manager_test.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/kernel/hypeman/cmd/api/config"
@@ -96,6 +97,34 @@ func TestPendingAllocationVisibleToNameExistsAndGetAllocation(t *testing.T) {
 	require.NotNil(t, alloc)
 	assert.Equal(t, "10.100.0.42", alloc.IP)
 	assert.Equal(t, "pending", alloc.State)
+}
+
+func TestPendingAllocationLoadsPersistedClassID(t *testing.T) {
+	m := &manager{
+		paths:              paths.New(t.TempDir()),
+		config:             &config.Config{},
+		pendingAllocations: make(map[string]pendingAllocation),
+	}
+
+	const instanceID = "inst-pending"
+	require.NoError(t, os.MkdirAll(m.paths.InstanceDir(instanceID), 0755))
+	require.NoError(t, m.saveClassID(instanceID, "00ab"))
+
+	m.mu.Lock()
+	m.rememberPendingAllocationLocked(Allocation{
+		InstanceID:   instanceID,
+		InstanceName: "pending-name",
+		IP:           "10.100.0.42",
+		MAC:          "02:00:00:00:00:42",
+		TAPDevice:    "hype-pending",
+		State:        "pending",
+	})
+	m.mu.Unlock()
+
+	alloc, err := m.GetAllocation(context.Background(), instanceID)
+	require.NoError(t, err)
+	require.NotNil(t, alloc)
+	assert.Equal(t, "00ab", alloc.ClassID)
 }
 
 func TestDefaultNetworkCacheReturnsCopy(t *testing.T) {

--- a/lib/network/manager_test.go
+++ b/lib/network/manager_test.go
@@ -1,9 +1,12 @@
 package network
 
 import (
+	"context"
 	"net"
 	"testing"
 
+	"github.com/kernel/hypeman/cmd/api/config"
+	"github.com/kernel/hypeman/lib/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,6 +67,51 @@ func TestAllocateUniqueMACFromSetFallsBackToSequentialScan(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "02:00:00:00:00:02", mac)
 	assert.Equal(t, macAllocationRandomAttempts, calls)
+}
+
+func TestPendingAllocationVisibleToNameExistsAndGetAllocation(t *testing.T) {
+	m := &manager{
+		paths:              paths.New(t.TempDir()),
+		config:             &config.Config{},
+		pendingAllocations: make(map[string]pendingAllocation),
+	}
+
+	m.mu.Lock()
+	m.rememberPendingAllocationLocked(Allocation{
+		InstanceID:   "inst-pending",
+		InstanceName: "pending-name",
+		IP:           "10.100.0.42",
+		MAC:          "02:00:00:00:00:42",
+		TAPDevice:    "hype-pending",
+		State:        "pending",
+	})
+	m.mu.Unlock()
+
+	exists, err := m.NameExists(context.Background(), "pending-name", "")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	alloc, err := m.GetAllocation(context.Background(), "inst-pending")
+	require.NoError(t, err)
+	require.NotNil(t, alloc)
+	assert.Equal(t, "10.100.0.42", alloc.IP)
+	assert.Equal(t, "pending", alloc.State)
+}
+
+func TestDefaultNetworkCacheReturnsCopy(t *testing.T) {
+	m := &manager{}
+	m.setDefaultNetwork(&Network{
+		Name:    "default",
+		Bridge:  "hm0",
+		Subnet:  "10.244.0.0/16",
+		Gateway: "10.244.0.1",
+	})
+
+	cached := m.cachedDefaultNetwork()
+	require.NotNil(t, cached)
+	cached.Bridge = "mutated"
+
+	assert.Equal(t, "hm0", m.cachedDefaultNetwork().Bridge)
 }
 
 func TestGenerateTAPName(t *testing.T) {

--- a/lib/network/tc_rate.go
+++ b/lib/network/tc_rate.go
@@ -1,0 +1,20 @@
+package network
+
+import "fmt"
+
+// formatTcRate formats bytes per second as a tc rate string.
+// It uses the largest unit that exactly represents the value to avoid
+// truncation from integer division (e.g., 2.5 Gbps becomes "2500mbit" not "2gbit").
+func formatTcRate(bytesPerSec int64) string {
+	bitsPerSec := bytesPerSec * 8
+	switch {
+	case bitsPerSec >= 1000000000 && bitsPerSec%1000000000 == 0:
+		return fmt.Sprintf("%dgbit", bitsPerSec/1000000000)
+	case bitsPerSec >= 1000000 && bitsPerSec%1000000 == 0:
+		return fmt.Sprintf("%dmbit", bitsPerSec/1000000)
+	case bitsPerSec >= 1000 && bitsPerSec%1000 == 0:
+		return fmt.Sprintf("%dkbit", bitsPerSec/1000)
+	default:
+		return fmt.Sprintf("%dbit", bitsPerSec)
+	}
+}

--- a/lib/network/tracing.go
+++ b/lib/network/tracing.go
@@ -11,6 +11,16 @@ import (
 )
 
 func startNetworkStep(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, func(error)) {
+	return startNetworkStepWithOptions(ctx, name, nil, attrs...)
+}
+
+func startDetachedNetworkStep(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, func(error)) {
+	return startNetworkStepWithOptions(context.WithoutCancel(ctx), name, []trace.SpanStartOption{
+		trace.WithNewRoot(),
+	}, attrs...)
+}
+
+func startNetworkStepWithOptions(ctx context.Context, name string, options []trace.SpanStartOption, attrs ...attribute.KeyValue) (context.Context, func(error)) {
 	inherited := hypervisor.TraceAttributesFromContext(ctx)
 	if len(inherited) > 0 {
 		merged := make([]attribute.KeyValue, 0, len(inherited)+len(attrs))
@@ -19,7 +29,7 @@ func startNetworkStep(ctx context.Context, name string, attrs ...attribute.KeyVa
 		attrs = merged
 	}
 
-	opts := []trace.SpanStartOption(nil)
+	opts := append([]trace.SpanStartOption(nil), options...)
 	if len(attrs) > 0 {
 		opts = append(opts, trace.WithAttributes(attrs...))
 	}

--- a/lib/network/tracing.go
+++ b/lib/network/tracing.go
@@ -1,0 +1,36 @@
+package network
+
+import (
+	"context"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func startNetworkStep(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, func(error)) {
+	inherited := hypervisor.TraceAttributesFromContext(ctx)
+	if len(inherited) > 0 {
+		merged := make([]attribute.KeyValue, 0, len(inherited)+len(attrs))
+		merged = append(merged, inherited...)
+		merged = append(merged, attrs...)
+		attrs = merged
+	}
+
+	opts := []trace.SpanStartOption(nil)
+	if len(attrs) > 0 {
+		opts = append(opts, trace.WithAttributes(attrs...))
+	}
+	ctx, span := otel.Tracer("hypeman/network").Start(ctx, name, opts...)
+	return ctx, func(err error) {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		} else {
+			span.SetStatus(codes.Ok, "")
+		}
+		span.End()
+	}
+}

--- a/lib/network/tracing_test.go
+++ b/lib/network/tracing_test.go
@@ -1,0 +1,70 @@
+package network
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestDetachedNetworkStepStartsNewTrace(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+		_ = provider.Shutdown(context.Background())
+	})
+
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "root")
+	ctx = hypervisor.WithTraceAttributes(ctx, attribute.String("instance_id", "inst-1"))
+
+	detachedCtx, detachedEnd := startDetachedNetworkStep(ctx, "network.rate_limit.wait_for_tc_mutex",
+		attribute.String("operation", "wait_for_tc_mutex"),
+	)
+	_, childEnd := startNetworkStep(detachedCtx, "network.rate_limit.apply",
+		attribute.String("operation", "apply_rate_limit"),
+	)
+	childEnd(nil)
+	detachedEnd(nil)
+	parent.End()
+
+	root := networkSpanByName(t, recorder.Ended(), "root")
+	detached := networkSpanByName(t, recorder.Ended(), "network.rate_limit.wait_for_tc_mutex")
+	child := networkSpanByName(t, recorder.Ended(), "network.rate_limit.apply")
+
+	require.False(t, detached.Parent().IsValid())
+	assert.NotEqual(t, root.SpanContext().TraceID(), detached.SpanContext().TraceID())
+	assert.Equal(t, detached.SpanContext().TraceID(), child.SpanContext().TraceID())
+	assert.Equal(t, detached.SpanContext().SpanID(), child.Parent().SpanID())
+
+	attrs := networkAttrsToMap(child.Attributes())
+	assert.Equal(t, "inst-1", attrs["instance_id"])
+	assert.Equal(t, "apply_rate_limit", attrs["operation"])
+}
+
+func networkSpanByName(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, span := range spans {
+		if span.Name() == name {
+			return span
+		}
+	}
+	t.Fatalf("span %q not found", name)
+	return nil
+}
+
+func networkAttrsToMap(attrs []attribute.KeyValue) map[string]string {
+	out := make(map[string]string, len(attrs))
+	for _, attr := range attrs {
+		out[string(attr.Key)] = attr.Value.AsString()
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- splits the network/TAP/TC portion out from the old combined UFFD/network branch
- bases it on the new restore-network optimization branch
- supersedes the network portion of #258; old branch is preserved for comparison

## Tests
- git diff --check origin/main...hypeship/fork-network-parallel-v2
- go test ./lib/network -count=1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency, pending allocation visibility, and async tc vs release ordering on shared bridge state; mistakes could cause duplicate identities, stale HTB classes, or briefly unshaped traffic after fork.
> 
> **Overview**
> **Fork/restore network setup is split into a fast blocking path and deferred shaping**, so concurrent forks no longer serialize on bridge `tc` work.
> 
> `CreateAllocation` and `RecreateAllocation` now **reserve name/IP/MAC/TAP under a short mutex** (with **pending allocations** visible to `NameExists` / `GetAllocation` before metadata is written), **create and bridge the TAP synchronously**, and **enqueue download/upload limits on a background goroutine** guarded by **`tcMu`**. TAP creation no longer applies rate limits inline; Linux `createTAPDevice` only brings up the interface. **Release** takes **`tcMu`** when deleting TAPs so async `tc` cannot race HTB cleanup, and delete prefers the **persisted class ID**. **Default bridge details are cached** after init to avoid repeated netlink queries. **Detached OTel spans** cover async rate-limit work so restore/request traces show only blocking network steps. Docs and unit tests cover pending state, class ID on delete, and detached tracing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a26c319a13330558942119e148c9729f24c32eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->