### PR TITLE
standby/restore (vz): document the clonefile win + fix restore state reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,11 +263,6 @@ $(BIN_DIR)/hypeman-uffd-pager: | $(BIN_DIR)
 # Build all binaries
 build-all: build
 
-# Run without live reload (build once and run)
-run: build
-	sudo setcap cap_net_admin,cap_net_bind_service=+eip $(BIN_DIR)/hypeman
-	$(BIN_DIR)/hypeman
-
 # Run in development mode with hot reload
 # On macOS, redirects to dev-darwin which uses vz instead of cloud-hypervisor
 dev:
@@ -410,10 +405,15 @@ ENTITLEMENTS_FILE ?= vz.entitlements
 
 # Build vz-shim (subprocess that hosts vz VMs)
 # Also copies to embed directory so it gets embedded in the hypeman binary
+# DARWIN_LDFLAGS silences the macOS (Xcode 15+) linker's "ignoring duplicate
+# libraries: '-lobjc'" warning: cgo deps that link Virtualization.framework
+# specify -lobjc more than once, which the new linker flags. Harmless; suppress.
+DARWIN_LDFLAGS := -ldflags=-extldflags=-Wl,-no_warn_duplicate_libraries
+
 .PHONY: build-vz-shim
 build-vz-shim: | $(BIN_DIR)
 	@echo "Building vz-shim for macOS..."
-	go build -o $(BIN_DIR)/vz-shim ./cmd/vz-shim
+	go build $(DARWIN_LDFLAGS) -o $(BIN_DIR)/vz-shim ./cmd/vz-shim
 	mkdir -p lib/hypervisor/vz/vz-shim
 	cp $(BIN_DIR)/vz-shim lib/hypervisor/vz/vz-shim/vz-shim
 	@echo "Build complete: $(BIN_DIR)/vz-shim"
@@ -431,7 +431,7 @@ sign-vz-shim: build-vz-shim
 .PHONY: build-darwin
 build-darwin: build-embedded build-vz-shim | $(BIN_DIR)
 	@echo "Building hypeman for macOS with vz support..."
-	go build -tags containers_image_openpgp -o $(BIN_DIR)/hypeman ./cmd/api
+	go build -tags containers_image_openpgp $(DARWIN_LDFLAGS) -o $(BIN_DIR)/hypeman ./cmd/api
 	@echo "Build complete: $(BIN_DIR)/hypeman"
 
 # Sign the binary with entitlements (required for Virtualization.framework)

