### PR TITLE
Publish darwin_arm64 server release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,37 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # The macOS server links cgo against Virtualization.framework, so it can't be
+  # cross-compiled from the Linux release job — it builds on a macOS arm64 runner.
+  release-darwin:
+    needs: release
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.4'
+
+      - name: Build server and token tool
+        run: |
+          make build-darwin
+          go build -o bin/hypeman-token ./cmd/gen-jwt
+
+      - name: Package and upload darwin_arm64 archive
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          STAGE="$(mktemp -d)"
+          cp bin/hypeman "${STAGE}/hypeman-api"
+          cp bin/hypeman-token "${STAGE}/hypeman-token"
+          cp config.example.darwin.yaml "${STAGE}/"
+          ARCHIVE="hypeman_${VERSION}_darwin_arm64.tar.gz"
+          tar -czf "${ARCHIVE}" -C "${STAGE}" .
+          gh release upload "${GITHUB_REF_NAME}" "${ARCHIVE}" --clobber


### PR DESCRIPTION
## Summary

Adds a `release-darwin` CI job so cutting a release also publishes a macOS server artifact: `hypeman_<version>_darwin_arm64.tar.gz`.

Today the release workflow builds Linux server artifacts only, so on Apple Silicon macOS `curl -fsSL https://get.hypeman.sh | bash` fails — the installer looks for `hypeman_<version>_darwin_arm64.tar.gz`, which is never published, and aborts before the server install completes.

The macOS server links cgo against Apple's Virtualization.framework (via `Code-Hex/vz`), so it **cannot** be cross-compiled from the existing Linux release runner. This adds a second job on a GitHub-hosted `macos-14` (Apple Silicon) runner that builds and uploads the artifact. macOS runners are free for this public repo.

## What the job does

- `needs: release` — runs after the Linux job, which creates the GitHub Release to attach to.
- `make build-darwin` builds the server (with the vz-shim embedded), plus `go build ./cmd/gen-jwt` for the token tool.
- Packages `hypeman-api` (renamed from the Makefile's `bin/hypeman`), `hypeman-token`, and `config.example.darwin.yaml` into `hypeman_<version>_darwin_arm64.tar.gz` and uploads it to the release.

Deliberately excluded: `hypeman-uffd-pager` (Linux `userfaultfd` only) and any standalone `vz-shim` (it's embedded into the server binary and re-signed at runtime). Binaries ship **unsigned** — the installer ad-hoc codesigns `hypeman-api` with the vz entitlements at install time, so no notarization/Developer-ID is needed for the `curl | bash` flow.

## Notes / limitations

- The darwin archive is uploaded via `gh release upload` after GoReleaser runs, so it is **not** listed in GoReleaser's `checksums.txt`. The installer does not verify checksums, so this doesn't affect installs.
- `.goreleaser.yaml` is intentionally untouched — GoReleaser can't run the multi-step `make build-darwin` embed flow in a single `go build`, so the Mac job builds and uploads directly.

## Test plan

- [x] Built end-to-end on real Apple Silicon: `make build-darwin` + `go build ./cmd/gen-jwt` succeed, and the staged tarball contains `hypeman-api`, `hypeman-token`, and `config.example.darwin.yaml` at root — matching what `scripts/install.sh` extracts on macOS.
- [x] Workflow YAML validates.
- [ ] The CI job itself (`make build-darwin` on `macos-14` + `gh release upload`) hasn't fired yet — only a real `v*` tag exercises the upload. Recommend a test/prerelease tag (or a temporary `workflow_dispatch` run) before relying on it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release pipeline and publishes new production binaries; failure or wrong archive layout would break macOS installs until fixed.
> 
> **Overview**
> **Adds a `release-darwin` GitHub Actions job** so version tags also ship `hypeman_<version>_darwin_arm64.tar.gz`, unblocking the macOS installer that expects that asset.
> 
> The new job runs on **`macos-14` after the existing Linux GoReleaser `release` job** (cgo/Virtualization.framework prevents cross-building from Linux). It runs `make build-darwin`, builds `hypeman-token` from `./cmd/gen-jwt`, stages `hypeman-api`, `hypeman-token`, and `config.example.darwin.yaml`, then **`gh release upload`s** the tarball to the same tag (outside GoReleaser/checksums).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a61a2921a4bf2f3b39061e66330f0492fbd92f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
