### PR TITLE
Clean up standby control socket earlier

### DIFF
--- a/lib/instances/standby.go
+++ b/lib/instances/standby.go
@@ -369,6 +369,11 @@ func (m *manager) shutdownHypervisor(ctx context.Context, inst *Instance) error 
 		shutdownErr = hv.Shutdown(ctx)
 	}
 
+	// Teardown is committed; prevent new control-socket clients while the
+	// hypervisor exits. The deferred remove remains as a fallback for early
+	// returns above.
+	_ = os.Remove(inst.SocketPath)
+
 	// Wait for process to exit
 	if inst.HypervisorPID != nil {
 		pid := *inst.HypervisorPID

--- a/lib/instances/standby_test.go
+++ b/lib/instances/standby_test.go
@@ -1,13 +1,46 @@
 package instances
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestShutdownHypervisorRemovesControlSocket(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "hypeman-standby-socket-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(tmpDir)
+	})
+	socketPath := filepath.Join(tmpDir, "noop.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	require.NoError(t, listener.Close())
+
+	lifecycleNoopHypervisorStates.Store(socketPath, hypervisor.StateRunning)
+	t.Cleanup(func() {
+		lifecycleNoopHypervisorStates.Delete(socketPath)
+	})
+
+	m := &manager{}
+	inst := &Instance{
+		StoredMetadata: StoredMetadata{
+			Id:             "standby-socket-cleanup",
+			SocketPath:     socketPath,
+			HypervisorType: lifecycleNoopHypervisorType,
+		},
+	}
+
+	require.NoError(t, m.shutdownHypervisor(t.Context(), inst))
+
+	_, err = os.Stat(socketPath)
+	require.True(t, os.IsNotExist(err), "shutdown should remove the hypervisor control socket")
+}
 
 func TestDiscardPromotedRetainedSnapshotTargetAfterSnapshotError(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- remove the hypervisor control socket as soon as standby teardown is committed
- keep the deferred socket removal as a fallback for early returns
- add a regression test for shutdown socket cleanup

## Tests

- go test ./lib/instances -run 'TestShutdownHypervisorRemovesControlSocket|TestDiscardPromotedRetainedSnapshotTargetAfterSnapshotError|TestPrepareRetainedSnapshotTargetDiscardsStaleSnapshotDirBeforeRetry'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small timing change in instance lifecycle socket cleanup during standby shutdown; deferred removal still covers failure paths, and behavior is covered by a new unit test.
> 
> **Overview**
> During **standby** hypervisor teardown, `shutdownHypervisor` now **deletes the hypervisor control socket** (`SocketPath`) right after the shutdown path is committed—after a graceful shutdown attempt or when graceful shutdown is skipped—instead of only at function exit.
> 
> That closes the window where the VMM is still exiting but new clients could still dial the control socket. The existing **deferred** `os.Remove(inst.SocketPath)` is unchanged as a fallback for early returns (e.g. cannot connect).
> 
> A regression test **`TestShutdownHypervisorRemovesControlSocket`** exercises `shutdownHypervisor` with a noop hypervisor and asserts the socket file is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b16fe111a11d3139fc8e1356c57691710debb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->