--- a/docs/proposals/faster-standby-restore.md
+++ b/docs/proposals/faster-standby-restore.md
@@ -1,0 +1,98 @@
+# RFC: Faster macOS VM standby/restore (snapshot save/restore)
+
+## Summary
+
+Standby/restore of `vz` (Apple Virtualization.framework) VMs on Apple silicon was slow mainly because the guest-disk copy on macOS was a full sparse copy. That copy is the win: **Section C — an APFS `clonefile(2)` copy-on-write disk copy in `lib/forkvm` — landed in #276** and makes a same-volume `overlay.raw` clone metadata-only and effectively size-independent.
+
+Two further optimizations were proposed and **evaluated, then found to be no-ops on `vz`** once the disk copy is `clonefile`-instant, so **neither is implemented**:
+
+- **A. Compress `machine-state.vzm`.** Apple's `SaveMachineStateToPath` already omits zero/free guest pages, so the file is the high-entropy residual of live RAM. Measured on `vz`: zstd shrinks it ~0% and lz4 comes out net-larger, while compression burns CPU in the latency-critical paused window. No space win, real cost — dropped.
+- **B. Overlap the machine-state save with the disk copy.** Once the disk copy is a `clonefile` CoW clone (~1 ms, size-independent), there is essentially nothing to overlap. Measured on a 2 GiB-overlay VM: serial save-then-copy standby ~445 ms vs the overlapped variant ~482 ms — within noise. The overlap added concurrency machinery (errgroup, subtree-prune-then-recopy, cross-leg failure handling) for no measurable benefit — dropped.
+
+The shipped `vz` standby/snapshot/fork path is therefore the simple serial one: pause, save `machine-state.vzm`, copy the guest disk (CoW via `clonefile`), resume/shutdown.
+
+A and B would still matter elsewhere, and the code for the cases where they pay off is retained:
+
+- **Firecracker / Cloud-Hypervisor.** Their raw memory files (`memory-ranges` / `memory`) include zero pages and compress well, so the existing async snapshot-compression subsystem (`lib/instances/snapshot_compression.go`) is kept intact for them. It is simply never applied to `machine-state.vzm`.
+- **Cross-volume / non-APFS fallback.** When `clonefile` can't serve a copy (different APFS volume → `EXDEV`, or non-APFS → `ENOTSUP`), `lib/forkvm` falls back to a `SEEK_DATA`/`SEEK_HOLE` sparse copy whose cost scales with disk size. In that regime overlapping the save with the copy (B) would again matter; it is not implemented because the common deployment (instance and snapshot dirs under one data root on one APFS volume) gets the `clonefile` fast path.
+
+## Motivation
+
+Standby reclaims host CPU and memory from idle VMs and restores them on demand. `lib/autostandby` drives this automatically: when an instance's inbound TCP flow count stays at zero for `idle_timeout`, the controller calls `StandbyInstance` (`lib/autostandby/controller.go`). The faster standby and restore are, the more aggressively idle reclaim can run without users noticing latency on the next request, and the cheaper it is to pack many guests onto a host.
+
+The dominant `vz` cost was the disk copy. Snapshot and fork copy the guest directory (which contains `overlay.raw`) via `lib/forkvm`. On Linux this uses `FICLONE` reflink and is effectively instantaneous on CoW filesystems; on macOS it previously fell through to `SEEK_DATA`/`SEEK_HOLE` extent copying, reading and rewriting every allocated block. #276 wired APFS `clonefile(2)` into `lib/forkvm`, so a same-volume copy is CoW-instant.
+
+This RFC targets headless Linux guests running under hypeman's server + `vz-shim` subprocess model.
+
+## What shipped: Section C — CoW-clone the disk on APFS (`clonefile`), #276
+
+This was the highest-leverage change for snapshot/fork latency on macOS.
+
+`lib/forkvm` has a real darwin `clonefile(2)` implementation (`copy_reflink_darwin.go`), and the previous `!linux` stub was narrowed to `!linux && !darwin` (`copy_reflink_other.go`). `copyRegularFileReflink` removes any stale destination (`clonefile` fails `EEXIST` if it exists), clones with `unix.CLONE_NOFOLLOW | unix.CLONE_NOOWNERCOPY` — the latter drops owner/SUID/SGID/ACL metadata that has no business entering a fork — then re-applies the caller's mode with `os.Chmod`. On APFS this is a metadata-only copy-on-write clone: it consumes no extra space until blocks diverge and completes in roughly constant time regardless of file size.
+
+Fallback is explicit and narrow. `isReflinkUnsupportedError` maps only volume/filesystem-capability signals — `ENOTSUP`, `EOPNOTSUPP`, `EXDEV` — to `ErrReflinkUnsupported`, so the reflink-first-then-sparse dispatcher (`lib/forkvm/copy.go`) flips its sticky `reflinkDead` flag and routes through `copyRegularFileSparse`. Everything else propagates. This preserves the invariant that fork copies are sparse-aware and never blindly desparsify (`lib/forkvm/README.md`). Coverage landed with the change (`copy_reflink_darwin_test.go`, plus `BenchmarkForkGuestDisk` and the end-to-end `TestVZForkSpeed`).
+
+A multi-GiB `overlay.raw` clone is now sub-millisecond and metadata-only on a same-volume APFS layout, which removes the macOS disk-copy cost from snapshot/fork outright.
+
+## Evaluated and not implemented
+
+### A. Compress `machine-state.vzm` — no-op on `vz`
+
+The vz Save/Restore API is path-based: `SaveMachineStateToPath` / `RestoreMachineStateFromURL` (Code-Hex/vz v3). The framework writes the file itself given a path — there is no `io.Writer` to interpose a compressor on, so compression would be a post-write pass over the complete file (and a pre-read pass on restore).
+
+It does not pay off. `SaveMachineStateToPath` already omits zero/free guest pages, so `machine-state.vzm` is the high-entropy residual of live RAM. Measured on `vz`: **zstd ~0%, lz4 net-larger**, while the compress pass burns CPU in the paused window. Not implemented on `vz`: the compression candidate set does not list `machine-state.vzm`, and the shim's `vz` snapshot request carries only `destination_path`.
+
+This differs for Firecracker/Cloud-Hypervisor, whose raw memory files include zero pages and compress well — the async compression subsystem (`lib/instances/snapshot_compression.go`) is retained intact for them and supports native `zstd`/`lz4` with a pure-Go fallback, decompressing on restore via `ensureSnapshotMemoryReady`.
+
+### B. Overlap the machine-state save with the disk copy — no-op on `vz`
+
+The idea: the guest disk is quiescent the moment the VM is paused, so the disk copy could run concurrently with `SaveMachineStateToPath` instead of after it. With Section C landed, the disk copy is a `clonefile` CoW clone — ~1 ms and size-independent — so there is essentially nothing to overlap.
+
+Measured standby of a 2 GiB-overlay VM: **serial ~445 ms vs overlap ~482 ms — within noise.** The overlap also added real complexity (an errgroup over save+copy legs, pruning the in-flight `snapshots/` subtree from the disk copy and recopying it after the save, and cross-leg failure/cleanup handling). Not worth it: the `vz` path keeps the simple serial save-then-copy.
+
+This would matter again only when the disk copy is *not* `clonefile`-instant — the cross-volume / non-APFS sparse-copy fallback — which is not the common deployment.
+
+## Current shipped behavior in hypeman
+
+### Standby orchestration (serial)
+
+`standbyInstance` (`lib/instances/standby.go`) performs a serial multi-hop transition:
+
+1. Pause the VM (`hv.Pause`).
+2. Create the snapshot into `InstanceSnapshotLatest(id)` via `createSnapshot` → `hv.Snapshot`. For `vz` this reaches the shim's `handleSnapshot`, which requires the VM be paused, validates save/restore support, then calls `vm.SaveMachineStateToPath(<dir>/machine-state.vzm)` and writes the `SnapshotManifest` as `config.json` (`cmd/vz-shim/server.go`). The HTTP call uses a long-running client because duration scales with guest RAM (`lib/hypervisor/vz/client.go`).
+3. Shut down the VMM process.
+4. Release network, persist metadata.
+
+A disk copy happens when a standby is promoted to a stored snapshot or forked (`copySnapshotPayload`, `lib/instances/snapshot.go`), serially with respect to the rest of the operation, using the `clonefile` fast path on APFS.
+
+### Restore orchestration
+
+`restoreInstance` (`lib/instances/restore.go`) materializes any compressed memory (Firecracker/CH) via `ensureSnapshotMemoryReady`, then `restoreFromSnapshot` → `starter.RestoreVM`. For `vz`, `RestoreVM` reads the manifest, sets `RestoreMachineStatePath`, and spawns the shim. The shim restores instead of cold-booting; the VM lands paused, and the caller resumes.
+
+On `vz`, `machine-state.vzm` is never compressed, so it is always present as written by the save — no decompress step before restore.
+
+### vz Resume is synchronous from the caller's view
+
+`vz`'s `vm.resume` is a fire-and-forget PUT to the shim: it returns before the guest has left the Paused/Resuming transition, so an immediate `vm.info` read-back or guest exec could observe a transient Paused. `Client.Resume` (`lib/hypervisor/vz/client.go`) therefore issues the resume PUT and then polls the shim's raw `vm.info` state until it reports `Running`, bounded by a short timeout. This makes `Resume`'s post-condition "the guest is Running", so generic restore needs no hypervisor-specific state priming.
+
+## Platform constraints & edge cases
+
+- **macOS 14+, Apple silicon only.** Save/restore is gated by `macOSAvailable(14)` and darwin/arm64 build tags; `Capabilities().SupportsSnapshot` is `runtime.GOARCH == "arm64"`. `clonefile` has been available since the introduction of APFS.
+- **APFS volume boundaries / non-APFS.** `clonefile` only clones within a single APFS volume; cross-volume returns `EXDEV` and non-APFS returns `ENOTSUP`, and we fall back to a sparse copy whose cost scales with disk size. No correctness risk, only a performance cliff. The common deployment keeps instance and snapshot dirs on one APFS volume and gets CoW.
+- **Compatibility / device-config stability.** Restore fails if the saved state is incompatible with the current configuration. The disk clone copies the disk exactly, so it does not affect restore compatibility; the constraint that NIC identity must not be rewritten in the serialized config (`lib/hypervisor/vz/fork.go`) is unaffected.
+
+## Testing
+
+- **`lib/forkvm` (landed with #276):** `copy_reflink_darwin_test.go` covers clone correctness over a guest-shaped tree, the stale-destination contract, the forced sparse fallback, and the `isReflinkUnsupportedError` table. Fork latency: `BenchmarkForkGuestDisk` and the end-to-end `TestVZForkSpeed`.
+- **Running-source snapshot round-trip (darwin/arm64):** `TestVZRunningSnapshotRoundTrip` (`lib/instances/snapshot_running_source_darwin_test.go`) drives a standby snapshot from a *running* source → fork → restore → resume → guest reachable with state intact. This exercises the running-source save + disk-copy path the other darwin tests don't (they snapshot from standby).
+- **Firecracker/CH compression** tests stay; there are no `machine-state.vzm` compression tests (not applicable on `vz`).
+
+## Prior art: Tart
+
+Tart is an open-source VM toolset on the same Virtualization.framework. Its suspend/resume uses the same path-based save/restore contract (`state.vzvmsave`), detects state by file existence, and clones via `FileManager.copyItem` — which on APFS transparently performs a `clonefile` CoW clone. hypeman gets the same CoW behavior via an explicit `unix.Clonefile` call in `lib/forkvm`, so the path is observable, testable, and has a defined fallback. Tart constrains suspend to interactive GUI macOS guests; hypeman's guests are headless Linux, gated only by `validateSaveRestoreSupport`.
+
+## Risks & alternatives considered
+
+- **Compressing `machine-state.vzm`** burns host CPU during reclaim and extends the paused window with no offsetting space win on `vz` (zero pages already omitted). Dropped. The async compression subsystem still helps Firecracker/Cloud-Hypervisor.
+- **Overlapping save and disk copy** adds concurrency and cleanup complexity for no measurable benefit once the disk copy is `clonefile`-instant (445 ms serial vs 482 ms overlap on a 2 GiB-overlay VM). Dropped on `vz`; would matter for the cross-volume/non-APFS sparse-copy fallback.
+- **`clonefile` vs `FICLONE` semantics (resolved in #276).** `clonefile` creates the destination and copies metadata; the darwin path removes the destination first, drops owner/SUID/SGID/ACL via `CLONE_NOOWNERCOPY`, and re-applies perms with `Chmod`.

--- a/docs/proposals/faster-standby-restore.md
+++ b/docs/proposals/faster-standby-restore.md
@@ -77,7 +77,7 @@ On `vz`, `machine-state.vzm` is never compressed, so it is always present as wri
 
 ## Platform constraints & edge cases
 
-- **macOS 14+, Apple silicon only.** Save/restore is gated by `macOSAvailable(14)` and darwin/arm64 build tags; `Capabilities().SupportsSnapshot` is `runtime.GOARCH == "arm64"`. `clonefile` has been available since the introduction of APFS.
+- **macOS 14+, Apple silicon only.** Save/restore is restricted to darwin/arm64 by build tags and gated at runtime by `validateSaveRestoreSupport` (`cmd/vz-shim`), which calls the framework's `ValidateSaveRestoreSupport()` (requires macOS 14+); `Capabilities().SupportsSnapshot` is `runtime.GOARCH == "arm64"`. `clonefile` has been available since the introduction of APFS.
 - **APFS volume boundaries / non-APFS.** `clonefile` only clones within a single APFS volume; cross-volume returns `EXDEV` and non-APFS returns `ENOTSUP`, and we fall back to a sparse copy whose cost scales with disk size. No correctness risk, only a performance cliff. The common deployment keeps instance and snapshot dirs on one APFS volume and gets CoW.
 - **Compatibility / device-config stability.** Restore fails if the saved state is incompatible with the current configuration. The disk clone copies the disk exactly, so it does not affect restore compatibility; the constraint that NIC identity must not be rewritten in the serialized config (`lib/hypervisor/vz/fork.go`) is unaffected.
 

--- a/lib/hypervisor/vz/client.go
+++ b/lib/hypervisor/vz/client.go
@@ -255,7 +255,7 @@ func (c *Client) Resume(ctx context.Context) error {
 	// be "Running" so an immediate vm.info read-back or guest exec doesn't observe
 	// a transient Paused. Poll the shim's raw state until it reports Running,
 	// bounded by a short timeout so a stuck VM still surfaces an error.
-	return c.waitForRawState(ctx, "Running", resumeReadyTimeout, resumeReadyPollInterval)
+	return c.waitForRawState(ctx, "Running")
 }
 
 const (
@@ -264,11 +264,11 @@ const (
 )
 
 // waitForRawState polls vm.info until the shim's raw state string equals want or
-// the timeout elapses. It checks the raw state (not the hypervisor.VMState
+// resumeReadyTimeout elapses. It checks the raw state (not the hypervisor.VMState
 // mapping, which collapses "Resuming" into Running) so the post-condition is the
 // guest actually being in the requested state.
-func (c *Client) waitForRawState(ctx context.Context, want string, timeout, interval time.Duration) error {
-	deadline := time.Now().Add(timeout)
+func (c *Client) waitForRawState(ctx context.Context, want string) error {
+	deadline := time.Now().Add(resumeReadyTimeout)
 	for {
 		state, err := c.rawVMState(ctx)
 		if err == nil && state == want {
@@ -278,12 +278,12 @@ func (c *Client) waitForRawState(ctx context.Context, want string, timeout, inte
 			if err != nil {
 				return fmt.Errorf("wait for vm state %q: %w", want, err)
 			}
-			return fmt.Errorf("vm did not reach state %q within %s (last state %q)", want, timeout, state)
+			return fmt.Errorf("vm did not reach state %q within %s (last state %q)", want, resumeReadyTimeout, state)
 		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(interval):
+		case <-time.After(resumeReadyPollInterval):
 		}
 	}
 }

--- a/lib/hypervisor/vz/client.go
+++ b/lib/hypervisor/vz/client.go
@@ -246,7 +246,59 @@ func (c *Client) Pause(ctx context.Context) error {
 }
 
 func (c *Client) Resume(ctx context.Context) error {
-	return c.doPut(ctx, "/api/v1/vm.resume", nil)
+	if err := c.doPut(ctx, "/api/v1/vm.resume", nil); err != nil {
+		return err
+	}
+	// vm.resume is fire-and-forget on the shim: it returns as soon as the resume
+	// is requested, before the guest has actually left the Paused/Resuming
+	// transition. Callers (e.g. generic restore) expect Resume's post-condition to
+	// be "Running" so an immediate vm.info read-back or guest exec doesn't observe
+	// a transient Paused. Poll the shim's raw state until it reports Running,
+	// bounded by a short timeout so a stuck VM still surfaces an error.
+	return c.waitForRawState(ctx, "Running", resumeReadyTimeout, resumeReadyPollInterval)
+}
+
+const (
+	resumeReadyTimeout      = 10 * time.Second
+	resumeReadyPollInterval = 25 * time.Millisecond
+)
+
+// waitForRawState polls vm.info until the shim's raw state string equals want or
+// the timeout elapses. It checks the raw state (not the hypervisor.VMState
+// mapping, which collapses "Resuming" into Running) so the post-condition is the
+// guest actually being in the requested state.
+func (c *Client) waitForRawState(ctx context.Context, want string, timeout, interval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		state, err := c.rawVMState(ctx)
+		if err == nil && state == want {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("wait for vm state %q: %w", want, err)
+			}
+			return fmt.Errorf("vm did not reach state %q within %s (last state %q)", want, timeout, state)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+// rawVMState returns the shim's unmapped state string from vm.info.
+func (c *Client) rawVMState(ctx context.Context) (string, error) {
+	body, err := c.doGet(ctx, "/api/v1/vm.info")
+	if err != nil {
+		return "", fmt.Errorf("get vm info: %w", err)
+	}
+	var info vmInfoResponse
+	if err := json.Unmarshal(body, &info); err != nil {
+		return "", fmt.Errorf("decode vm info: %w", err)
+	}
+	return info.State, nil
 }
 
 func (c *Client) Snapshot(ctx context.Context, destPath string, _ hypervisor.SnapshotOptions) error {

--- a/lib/instances/snapshot_running_source_darwin_test.go
+++ b/lib/instances/snapshot_running_source_darwin_test.go
@@ -1,0 +1,149 @@
+//go:build darwin
+
+package instances
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+	"github.com/kernel/hypeman/lib/images"
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/system"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVZRunningSnapshotRoundTrip drives the running-source standby snapshot path
+// end-to-end on a real vz guest. A standby snapshot taken from a RUNNING source
+// saves the machine state and copies the guest disk inside the paused window,
+// then resumes the source. Forking the snapshot and restoring it proves the
+// snapshot resumes with guest state intact — coverage the other darwin tests
+// don't provide (they snapshot from standby, never exercising the running-source
+// save+copy path).
+func TestVZRunningSnapshotRoundTrip(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "darwin" {
+		t.Skip("vz tests require macOS")
+	}
+	if runtime.GOARCH != "arm64" {
+		t.Skip("vz standby/restore requires Apple Silicon (arm64)")
+	}
+	if !isMacOS14OrLater(t) {
+		t.Skip("vz standby/restore requires macOS 14+")
+	}
+	ensureMkfsExt4Available(t)
+
+	mgr, tmpDir := setupVZTestManager(t)
+	ctx := context.Background()
+	p := paths.New(tmpDir)
+
+	imageManager, err := images.NewManager(p, 1, nil)
+	require.NoError(t, err)
+
+	imageRef := integrationTestImageRef(t, "docker.io/library/alpine:latest")
+	alpineImage, err := imageManager.CreateImage(ctx, images.CreateImageRequest{Name: imageRef})
+	require.NoError(t, err)
+	alpineRef, err := images.ParseNormalizedRef(alpineImage.Name)
+	require.NoError(t, err)
+	waitName := alpineImage.Name
+	if alpineImage.Digest != "" {
+		waitName = alpineRef.Repository() + "@" + alpineImage.Digest
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	require.NoError(t, imageManager.WaitForReady(waitCtx, waitName), "image should become ready")
+
+	require.NoError(t, system.NewManager(p).EnsureSystemFiles(ctx))
+
+	source, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
+		Name:           "vz-running-snap-src",
+		Image:          imageRef,
+		Size:           2 * 1024 * 1024 * 1024,
+		OverlaySize:    10 * 1024 * 1024 * 1024,
+		Vcpus:          1,
+		NetworkEnabled: false,
+		Hypervisor:     hypervisor.TypeVZ,
+		Cmd:            []string{"sleep", "infinity"},
+	})
+	if err != nil {
+		dumpVZShimLogs(t, tmpDir)
+		require.NoError(t, err)
+	}
+	sourceID := source.Id
+	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), sourceID) })
+
+	require.NoError(t, waitForExecAgent(ctx, mgr, sourceID, 60*time.Second), "guest agent should be ready")
+	source, err = waitForInstanceState(ctx, mgr, sourceID, StateRunning, 30*time.Second)
+	require.NoError(t, err)
+
+	// Write a marker into the guest so the snapshot round-trip can be verified
+	// against concrete guest state.
+	const marker = "running-snap-marker"
+	_, code, err := vzExecCommand(ctx, source, "sh", "-c", fmt.Sprintf("echo %s > /root/marker && sync", marker))
+	require.NoError(t, err)
+	require.Equal(t, 0, code, "writing the marker should succeed")
+
+	// Standby snapshot from the RUNNING source: saves machine state and copies the
+	// guest disk inside the paused window, then resumes the source.
+	snapshot, err := mgr.CreateSnapshot(ctx, sourceID, CreateSnapshotRequest{
+		Kind: SnapshotKindStandby,
+		Name: "running-snap",
+	})
+	if err != nil {
+		dumpVZShimLogs(t, tmpDir)
+		require.NoError(t, err)
+	}
+	require.Equal(t, SnapshotKindStandby, snapshot.Kind)
+
+	// The save must have written the raw machine state into the snapshot payload.
+	stateDir := filepath.Join(p.SnapshotGuestDir(snapshot.Id), "snapshots", "snapshot-latest")
+	assert.FileExists(t, filepath.Join(stateDir, "machine-state.vzm"), "snapshot should contain the saved machine state")
+
+	// The running source is resumed after the snapshot; it must remain reachable
+	// with its guest state intact.
+	_, err = waitForInstanceState(ctx, mgr, sourceID, StateRunning, 60*time.Second)
+	require.NoError(t, err, "source should be resumed to running after the snapshot")
+	require.NoError(t, waitForExecAgent(ctx, mgr, sourceID, 60*time.Second))
+	srcInst, err := mgr.GetInstance(ctx, sourceID)
+	require.NoError(t, err)
+	out, code, err := vzExecCommand(ctx, srcInst, "cat", "/root/marker")
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+	assert.Equal(t, marker, strings.TrimSpace(out), "source guest state intact after the running-source snapshot")
+
+	require.NoError(t, mgr.DeleteInstance(ctx, sourceID))
+
+	// Fork the snapshot into a standby instance, then restore it. A successful
+	// resume proves the running-source snapshot produced a restorable snapshot.
+	forked, err := mgr.ForkSnapshot(ctx, snapshot.Id, ForkSnapshotRequest{Name: "running-snap-fork", TargetState: StateStandby})
+	if err != nil {
+		dumpVZShimLogs(t, tmpDir)
+		require.NoError(t, err)
+	}
+	forkID := forked.Id
+	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), forkID) })
+
+	restored, err := mgr.RestoreInstance(ctx, forkID)
+	if err != nil {
+		dumpVZShimLogs(t, tmpDir)
+		require.NoError(t, err)
+	}
+	assert.Contains(t, []State{StateInitializing, StateRunning}, restored.State)
+
+	require.NoError(t, waitForExecAgent(ctx, mgr, forkID, 60*time.Second), "restored fork guest agent should be ready")
+	forkInst, err := mgr.GetInstance(ctx, forkID)
+	require.NoError(t, err)
+	forkOut, code, err := vzExecCommand(ctx, forkInst, "cat", "/root/marker")
+	if err != nil {
+		dumpVZShimLogs(t, tmpDir)
+	}
+	require.NoError(t, err, "exec should succeed on the restored fork")
+	require.Equal(t, 0, code)
+	assert.Equal(t, marker, strings.TrimSpace(forkOut), "restored fork must carry the source's guest state from the running-source snapshot")
+}


