### PR TITLE
Add CLI-only install script (scripts/install-cli.sh)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,6 +258,11 @@ jobs:
         run: brew list caddy &>/dev/null || brew install caddy
       - name: Run E2E install test
         run: bash scripts/e2e-install-test.sh
+      - name: Run E2E CLI-only install test
+        run: |
+          CLI_DIR="$(mktemp -d)"
+          INSTALL_DIR="$CLI_DIR" bash scripts/install-cli.sh
+          "$CLI_DIR/hypeman" --version
       - name: Cleanup on failure
         if: failure()
         run: bash scripts/uninstall.sh || true

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To use the Hypeman CLI from a **different machine** than the server:
 brew install kernel/tap/hypeman
 ```
 
-**Linux:**
+**Install script (Linux & macOS):**
 ```bash
 curl -fsSL https://get.hypeman.sh/cli | bash
 ```

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -97,11 +97,12 @@ fi
 
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 SUDO=""
-if [ -w "$INSTALL_DIR" ]; then
+if [ -w "$INSTALL_DIR" ] || [ -w "$(dirname "$INSTALL_DIR")" ]; then
     :
 elif command -v sudo >/dev/null 2>&1; then
     SUDO="sudo"
 else
+    warn "${INSTALL_DIR} is not writable and sudo is unavailable; installing to ~/.local/bin instead"
     INSTALL_DIR="$HOME/.local/bin"
 fi
 $SUDO mkdir -p "$INSTALL_DIR"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -29,6 +29,7 @@ info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 
+# Mirrored from scripts/install.sh; keep in sync (a curl | bash script can't source a shared file).
 # Find the most recent release that has a specific artifact available
 # Usage: find_release_with_artifact <repo> <archive_prefix> <os> <arch> [ext]
 # Returns: version tag (e.g., v0.5.0) or empty string if not found

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+#
+# Hypeman CLI Install Script
+#
+# Installs only the hypeman CLI (kernel/hypeman-cli). It does not install or
+# configure the hypeman server.
+#
+# Usage:
+#   curl -fsSL https://get.hypeman.sh/cli | bash
+#
+# Options (via environment variables):
+#   CLI_VERSION  - Install a specific CLI version (default: latest)
+#   INSTALL_DIR  - Binary installation directory (default: /usr/local/bin,
+#                  falling back to ~/.local/bin when not writable)
+#
+
+set -e
+
+REPO="kernel/hypeman-cli"
+BINARY_NAME="hypeman"
+
+# Colors for output (true color)
+RED='\033[38;2;255;110;110m'
+GREEN='\033[38;2;92;190;83m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# Find the most recent release that has a specific artifact available
+# Usage: find_release_with_artifact <repo> <archive_prefix> <os> <arch> [ext]
+# Returns: version tag (e.g., v0.5.0) or empty string if not found
+find_release_with_artifact() {
+    local repo="$1"
+    local archive_prefix="$2"
+    local os="$3"
+    local arch="$4"
+    local ext="${5:-tar.gz}"
+
+    local tags
+    tags=$(curl -fsSL "https://api.github.com/repos/${repo}/releases?per_page=10" 2>/dev/null | grep '"tag_name"' | cut -d'"' -f4)
+    if [ -z "$tags" ]; then
+        return 1
+    fi
+
+    for tag in $tags; do
+        local version_num="${tag#v}"
+        local artifact_name="${archive_prefix}_${version_num}_${os}_${arch}.${ext}"
+        local artifact_url="https://github.com/${repo}/releases/download/${tag}/${artifact_name}"
+
+        if curl -fsSL --head "$artifact_url" >/dev/null 2>&1; then
+            echo "$tag"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# =============================================================================
+# Detect OS and architecture
+# =============================================================================
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case $ARCH in
+    x86_64|amd64)
+        ARCH="amd64"
+        ;;
+    aarch64|arm64)
+        ARCH="arm64"
+        ;;
+    *)
+        error "Unsupported architecture: $ARCH (supported: amd64, arm64)"
+        ;;
+esac
+
+if [ "$OS" != "linux" ] && [ "$OS" != "darwin" ]; then
+    error "Unsupported OS: $OS (supported: linux, darwin)"
+fi
+
+# CLI releases use goreleaser naming: "macos" not "darwin", .zip not .tar.gz on macOS
+if [ "$OS" = "darwin" ]; then
+    CLI_OS="macos"
+    CLI_EXT="zip"
+else
+    CLI_OS="$OS"
+    CLI_EXT="tar.gz"
+fi
+
+# =============================================================================
+# Resolve installation directory
+# =============================================================================
+
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+SUDO=""
+if [ -w "$INSTALL_DIR" ]; then
+    :
+elif command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+else
+    INSTALL_DIR="$HOME/.local/bin"
+fi
+$SUDO mkdir -p "$INSTALL_DIR"
+
+# =============================================================================
+# Resolve version and download
+# =============================================================================
+
+if [ -z "${CLI_VERSION:-}" ] || [ "$CLI_VERSION" = "latest" ]; then
+    info "Fetching latest CLI release for ${CLI_OS}/${ARCH}..."
+    CLI_VERSION=$(find_release_with_artifact "$REPO" "$BINARY_NAME" "$CLI_OS" "$ARCH" "$CLI_EXT" || true)
+    [ -n "$CLI_VERSION" ] || error "Could not find a CLI release with an artifact for ${CLI_OS}/${ARCH}"
+fi
+
+CLI_VERSION_NUM="${CLI_VERSION#v}"
+ARCHIVE_NAME="${BINARY_NAME}_${CLI_VERSION_NUM}_${CLI_OS}_${ARCH}.${CLI_EXT}"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${CLI_VERSION}/${ARCHIVE_NAME}"
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+info "Installing hypeman CLI ${CLI_VERSION}..."
+curl -fsSL "$DOWNLOAD_URL" -o "${TMP_DIR}/${ARCHIVE_NAME}" || error "Failed to download ${DOWNLOAD_URL}"
+
+mkdir -p "${TMP_DIR}/cli"
+if [ "$CLI_EXT" = "zip" ]; then
+    unzip -qo "${TMP_DIR}/${ARCHIVE_NAME}" -d "${TMP_DIR}/cli"
+else
+    tar -xzf "${TMP_DIR}/${ARCHIVE_NAME}" -C "${TMP_DIR}/cli"
+fi
+
+[ -f "${TMP_DIR}/cli/${BINARY_NAME}" ] || error "Archive did not contain expected '${BINARY_NAME}' binary"
+
+$SUDO install -m 755 "${TMP_DIR}/cli/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+
+info "Installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"
+
+case ":$PATH:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *) warn "${INSTALL_DIR} is not on your PATH. Add it with: export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
+esac
+
+info "Run 'hypeman --help' to get started."


### PR DESCRIPTION
## Summary

Adds `scripts/install-cli.sh`, a CLI-only installer that installs **only** the `hypeman` CLI from `kernel/hypeman-cli` releases — without attempting the server install.

This is the script side of fixing the `get.hypeman.sh/cli` path: today `/cli` redirects to the full `install.sh`, which installs the server first and aborts on macOS (no `darwin_arm64` server release artifact exists), so the CLI never installs. A standalone CLI installer lets `/cli` install the CLI on any supported machine regardless of server availability.

The redirect flip (pointing `get.hypeman.sh/cli` at this script) is a separate change in the `kernel/hypeman-www` repo and should land only after this is merged to `main`.

## What it does

- Detects OS/arch and maps to the CLI release naming (`darwin` → `macos`, `.zip`; otherwise `<os>`, `.tar.gz`).
- Resolves the latest `kernel/hypeman-cli` release that has a matching artifact (reusing the same `find_release_with_artifact` helper used by `install.sh`).
- Downloads, extracts, and installs the `hypeman` binary to `/usr/local/bin` — using `sudo` only when neither the target dir nor its parent is writable, otherwise falling back to `~/.local/bin` (and warning before it does). Warns if the install dir isn't on `PATH`.
- Requires none of Docker, codesign, systemd, or KVM — those are server-only.
- A new step in the macOS `e2e-install` CI job runs the script end-to-end (into a temp `INSTALL_DIR`) and asserts `hypeman --version`.

It deliberately does **not** generate `~/.config/hypeman/cli.yaml` (that needs the server's token tooling) and does **not** carry the server installer's "Intel Macs not supported" guard (the CLI runs fine on Intel and a `macos_amd64` build is published).

## Test plan

- [x] Runs end-to-end on a real Apple Silicon runner via the new `e2e-install` CI step — downloads the macOS `.zip`, installs, and `hypeman --version` passes.
- [x] Ran on Linux x86_64 against the live `kernel/hypeman-cli` release: installs `hypeman`, `--version` / `--help` work, and the not-on-PATH warning fires when installing outside `PATH`.
- [x] Confirmed the resolved macOS arm64 artifact (`hypeman_<ver>_macos_arm64.zip`) exists on the current release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New installer script and CI/docs only; no server or auth code changes.
> 
> **Overview**
> Adds **`scripts/install-cli.sh`**, a **curl | bash** path that installs only the **`hypeman`** binary from **`kernel/hypeman-cli`** GitHub releases—no server, Docker, or service setup. It maps **darwin** to **macos** / **.zip** artifacts, picks the latest release with a matching build via **`find_release_with_artifact`** (mirrored from **`install.sh`**), and installs to **`INSTALL_DIR`** (default **`/usr/local/bin`**, with **sudo** or **`~/.local/bin`** fallback).
> 
> The **macOS `e2e-install`** workflow gains a step that runs the script into a temp dir and checks **`hypeman --version`**. **README** remote-CLI docs now label the install script as **Linux & macOS** (not Linux-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d43ab77e82e7e728e8c2eaa211aef1e48f9994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

