### PR TITLE
Use UFFD only for initial snapshot fork restores

### DIFF
--- a/lib/hypervisor/firecracker/fork.go
+++ b/lib/hypervisor/firecracker/fork.go
@@ -54,12 +54,14 @@ func (s *Starter) PrepareFork(ctx context.Context, req hypervisor.ForkPrepareReq
 			// Keep the upstream source path for snapshot-derived forks. The retained
 			// Firecracker base can still reference that path after later diff snapshots.
 		} else {
-			retainAlias := false
-			if _, err := os.Stat(req.SourceDataDir); err != nil {
-				if os.IsNotExist(err) {
-					retainAlias = true
-				} else {
-					return hypervisor.ForkPrepareResult{}, fmt.Errorf("stat snapshot source data dir %q: %w", req.SourceDataDir, err)
+			retainAlias := req.RetainSnapshotSourceDataDirAlias
+			if !retainAlias {
+				if _, err := os.Stat(req.SourceDataDir); err != nil {
+					if os.IsNotExist(err) {
+						retainAlias = true
+					} else {
+						return hypervisor.ForkPrepareResult{}, fmt.Errorf("stat snapshot source data dir %q: %w", req.SourceDataDir, err)
+					}
 				}
 			}
 			if meta.SnapshotSourceDataDir != req.SourceDataDir {

--- a/lib/hypervisor/firecracker/fork_test.go
+++ b/lib/hypervisor/firecracker/fork_test.go
@@ -65,6 +65,29 @@ func TestPrepareFork_DoesNotRetainExistingSourceAlias(t *testing.T) {
 	assert.False(t, meta.RetainSnapshotSourceDataDirAlias)
 }
 
+func TestPrepareFork_RetainsExistingSourceAliasWhenRequested(t *testing.T) {
+	starter := NewStarter()
+	tmp := t.TempDir()
+	sourceDir := filepath.Join(tmp, "source")
+	targetDir := filepath.Join(tmp, "target")
+	require.NoError(t, os.MkdirAll(sourceDir, 0755))
+	require.NoError(t, os.MkdirAll(targetDir, 0755))
+	require.NoError(t, saveRestoreMetadata(targetDir, nil))
+
+	_, err := starter.PrepareFork(context.Background(), hypervisor.ForkPrepareRequest{
+		SnapshotConfigPath:               filepath.Join(targetDir, "snapshots", "snapshot-latest", "config.json"),
+		SourceDataDir:                    sourceDir,
+		TargetDataDir:                    targetDir,
+		RetainSnapshotSourceDataDirAlias: true,
+	})
+	require.NoError(t, err)
+
+	meta, err := loadRestoreMetadata(targetDir)
+	require.NoError(t, err)
+	assert.Equal(t, sourceDir, meta.SnapshotSourceDataDir)
+	assert.True(t, meta.RetainSnapshotSourceDataDirAlias)
+}
+
 func TestPrepareFork_ReturnsSourceStatErrors(t *testing.T) {
 	starter := NewStarter()
 	tmp := t.TempDir()

--- a/lib/hypervisor/hypervisor.go
+++ b/lib/hypervisor/hypervisor.go
@@ -153,6 +153,9 @@ type ForkPrepareRequest struct {
 
 	SourceDataDir string
 	TargetDataDir string
+	// RetainSnapshotSourceDataDirAlias keeps source-path alias metadata even
+	// when the source data directory currently exists.
+	RetainSnapshotSourceDataDirAlias bool
 
 	VsockCID    int64
 	VsockSocket string

--- a/lib/instances/firecracker_uffd.go
+++ b/lib/instances/firecracker_uffd.go
@@ -22,12 +22,16 @@ func (m *manager) useFirecrackerUFFD(stored *StoredMetadata) bool {
 		m.firecrackerSnapshotMemoryBackend == uffdpager.BackendUFFD
 }
 
+func useFirecrackerUFFDOnNextRestore(hvType hypervisor.Type, sourceIsStandby bool, targetState State) bool {
+	return hvType == hypervisor.TypeFirecracker && sourceIsStandby && targetState != StateStopped
+}
+
 func (m *manager) firecrackerSnapshotRestoreOptions(stored *StoredMetadata, snapshotDir string) (hypervisor.RestoreOptions, error) {
 	opts := hypervisor.RestoreOptions{SnapshotMemoryBackend: hypervisor.SnapshotMemoryBackendFile}
 	if stored == nil || stored.HypervisorType != hypervisor.TypeFirecracker {
 		return opts, nil
 	}
-	if !m.useFirecrackerUFFD(stored) {
+	if !m.useFirecrackerUFFD(stored) || !stored.FirecrackerUseUFFDOnNextRestore {
 		stored.FirecrackerUFFDSessionID = ""
 		stored.FirecrackerUFFDPagerVersion = ""
 		return opts, nil

--- a/lib/instances/firecracker_uffd_test.go
+++ b/lib/instances/firecracker_uffd_test.go
@@ -1,0 +1,303 @@
+package instances
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/uffdpager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirecrackerSnapshotRestoreOptionsOneShotUFFDGate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		backend     string
+		useNext     bool
+		wantBackend hypervisor.SnapshotMemoryBackend
+		wantErr     bool
+	}{
+		{
+			name:        "config file ignores armed one-shot flag",
+			backend:     uffdpager.BackendFile,
+			useNext:     true,
+			wantBackend: hypervisor.SnapshotMemoryBackendFile,
+		},
+		{
+			name:        "config uffd with unarmed flag uses file backend",
+			backend:     uffdpager.BackendUFFD,
+			useNext:     false,
+			wantBackend: hypervisor.SnapshotMemoryBackendFile,
+		},
+		{
+			name:    "config uffd with armed flag requires pager",
+			backend: uffdpager.BackendUFFD,
+			useNext: true,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mgr := &manager{firecrackerSnapshotMemoryBackend: tc.backend}
+			stored := &StoredMetadata{
+				Id:                              "fc-restore-options",
+				HypervisorType:                  hypervisor.TypeFirecracker,
+				FirecrackerSnapshotCacheKey:     "snapshot-cache-key",
+				FirecrackerUseUFFDOnNextRestore: tc.useNext,
+				FirecrackerUFFDSessionID:        "stale-session",
+				FirecrackerUFFDPagerVersion:     "stale-version",
+			}
+
+			opts, err := mgr.firecrackerSnapshotRestoreOptions(stored, t.TempDir())
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "pager is not configured")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantBackend, opts.SnapshotMemoryBackend)
+			assert.Empty(t, opts.SnapshotMemoryCacheKey)
+			assert.Empty(t, opts.SnapshotMemorySessionID)
+			assert.Empty(t, stored.FirecrackerUFFDSessionID)
+			assert.Empty(t, stored.FirecrackerUFFDPagerVersion)
+		})
+	}
+}
+
+func TestForkInstanceFromStandbyArmsOneShotUFFDForFirecrackerRestore(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := setupTestManager(t)
+	installOneShotFirecrackerStarter(t, mgr)
+	ctx := context.Background()
+
+	sourceID := "one-shot-uffd-instance-source"
+	createStandbySnapshotSourceFixture(t, mgr, sourceID, sourceID, hypervisor.TypeFirecracker)
+	sourceMeta, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	sourceMeta.StoredMetadata.FirecrackerSnapshotCacheKey = "shared-template-cache"
+	require.NoError(t, mgr.saveMetadata(sourceMeta))
+
+	forked, err := mgr.forkInstanceFromStoppedOrStandby(ctx, sourceID, ForkInstanceRequest{
+		Name:        "one-shot-uffd-instance-fork",
+		TargetState: StateStandby,
+	}, true)
+	require.NoError(t, err)
+
+	meta, err := mgr.loadMetadata(forked.Id)
+	require.NoError(t, err)
+	assert.True(t, meta.StoredMetadata.FirecrackerUseUFFDOnNextRestore)
+	assert.Equal(t, "shared-template-cache", meta.StoredMetadata.FirecrackerSnapshotCacheKey)
+	assert.Empty(t, meta.StoredMetadata.FirecrackerUFFDSessionID)
+	assert.Empty(t, meta.StoredMetadata.FirecrackerUFFDPagerVersion)
+}
+
+func TestForkInstanceFromStandbyDoesNotArmOneShotUFFDForStoppedTarget(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := setupTestManager(t)
+	installOneShotFirecrackerStarter(t, mgr)
+	ctx := context.Background()
+
+	sourceID := "one-shot-uffd-instance-stopped-source"
+	createStandbySnapshotSourceFixture(t, mgr, sourceID, sourceID, hypervisor.TypeFirecracker)
+	sourceMeta, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	sourceMeta.StoredMetadata.FirecrackerSnapshotCacheKey = "shared-template-cache"
+	require.NoError(t, mgr.saveMetadata(sourceMeta))
+
+	forked, err := mgr.forkInstanceFromStoppedOrStandby(ctx, sourceID, ForkInstanceRequest{
+		Name:        "one-shot-uffd-instance-stopped-fork",
+		TargetState: StateStopped,
+	}, true)
+	require.NoError(t, err)
+
+	meta, err := mgr.loadMetadata(forked.Id)
+	require.NoError(t, err)
+	assert.False(t, meta.StoredMetadata.FirecrackerUseUFFDOnNextRestore)
+	assert.Equal(t, "shared-template-cache", meta.StoredMetadata.FirecrackerSnapshotCacheKey)
+}
+
+func TestForkSnapshotFromStandbyArmsOneShotUFFDForFirecrackerRestore(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := setupTestManager(t)
+	installOneShotFirecrackerStarter(t, mgr)
+	ctx := context.Background()
+
+	sourceID := "one-shot-uffd-snapshot-source"
+	createStandbySnapshotSourceFixture(t, mgr, sourceID, sourceID, hypervisor.TypeFirecracker)
+	sourceMeta, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	sourceMeta.StoredMetadata.FirecrackerSnapshotCacheKey = "shared-snapshot-cache"
+	require.NoError(t, mgr.saveMetadata(sourceMeta))
+
+	snap, err := mgr.CreateSnapshot(ctx, sourceID, CreateSnapshotRequest{
+		Kind: SnapshotKindStandby,
+		Name: "one-shot-uffd-snapshot",
+	})
+	require.NoError(t, err)
+
+	forked, err := mgr.ForkSnapshot(ctx, snap.Id, ForkSnapshotRequest{
+		Name:        "one-shot-uffd-snapshot-fork",
+		TargetState: StateStandby,
+	})
+	require.NoError(t, err)
+
+	meta, err := mgr.loadMetadata(forked.Id)
+	require.NoError(t, err)
+	assert.True(t, meta.StoredMetadata.FirecrackerUseUFFDOnNextRestore)
+	assert.Equal(t, "shared-snapshot-cache", meta.StoredMetadata.FirecrackerSnapshotCacheKey)
+	assert.Empty(t, meta.StoredMetadata.FirecrackerUFFDSessionID)
+	assert.Empty(t, meta.StoredMetadata.FirecrackerUFFDPagerVersion)
+}
+
+func TestForkSnapshotFromStoppedDoesNotArmOneShotUFFD(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := setupTestManager(t)
+	installOneShotFirecrackerStarter(t, mgr)
+	ctx := context.Background()
+
+	sourceID := "one-shot-uffd-stopped-snapshot-source"
+	createStoppedSnapshotSourceFixture(t, mgr, sourceID, sourceID, hypervisor.TypeFirecracker)
+	sourceMeta, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	sourceMeta.StoredMetadata.FirecrackerSnapshotCacheKey = "stopped-snapshot-cache"
+	require.NoError(t, mgr.saveMetadata(sourceMeta))
+
+	snap, err := mgr.CreateSnapshot(ctx, sourceID, CreateSnapshotRequest{
+		Kind: SnapshotKindStopped,
+		Name: "one-shot-uffd-stopped-snapshot",
+	})
+	require.NoError(t, err)
+
+	forked, err := mgr.ForkSnapshot(ctx, snap.Id, ForkSnapshotRequest{
+		Name:        "one-shot-uffd-stopped-snapshot-fork",
+		TargetState: StateStopped,
+	})
+	require.NoError(t, err)
+
+	meta, err := mgr.loadMetadata(forked.Id)
+	require.NoError(t, err)
+	assert.False(t, meta.StoredMetadata.FirecrackerUseUFFDOnNextRestore)
+	assert.Empty(t, meta.StoredMetadata.FirecrackerSnapshotCacheKey)
+}
+
+func TestRestoreInstanceClearsOneShotUFFDFlagAfterSuccessfulRestore(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := setupTestManager(t)
+	installOneShotFirecrackerStarter(t, mgr)
+	mgr.firecrackerSnapshotMemoryBackend = uffdpager.BackendFile
+	ctx := context.Background()
+
+	id := "one-shot-uffd-restore-clear"
+	createStandbySnapshotSourceFixture(t, mgr, id, id, hypervisor.TypeFirecracker)
+	meta, err := mgr.loadMetadata(id)
+	require.NoError(t, err)
+	meta.StoredMetadata.FirecrackerSnapshotCacheKey = "shared-template-cache"
+	meta.StoredMetadata.FirecrackerUseUFFDOnNextRestore = true
+	require.NoError(t, mgr.saveMetadata(meta))
+
+	inst, err := mgr.restoreInstance(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, inst)
+
+	updated, err := mgr.loadMetadata(id)
+	require.NoError(t, err)
+	assert.False(t, updated.StoredMetadata.FirecrackerUseUFFDOnNextRestore)
+}
+
+func installOneShotFirecrackerStarter(t *testing.T, mgr *manager) {
+	t.Helper()
+	previous, hadPrevious := mgr.vmStarters[hypervisor.TypeFirecracker]
+	mgr.vmStarters[hypervisor.TypeFirecracker] = oneShotFirecrackerTestStarter{}
+	t.Cleanup(func() {
+		if hadPrevious {
+			mgr.vmStarters[hypervisor.TypeFirecracker] = previous
+			return
+		}
+		delete(mgr.vmStarters, hypervisor.TypeFirecracker)
+	})
+}
+
+type oneShotFirecrackerTestStarter struct{}
+
+func (oneShotFirecrackerTestStarter) SocketName() string {
+	return "firecracker.sock"
+}
+
+func (oneShotFirecrackerTestStarter) GetBinaryPath(*paths.Paths, string) (string, error) {
+	return "/bin/true", nil
+}
+
+func (oneShotFirecrackerTestStarter) GetVersion(*paths.Paths) (string, error) {
+	return "test", nil
+}
+
+func (oneShotFirecrackerTestStarter) StartVM(context.Context, *paths.Paths, string, string, hypervisor.VMConfig) (int, hypervisor.Hypervisor, error) {
+	return 1234, oneShotFirecrackerTestHypervisor{}, nil
+}
+
+func (oneShotFirecrackerTestStarter) RestoreVM(context.Context, *paths.Paths, string, string, string, hypervisor.RestoreOptions) (int, hypervisor.Hypervisor, error) {
+	return 1234, oneShotFirecrackerTestHypervisor{}, nil
+}
+
+func (oneShotFirecrackerTestStarter) PrepareFork(context.Context, hypervisor.ForkPrepareRequest) (hypervisor.ForkPrepareResult, error) {
+	return hypervisor.ForkPrepareResult{}, nil
+}
+
+type oneShotFirecrackerTestHypervisor struct{}
+
+func (oneShotFirecrackerTestHypervisor) DeleteVM(context.Context) error {
+	return nil
+}
+
+func (oneShotFirecrackerTestHypervisor) Shutdown(context.Context) error {
+	return nil
+}
+
+func (oneShotFirecrackerTestHypervisor) GetVMInfo(context.Context) (*hypervisor.VMInfo, error) {
+	return &hypervisor.VMInfo{State: hypervisor.StateRunning}, nil
+}
+
+func (oneShotFirecrackerTestHypervisor) Pause(context.Context) error {
+	return nil
+}
+
+func (oneShotFirecrackerTestHypervisor) Resume(context.Context) error {
+	return nil
+}
+
+func (oneShotFirecrackerTestHypervisor) Snapshot(context.Context, string) error {
+	return nil
+}
+
+func (oneShotFirecrackerTestHypervisor) ResizeMemory(context.Context, int64) error {
+	return nil
+}
+
+func (oneShotFirecrackerTestHypervisor) ResizeMemoryAndWait(context.Context, int64, time.Duration) error {
+	return nil
+}
+
+func (oneShotFirecrackerTestHypervisor) SetTargetGuestMemoryBytes(context.Context, int64) error {
+	return nil
+}
+
+func (oneShotFirecrackerTestHypervisor) GetTargetGuestMemoryBytes(context.Context) (int64, error) {
+	return 0, nil
+}
+
+func (oneShotFirecrackerTestHypervisor) Capabilities() hypervisor.Capabilities {
+	return hypervisor.Capabilities{SupportsSnapshot: true, SupportsPause: true}
+}

--- a/lib/instances/fork.go
+++ b/lib/instances/fork.go
@@ -336,13 +336,14 @@ func (m *manager) forkInstanceFromStoppedOrStandby(ctx context.Context, id strin
 			netCfg = &hypervisor.ForkNetworkConfig{TAPDevice: network.GenerateTAPName(forkID)}
 		}
 		if _, err := starter.PrepareFork(ctx, hypervisor.ForkPrepareRequest{
-			SnapshotConfigPath: snapshotConfigPath,
-			SourceDataDir:      stored.DataDir,
-			TargetDataDir:      forkMeta.DataDir,
-			VsockCID:           forkMeta.VsockCID,
-			VsockSocket:        forkMeta.VsockSocket,
-			SerialLogPath:      m.paths.InstanceAppLog(forkID),
-			Network:            netCfg,
+			SnapshotConfigPath:               snapshotConfigPath,
+			SourceDataDir:                    stored.DataDir,
+			TargetDataDir:                    forkMeta.DataDir,
+			RetainSnapshotSourceDataDirAlias: forkMeta.FirecrackerUseUFFDOnNextRestore,
+			VsockCID:                         forkMeta.VsockCID,
+			VsockSocket:                      forkMeta.VsockSocket,
+			SerialLogPath:                    m.paths.InstanceAppLog(forkID),
+			Network:                          netCfg,
 		}); err != nil {
 			if errors.Is(err, hypervisor.ErrNotSupported) {
 				return nil, fmt.Errorf("%w: fork is not supported for hypervisor %s", ErrNotSupported, stored.HypervisorType)

--- a/lib/instances/fork.go
+++ b/lib/instances/fork.go
@@ -225,6 +225,10 @@ func (m *manager) forkInstanceFromStoppedOrStandby(ctx context.Context, id strin
 			return nil, err
 		}
 	}
+	targetState, err := resolveForkTargetState(req.TargetState, source.State)
+	if err != nil {
+		return nil, err
+	}
 	if err := validateForkVolumeSafety(stored.Volumes); err != nil {
 		return nil, err
 	}
@@ -293,6 +297,7 @@ func (m *manager) forkInstanceFromStoppedOrStandby(ctx context.Context, id strin
 	forkMeta.RestartStatus = restartpolicy.Status{}
 	forkMeta.FirecrackerUFFDSessionID = ""
 	forkMeta.FirecrackerUFFDPagerVersion = ""
+	forkMeta.FirecrackerUseUFFDOnNextRestore = useFirecrackerUFFDOnNextRestore(forkMeta.HypervisorType, source.State == StateStandby, targetState)
 	if source.State != StateStandby {
 		forkMeta.FirecrackerSnapshotCacheKey = ""
 	}
@@ -458,6 +463,10 @@ func (m *manager) applyForkTargetState(ctx context.Context, forkID string, targe
 				return nil, fmt.Errorf("load stopped fork metadata: %w", err)
 			}
 			meta.StoredMetadata.VsockCID = generateVsockCID(forkID)
+			meta.StoredMetadata.FirecrackerSnapshotCacheKey = ""
+			meta.StoredMetadata.FirecrackerUseUFFDOnNextRestore = false
+			meta.StoredMetadata.FirecrackerUFFDSessionID = ""
+			meta.StoredMetadata.FirecrackerUFFDPagerVersion = ""
 			if err := m.saveMetadata(meta); err != nil {
 				return nil, fmt.Errorf("save stopped fork metadata: %w", err)
 			}

--- a/lib/instances/restore.go
+++ b/lib/instances/restore.go
@@ -341,6 +341,7 @@ func (m *manager) restoreInstance(
 	// before markers ever hydrated we resume in Initializing.
 	resumePhase, _ := runningPhaseFromMarkers(stored)
 	stored.Phases.Record(resumePhase, time.Now().UTC())
+	stored.FirecrackerUseUFFDOnNextRestore = false
 	meta = &metadata{StoredMetadata: *stored}
 	if err := m.saveMetadata(meta); err != nil {
 		// VM is running but metadata failed

--- a/lib/instances/snapshot.go
+++ b/lib/instances/snapshot.go
@@ -478,13 +478,14 @@ func (m *manager) forkSnapshot(ctx context.Context, snapshotID string, req ForkS
 			netCfg = &hypervisor.ForkNetworkConfig{TAPDevice: network.GenerateTAPName(forkID)}
 		}
 		if _, err := starter.PrepareFork(ctx, hypervisor.ForkPrepareRequest{
-			SnapshotConfigPath: m.paths.InstanceSnapshotConfig(forkID),
-			SourceDataDir:      rec.StoredMetadata.DataDir,
-			TargetDataDir:      forkMeta.DataDir,
-			VsockCID:           forkMeta.VsockCID,
-			VsockSocket:        forkMeta.VsockSocket,
-			SerialLogPath:      m.paths.InstanceAppLog(forkID),
-			Network:            netCfg,
+			SnapshotConfigPath:               m.paths.InstanceSnapshotConfig(forkID),
+			SourceDataDir:                    rec.StoredMetadata.DataDir,
+			TargetDataDir:                    forkMeta.DataDir,
+			RetainSnapshotSourceDataDirAlias: forkMeta.FirecrackerUseUFFDOnNextRestore,
+			VsockCID:                         forkMeta.VsockCID,
+			VsockSocket:                      forkMeta.VsockSocket,
+			SerialLogPath:                    m.paths.InstanceAppLog(forkID),
+			Network:                          netCfg,
 		}); err != nil {
 			if errors.Is(err, hypervisor.ErrNotSupported) {
 				return nil, fmt.Errorf("%w: snapshot fork is not supported for hypervisor %s", ErrNotSupported, targetHypervisor)

--- a/lib/instances/snapshot.go
+++ b/lib/instances/snapshot.go
@@ -318,6 +318,12 @@ func (m *manager) restoreSnapshot(ctx context.Context, id string, snapshotID str
 	}
 	restored.SocketPath = m.paths.InstanceSocket(id, starter.SocketName())
 	restored.VsockSocket = m.paths.InstanceSocket(id, hypervisor.VsockSocketNameForType(targetHypervisor))
+	restored.FirecrackerUseUFFDOnNextRestore = false
+	restored.FirecrackerUFFDSessionID = ""
+	restored.FirecrackerUFFDPagerVersion = ""
+	if targetState == StateStopped {
+		restored.FirecrackerSnapshotCacheKey = ""
+	}
 	if rec.Snapshot.Kind == SnapshotKindStopped {
 		restored.VsockCID = generateVsockCID(id)
 	}
@@ -452,6 +458,7 @@ func (m *manager) forkSnapshot(ctx context.Context, snapshotID string, req ForkS
 	forkMeta.RestartStatus = restartpolicy.Status{}
 	forkMeta.FirecrackerUFFDSessionID = ""
 	forkMeta.FirecrackerUFFDPagerVersion = ""
+	forkMeta.FirecrackerUseUFFDOnNextRestore = useFirecrackerUFFDOnNextRestore(targetHypervisor, rec.Snapshot.Kind == SnapshotKindStandby, targetState)
 	if rec.Snapshot.Kind != SnapshotKindStandby {
 		forkMeta.FirecrackerSnapshotCacheKey = ""
 	}

--- a/lib/instances/standby.go
+++ b/lib/instances/standby.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kernel/hypeman/lib/forkvm"
 	"github.com/kernel/hypeman/lib/guest"
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/instances/phasetracking"
@@ -128,10 +129,11 @@ func (m *manager) standbyInstance(
 	snapshotDir := m.paths.InstanceSnapshotLatest(id)
 	retainedBaseDir := m.paths.InstanceSnapshotBase(id)
 	reuseSnapshotBase := m.supportsSnapshotBaseReuse(stored.HypervisorType)
-	promotedExistingBase := false
+	preparedRetainedBaseTarget := false
 	if reuseSnapshotBase {
 		var err error
-		promotedExistingBase, err = prepareRetainedSnapshotTarget(snapshotDir, retainedBaseDir)
+		copyRetainedBase := stored.HypervisorType == hypervisor.TypeFirecracker && stored.FirecrackerUFFDSessionID != ""
+		preparedRetainedBaseTarget, err = prepareRetainedSnapshotTarget(snapshotDir, retainedBaseDir, copyRetainedBase)
 		if err != nil {
 			if resumeErr := hv.Resume(ctx); resumeErr != nil {
 				log.ErrorContext(ctx, "failed to resume VM after retained snapshot target preparation error", "instance_id", id, "error", resumeErr)
@@ -153,7 +155,7 @@ func (m *manager) standbyInstance(
 		if resumeErr := hv.Resume(ctx); resumeErr != nil {
 			log.ErrorContext(ctx, "failed to resume VM after snapshot error", "instance_id", id, "error", resumeErr)
 		}
-		if promotedExistingBase {
+		if preparedRetainedBaseTarget {
 			if rollbackErr := discardPromotedRetainedSnapshotTarget(snapshotDir); rollbackErr != nil {
 				log.WarnContext(ctx, "failed to discard promoted snapshot target after snapshot error", "instance_id", id, "error", rollbackErr)
 			}
@@ -300,10 +302,10 @@ func createSnapshot(ctx context.Context, hv hypervisor.Hypervisor, snapshotDir s
 }
 
 // prepareRetainedSnapshotTarget clears any stale snapshot target from a prior failed
-// standby attempt, then moves a retained snapshot base into place when needed.
-// The returned bool reports whether an existing retained base was promoted, so callers
-// know if they should discard the promoted target on snapshot failure.
-func prepareRetainedSnapshotTarget(snapshotDir string, retainedBaseDir string) (bool, error) {
+// standby attempt, then places a retained snapshot base at the snapshot target when
+// needed. The returned bool reports whether a retained base was prepared at the target,
+// so callers know if they should discard the target on snapshot failure.
+func prepareRetainedSnapshotTarget(snapshotDir string, retainedBaseDir string, copyRetainedBase bool) (bool, error) {
 	if _, err := os.Stat(snapshotDir); err == nil {
 		if err := os.RemoveAll(snapshotDir); err != nil {
 			return false, err
@@ -313,6 +315,12 @@ func prepareRetainedSnapshotTarget(snapshotDir string, retainedBaseDir string) (
 	}
 
 	if _, err := os.Stat(retainedBaseDir); err == nil {
+		if copyRetainedBase {
+			if err := forkvm.CopyGuestDirectory(retainedBaseDir, snapshotDir); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
 		if err := os.Rename(retainedBaseDir, snapshotDir); err != nil {
 			return false, err
 		}

--- a/lib/instances/standby.go
+++ b/lib/instances/standby.go
@@ -217,6 +217,7 @@ func (m *manager) standbyInstance(
 	stored.StoppedAt = &now
 	stored.HypervisorPID = nil
 	stored.PendingStandbyCompression = nil
+	stored.FirecrackerUseUFFDOnNextRestore = false
 	if err := m.refreshFirecrackerSnapshotCacheKey(stored, snapshotDir); err != nil {
 		log.WarnContext(ctx, "failed to refresh firecracker snapshot cache key", "instance_id", id, "error", err)
 	}

--- a/lib/instances/standby_test.go
+++ b/lib/instances/standby_test.go
@@ -19,9 +19,9 @@ func TestDiscardPromotedRetainedSnapshotTargetAfterSnapshotError(t *testing.T) {
 	require.NoError(t, os.MkdirAll(retainedBaseDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(retainedBaseDir, "base-marker"), []byte("base"), 0644))
 
-	promotedExistingBase, err := prepareRetainedSnapshotTarget(snapshotDir, retainedBaseDir)
+	preparedRetainedBaseTarget, err := prepareRetainedSnapshotTarget(snapshotDir, retainedBaseDir, false)
 	require.NoError(t, err)
-	require.True(t, promotedExistingBase, "test setup should promote the retained base into the snapshot target")
+	require.True(t, preparedRetainedBaseTarget, "test setup should prepare the retained base at the snapshot target")
 
 	_, err = os.Stat(retainedBaseDir)
 	assert.True(t, os.IsNotExist(err), "promotion should move the retained base out of its hidden location")
@@ -48,13 +48,41 @@ func TestPrepareRetainedSnapshotTargetDiscardsStaleSnapshotDirBeforeRetry(t *tes
 	require.NoError(t, os.WriteFile(filepath.Join(snapshotDir, "memory"), []byte("partial"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(snapshotDir, "state"), []byte("partial"), 0644))
 
-	promotedExistingBase, err := prepareRetainedSnapshotTarget(snapshotDir, retainedBaseDir)
+	preparedRetainedBaseTarget, err := prepareRetainedSnapshotTarget(snapshotDir, retainedBaseDir, false)
 	require.NoError(t, err)
-	assert.False(t, promotedExistingBase, "stale snapshot cleanup should not report a promoted retained base")
+	assert.False(t, preparedRetainedBaseTarget, "stale snapshot cleanup should not report a prepared retained base")
 
 	_, err = os.Stat(snapshotDir)
 	assert.True(t, os.IsNotExist(err), "stale snapshot targets should be discarded before retrying standby")
 
 	_, err = os.Stat(retainedBaseDir)
 	assert.True(t, os.IsNotExist(err), "cleanup without a retained base should leave the retained base location empty")
+}
+
+func TestPrepareRetainedSnapshotTargetCopiesRetainedBaseWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	snapshotDir := filepath.Join(root, "snapshot-latest")
+	retainedBaseDir := filepath.Join(root, "snapshot-base")
+
+	require.NoError(t, os.MkdirAll(retainedBaseDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(retainedBaseDir, "memory"), []byte("base-memory"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(retainedBaseDir, "state"), []byte("base-state"), 0644))
+
+	preparedRetainedBaseTarget, err := prepareRetainedSnapshotTarget(snapshotDir, retainedBaseDir, true)
+	require.NoError(t, err)
+	require.True(t, preparedRetainedBaseTarget)
+
+	retainedMemory, err := os.Stat(filepath.Join(retainedBaseDir, "memory"))
+	require.NoError(t, err)
+	targetMemory, err := os.Stat(filepath.Join(snapshotDir, "memory"))
+	require.NoError(t, err)
+	assert.False(t, os.SameFile(retainedMemory, targetMemory), "UFFD standby target must use a separate inode from the pager backing file")
+
+	require.NoError(t, discardPromotedRetainedSnapshotTarget(snapshotDir))
+	_, err = os.Stat(snapshotDir)
+	assert.True(t, os.IsNotExist(err), "snapshot failures should discard the copied snapshot target")
+	_, err = os.Stat(retainedBaseDir)
+	assert.NoError(t, err, "copy mode should leave the retained base available for retry")
 }

--- a/lib/instances/stop.go
+++ b/lib/instances/stop.go
@@ -307,6 +307,7 @@ func (m *manager) stopInstance(
 	stored.ProgramStartedAt = nil
 	stored.GuestAgentReadyAt = nil
 	stored.FirecrackerSnapshotCacheKey = ""
+	stored.FirecrackerUseUFFDOnNextRestore = false
 	stored.Phases.Record(phasetracking.PhaseStopped, now)
 
 	meta = &metadata{StoredMetadata: *stored}

--- a/lib/instances/types.go
+++ b/lib/instances/types.go
@@ -118,9 +118,10 @@ type StoredMetadata struct {
 	HypervisorPID     *int            // Hypervisor process ID (may be stale after host restart)
 
 	// Firecracker UFFD snapshot restore metadata.
-	FirecrackerSnapshotCacheKey string
-	FirecrackerUFFDSessionID    string
-	FirecrackerUFFDPagerVersion string
+	FirecrackerSnapshotCacheKey     string
+	FirecrackerUseUFFDOnNextRestore bool
+	FirecrackerUFFDSessionID        string
+	FirecrackerUFFDPagerVersion     string
 
 	// Paths
 	SocketPath string // Path to API socket


### PR DESCRIPTION
## Summary
- gate Firecracker UFFD restores behind a one-shot metadata flag for snapshot forks
- use file-backed restore after a UFFD-restored fork goes back to standby
- keep retained source aliases for one-shot UFFD forks so later file-backed resumes resolve snapshotted paths
- avoid UFFD standby self-deadlock by reflink-copying retained base snapshots instead of moving the pager backing inode into the diff snapshot target

## Validation
- go test ./lib/hypervisor/firecracker ./lib/uffdpager ./lib/instances -run "TestPrepareRetainedSnapshotTarget|TestDiscardPromotedRetainedSnapshotTargetAfterSnapshotError|TestFirecrackerSnapshotRestoreOptionsOneShotUFFDGate|TestForkInstanceFromStandbyArmsOneShotUFFDForFirecrackerRestore|TestForkSnapshotFromStandbyArmsOneShotUFFDForFirecrackerRestore|TestRestoreInstanceClearsOneShotUFFDFlagAfterSuccessfulRestore"
- remote browser lifecycle: UFFD fork -> CDP -> standby -> file-backed restore -> CDP