### PR DESCRIPTION
> **Point-in-time note (rewritten):** this PR started as "compress machine-state + overlap the save with the disk copy." Investigation showed **neither mechanism helps on vz today** — the real standby/fork speedup already shipped in #276 (APFS `clonefile` CoW disk copy). So this PR was slimmed to an RFC documenting that finding plus the small fixes that survived. Net diff: **4 files, +307/−8.**

## What actually made vz standby/fork fast: #276 (clonefile)
APFS `clonefile` makes the guest-disk copy a copy-on-write, size-independent ~1ms operation. That — not anything in this PR — is the win. See #276 for before/after fork timings.

## Why the two originally-proposed mechanisms are no-ops on vz
**A — compress `machine-state.vzm`:** a no-op. Apple's `SaveMachineStateToPath` already omits zero/free guest pages, so the artifact is a high-entropy residual. Measured: zstd compresses it **~0%**, lz4 nets **larger**. (This is distinct from Tart, whose beneficial compression is on the OCI *disk image* — hypeman's equivalent is the overlay, handled by #276.)

**B — overlap save ∥ disk-copy in the paused window:** no measurable speedup now that the copy is ~1ms via clonefile. The paused window is dominated by the machine-state save, and the disk copy that B would hide behind it is already negligible. Not worth the concurrency/complexity on vz.

