### PR TITLE
Exempt SSE endpoints from the 60s request timeout middleware

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -453,7 +453,19 @@ func run() error {
 			})
 		}
 
-		r.Use(middleware.Timeout(60 * time.Second))
+		// Skip the request timeout for SSE streaming endpoints (instance logs,
+		// build events): middleware.Timeout cancels the request context, which
+		// kills long-lived streams at 60s even while events are flowing.
+		r.Use(func(next http.Handler) http.Handler {
+			timeoutHandler := middleware.Timeout(60 * time.Second)(next)
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/logs") || strings.HasSuffix(r.URL.Path, "/events") {
+					next.ServeHTTP(w, r)
+					return
+				}
+				timeoutHandler.ServeHTTP(w, r)
+			})
+		})
 
 		// OpenAPI request validation with authentication
 		validatorOptions := &nethttpmiddleware.Options{


### PR DESCRIPTION
## Summary

- `middleware.Timeout(60 * time.Second)` on the authenticated route group cancels the request context after 60s, which hard-kills SSE streams (`/builds/{id}/events`, `/instances/{id}/logs`) even while events are actively flowing.
- For build events this is a correctness bug: a consumer following a build that takes >60s (including post-build image conversion) sees the stream close while the build status is still `building`, and misclassifies a successful build as timed out. In production this caused deployments to be marked failed at exactly stream-start+60s while the underlying build succeeded seconds later.
- Fix: skip the timeout middleware for paths ending in `/logs` or `/events`, mirroring the existing SSE skip in the HTTP metrics middleware directly above. All other routes keep the 60s timeout.

## Test plan

- [x] `go build ./cmd/api` and `go vet ./cmd/api` pass
- [ ] Follow a >60s build via `GET /builds/{id}/events?follow=true` and confirm the stream stays open until the terminal status event
- [ ] Confirm non-streaming endpoints still time out after 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing change for two SSE path suffixes; other endpoints keep the 60s timeout.
> 
> **Overview**
> Replaces the blanket **60s** `middleware.Timeout` on the authenticated API group with a wrapper that **bypasses** the timeout for paths ending in **`/logs`** or **`/events`**, while other routes still use the 60s limit.
> 
> `middleware.Timeout` cancels the request context at 60s, which was cutting off long-lived SSE streams (instance logs, build events) even when data was still flowing—e.g. builds over 60s could look failed when the stream died before the terminal status. The skip mirrors the existing HTTP metrics middleware pattern for `/logs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15020d6a1c83ee76c22fa5aa9d41e0f9395088f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->