Neither A nor B is implemented here. Both still matter for the **cross-volume / sparse-copy fallback** path and for the **firecracker/cloud-hypervisor** backends, so the RFC keeps them on the table for those cases.

## Measured CLI timings (Apple Silicon, vz, 4 GB guest)
End-to-end wall-clock of the actual CLI commands: `standby` timed until the instance reaches `Standby` (machine state fully saved + disk cloned + VM stopped); `restore` timed until `Running` **and** an immediate `exec` succeeds. Median of 3, configured RAM fixed at 4 GB; the variable is how much guest RAM was *dirtied* before standby.

| dirtied RAM | `standby` → Standby | `restore` → Running+exec | `machine-state.vzm` |
|------------:|--------------------:|-------------------------:|--------------------:|
|       64 MB |              1666ms |                    761ms |               164 MB |
|      256 MB |              1813ms |                   1111ms |               360 MB |
|      512 MB |              1839ms |                   1685ms |               624 MB |
|    1024 MB |              2232ms |                   2814ms |              1120 MB |
|    2048 MB |              2641ms |                   5365ms |              2048 MB |

Takeaways:
- **State size tracks *dirtied* RAM, not configured RAM** (a 4 GB guest with 2 GB touched saves a ~2 GB `.vzm`, not 4 GB) — direct confirmation that vz omits zero/free pages, which is why mechanism A can't compress it.
- **standby/restore time is dominated by the machine-state save/load**, proportional to the live working set. The guest-disk copy is ~1ms (clonefile) and contributes nothing measurable — which is precisely why overlapping it (mechanism B) is a no-op.

## What this PR lands (the keepers)
- **`docs/proposals/faster-standby-restore.md`** — the RFC above, with the measurements.
- **`lib/hypervisor/vz/client.go`** — `Resume()` now polls `vm.info` until the shim reports raw state `Running` (10s bound, 25ms poll) instead of being fire-and-forget. So `restore` reports `Running` and an immediate `exec` succeeds. This replaces a generic hypervisor-state prime that had leaked vz-specific semantics up into `lib/instances`.
- **`Makefile`** — drop a dead duplicate `run` target; silence duplicate-library linker warnings on darwin builds.
- **`lib/instances/...darwin_test.go`** — serial running-source snapshot→fork→restore roundtrip e2e regression test.

## Verification
Live-tested on Apple Silicon (vz): standby→restore reports `(state: Running)` with immediate `exec` succeeding and uptime preserved; fork-from-running boots, sees source state, stays CoW-isolated (no write leak back to source). Timings above captured on the same setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is localized to vz Resume polling (adds up to ~10s wait on failure); restore path is more correct for immediate exec. Docs and test-only additions otherwise.
> 
> **Overview**
> Adds **`docs/proposals/faster-standby-restore.md`**, an RFC that records why vz standby/fork latency is dominated by **`machine-state.vzm` save/load** (with #276’s APFS **`clonefile`** disk copy already ~instant), and why **compressing `machine-state.vzm`** and **overlapping save with disk copy** were measured as no-ops on vz and not shipped.
> 
> **`lib/hypervisor/vz/client.go`**: **`Resume()`** no longer treats the shim’s fire-and-forget resume PUT as done—it **polls raw `vm.info` until state is `Running`** (10s cap, 25ms interval) so restore callers see a real **Running** post-condition before **`exec`**.
> 
> **`lib/instances/snapshot_running_source_darwin_test.go`**: new darwin e2e **`TestVZRunningSnapshotRoundTrip`** (running source → standby snapshot → fork → restore) with guest marker verification.
> 
> **`Makefile`**: removes an older duplicate **`run`** recipe; adds **`DARWIN_LDFLAGS`** to silence Xcode 15+ duplicate **`-lobjc`** linker warnings on **`vz-shim`** and **`hypeman`** darwin builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 021b4f467e6cd8239b38ae1a0d8864d955b1f69d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->