### PR TITLE
Delete tc classes by TAP filter ownership

### DIFF
--- a/lib/instances/network_test.go
+++ b/lib/instances/network_test.go
@@ -65,18 +65,20 @@ func TestCreateInstanceWithNetwork(t *testing.T) {
 	t.Log("Initializing network...")
 	err = manager.networkManager.Initialize(ctx, nil)
 	require.NoError(t, err)
+	require.NoError(t, manager.networkManager.SetupHTB(ctx, 100*1024*1024))
 	t.Log("Network initialized")
 
 	// Create instance with nginx:alpine and default network
 	t.Log("Creating instance with default network...")
 	inst, err := manager.CreateInstance(ctx, CreateInstanceRequest{
-		Name:           "test-net-instance",
-		Image:          integrationTestImageRef(t, "docker.io/library/nginx:alpine"),
-		Size:           2 * 1024 * 1024 * 1024, // 2GB (needs extra room for initrd with NVIDIA libs)
-		HotplugSize:    512 * 1024 * 1024,
-		OverlaySize:    5 * 1024 * 1024 * 1024,
-		Vcpus:          1,
-		NetworkEnabled: true,
+		Name:                   "test-net-instance",
+		Image:                  integrationTestImageRef(t, "docker.io/library/nginx:alpine"),
+		Size:                   2 * 1024 * 1024 * 1024, // 2GB (needs extra room for initrd with NVIDIA libs)
+		HotplugSize:            512 * 1024 * 1024,
+		OverlaySize:            5 * 1024 * 1024 * 1024,
+		Vcpus:                  1,
+		NetworkEnabled:         true,
+		NetworkBandwidthUpload: 1024 * 1024,
 		HealthCheck: &healthcheck.Policy{
 			Type:             healthcheck.TypeHTTP,
 			Interval:         "1s",
@@ -126,6 +128,18 @@ func TestCreateInstanceWithNetwork(t *testing.T) {
 	require.NoError(t, err)
 	_, isBridge := master.(*netlink.Bridge)
 	assert.True(t, isBridge, "TAP should be attached to a bridge")
+	bridgeName := master.Attrs().Name
+
+	t.Log("Verifying orphaned bridge tc cleanup preserves live TAP state...")
+	liveFlowID := waitForUploadFlowID(t, ctx, manager, inst.Id, bridgeName)
+	require.True(t, bridgeClassExists(t, bridgeName, liveFlowID), "live upload class should exist before cleanup")
+	staleFlowID := createStaleBridgeTCForTest(t, bridgeName)
+	deletedTC := manager.networkManager.CleanupOrphanedClasses(ctx)
+	require.GreaterOrEqual(t, deletedTC, 2, "expected stale filter and class to be deleted")
+	assert.True(t, bridgeFilterExistsForFlowID(t, bridgeName, liveFlowID), "live upload filter should remain")
+	assert.True(t, bridgeClassExists(t, bridgeName, liveFlowID), "live upload class should remain")
+	assert.False(t, bridgeFilterExistsForFlowID(t, bridgeName, staleFlowID), "stale upload filter should be deleted")
+	assert.False(t, bridgeClassExists(t, bridgeName, staleFlowID), "stale upload class should be deleted")
 
 	// Wait for nginx to start
 	t.Log("Waiting for nginx to start...")
@@ -299,6 +313,137 @@ func TestCreateInstanceWithNetwork(t *testing.T) {
 	t.Log("Network allocation released after delete")
 
 	t.Log("Network integration test complete!")
+}
+
+func tcForTest(t *testing.T) string {
+	t.Helper()
+	if path, err := exec.LookPath("tc"); err == nil {
+		return path
+	}
+	return "/usr/sbin/tc"
+}
+
+func runTCForTest(t *testing.T, args ...string) string {
+	t.Helper()
+	output, err := exec.Command(tcForTest(t), args...).CombinedOutput()
+	require.NoError(t, err, "tc %s output: %s", strings.Join(args, " "), string(output))
+	return string(output)
+}
+
+func bridgeClassesForTest(t *testing.T, bridgeName string) []string {
+	t.Helper()
+	output := runTCForTest(t, "class", "show", "dev", bridgeName)
+	var classes []string
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "class htb 1:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 3 {
+			classes = append(classes, fields[2])
+		}
+	}
+	return classes
+}
+
+func bridgeClassExists(t *testing.T, bridgeName, classID string) bool {
+	t.Helper()
+	for _, class := range bridgeClassesForTest(t, bridgeName) {
+		if class == classID {
+			return true
+		}
+	}
+	return false
+}
+
+func bridgeFilterExistsForFlowID(t *testing.T, bridgeName, flowID string) bool {
+	t.Helper()
+	return len(bridgeFilterHandlesForFlowID(t, bridgeName, flowID)) > 0
+}
+
+func bridgeFilterHandlesForFlowID(t *testing.T, bridgeName, flowID string) []string {
+	t.Helper()
+	output := runTCForTest(t, "filter", "show", "dev", bridgeName, "parent", "1:")
+	var handles []string
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "filter ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		handle, gotFlowID := "", ""
+		for i, field := range fields {
+			if i+1 >= len(fields) {
+				break
+			}
+			switch field {
+			case "handle":
+				handle = fields[i+1]
+			case "flowid":
+				gotFlowID = fields[i+1]
+			}
+		}
+		if handle != "" && gotFlowID == flowID {
+			handles = append(handles, handle)
+		}
+	}
+	return handles
+}
+
+func waitForUploadFlowID(t *testing.T, ctx context.Context, manager *manager, instanceID, bridgeName string) string {
+	t.Helper()
+	var flowID string
+	require.Eventually(t, func() bool {
+		alloc, err := manager.networkManager.GetAllocation(ctx, instanceID)
+		if err != nil || alloc == nil || alloc.ClassID == "" {
+			return false
+		}
+		flowID = "1:" + alloc.ClassID
+		return bridgeClassExists(t, bridgeName, flowID) && bridgeFilterExistsForFlowID(t, bridgeName, flowID)
+	}, integrationTestTimeout(5*time.Second), 100*time.Millisecond)
+	return flowID
+}
+
+func createStaleBridgeTCForTest(t *testing.T, bridgeName string) string {
+	t.Helper()
+	used := make(map[string]bool)
+	for _, classID := range bridgeClassesForTest(t, bridgeName) {
+		used[classID] = true
+	}
+
+	staleFlowID := ""
+	for id := 0xff00; id <= 0xffff; id++ {
+		candidate := fmt.Sprintf("1:%04x", id)
+		if !used[candidate] {
+			staleFlowID = candidate
+			break
+		}
+	}
+	require.NotEmpty(t, staleFlowID, "expected an unused test class id")
+
+	t.Cleanup(func() {
+		bestEffortDeleteBridgeFiltersForFlowID(t, bridgeName, staleFlowID)
+		_ = exec.Command(tcForTest(t), "qdisc", "del", "dev", bridgeName, "parent", staleFlowID).Run()
+		_ = exec.Command(tcForTest(t), "class", "del", "dev", bridgeName, "classid", staleFlowID).Run()
+	})
+
+	runTCForTest(t, "class", "add", "dev", bridgeName, "parent", "1:1",
+		"classid", staleFlowID, "htb", "rate", "1mbit", "ceil", "1mbit")
+	runTCForTest(t, "qdisc", "add", "dev", bridgeName, "parent", staleFlowID, "fq_codel")
+	runTCForTest(t, "filter", "add", "dev", bridgeName, "parent", "1:",
+		"protocol", "all", "prio", "1", "basic",
+		"match", "meta(rt_iif eq 1)", "flowid", staleFlowID)
+
+	require.True(t, bridgeClassExists(t, bridgeName, staleFlowID), "staged stale class should exist")
+	require.True(t, bridgeFilterExistsForFlowID(t, bridgeName, staleFlowID), "staged stale filter should exist")
+	return staleFlowID
+}
+
+func bestEffortDeleteBridgeFiltersForFlowID(t *testing.T, bridgeName, flowID string) {
+	t.Helper()
+	for _, handle := range bridgeFilterHandlesForFlowID(t, bridgeName, flowID) {
+		_ = exec.Command(tcForTest(t), "filter", "del", "dev", bridgeName, "parent", "1:",
+			"protocol", "all", "prio", "1", "handle", handle, "basic").Run()
+	}
 }
 
 func startRestartPolicyControllerForTest(t *testing.T, ctx context.Context, manager *manager) {

--- a/lib/instances/network_test.go
+++ b/lib/instances/network_test.go
@@ -71,14 +71,13 @@ func TestCreateInstanceWithNetwork(t *testing.T) {
 	// Create instance with nginx:alpine and default network
 	t.Log("Creating instance with default network...")
 	inst, err := manager.CreateInstance(ctx, CreateInstanceRequest{
-		Name:                   "test-net-instance",
-		Image:                  integrationTestImageRef(t, "docker.io/library/nginx:alpine"),
-		Size:                   2 * 1024 * 1024 * 1024, // 2GB (needs extra room for initrd with NVIDIA libs)
-		HotplugSize:            512 * 1024 * 1024,
-		OverlaySize:            5 * 1024 * 1024 * 1024,
-		Vcpus:                  1,
-		NetworkEnabled:         true,
-		NetworkBandwidthUpload: 1024 * 1024,
+		Name:           "test-net-instance",
+		Image:          integrationTestImageRef(t, "docker.io/library/nginx:alpine"),
+		Size:           2 * 1024 * 1024 * 1024, // 2GB (needs extra room for initrd with NVIDIA libs)
+		HotplugSize:    512 * 1024 * 1024,
+		OverlaySize:    5 * 1024 * 1024 * 1024,
+		Vcpus:          1,
+		NetworkEnabled: true,
 		HealthCheck: &healthcheck.Policy{
 			Type:             healthcheck.TypeHTTP,
 			Interval:         "1s",
@@ -131,15 +130,15 @@ func TestCreateInstanceWithNetwork(t *testing.T) {
 	bridgeName := master.Attrs().Name
 
 	t.Log("Verifying orphaned bridge tc cleanup preserves live TAP state...")
-	liveFlowID := waitForUploadFlowID(t, ctx, manager, inst.Id, bridgeName)
-	require.True(t, bridgeClassExists(t, bridgeName, liveFlowID), "live upload class should exist before cleanup")
-	staleFlowID := createStaleBridgeTCForTest(t, bridgeName)
+	liveFlowID := createBridgeTCForTest(t, bridgeName, tap.Attrs().Index)
+	require.True(t, bridgeClassExists(t, bridgeName, liveFlowID), "live bridge tc class should exist before cleanup")
+	staleFlowID := createBridgeTCForTest(t, bridgeName, 1)
 	deletedTC := manager.networkManager.CleanupOrphanedClasses(ctx)
 	require.GreaterOrEqual(t, deletedTC, 2, "expected stale filter and class to be deleted")
-	assert.True(t, bridgeFilterExistsForFlowID(t, bridgeName, liveFlowID), "live upload filter should remain")
-	assert.True(t, bridgeClassExists(t, bridgeName, liveFlowID), "live upload class should remain")
-	assert.False(t, bridgeFilterExistsForFlowID(t, bridgeName, staleFlowID), "stale upload filter should be deleted")
-	assert.False(t, bridgeClassExists(t, bridgeName, staleFlowID), "stale upload class should be deleted")
+	assert.True(t, bridgeFilterExistsForFlowID(t, bridgeName, liveFlowID), "live bridge tc filter should remain")
+	assert.True(t, bridgeClassExists(t, bridgeName, liveFlowID), "live bridge tc class should remain")
+	assert.False(t, bridgeFilterExistsForFlowID(t, bridgeName, staleFlowID), "stale bridge tc filter should be deleted")
+	assert.False(t, bridgeClassExists(t, bridgeName, staleFlowID), "stale bridge tc class should be deleted")
 
 	// Wait for nginx to start
 	t.Log("Waiting for nginx to start...")
@@ -389,53 +388,39 @@ func bridgeFilterHandlesForFlowID(t *testing.T, bridgeName, flowID string) []str
 	return handles
 }
 
-func waitForUploadFlowID(t *testing.T, ctx context.Context, manager *manager, instanceID, bridgeName string) string {
-	t.Helper()
-	var flowID string
-	require.Eventually(t, func() bool {
-		alloc, err := manager.networkManager.GetAllocation(ctx, instanceID)
-		if err != nil || alloc == nil || alloc.ClassID == "" {
-			return false
-		}
-		flowID = "1:" + alloc.ClassID
-		return bridgeClassExists(t, bridgeName, flowID) && bridgeFilterExistsForFlowID(t, bridgeName, flowID)
-	}, integrationTestTimeout(5*time.Second), 100*time.Millisecond)
-	return flowID
-}
-
-func createStaleBridgeTCForTest(t *testing.T, bridgeName string) string {
+func createBridgeTCForTest(t *testing.T, bridgeName string, rtIif int) string {
 	t.Helper()
 	used := make(map[string]bool)
 	for _, classID := range bridgeClassesForTest(t, bridgeName) {
 		used[classID] = true
 	}
 
-	staleFlowID := ""
+	flowID := ""
 	for id := 0xff00; id <= 0xffff; id++ {
 		candidate := fmt.Sprintf("1:%04x", id)
 		if !used[candidate] {
-			staleFlowID = candidate
+			flowID = candidate
 			break
 		}
 	}
-	require.NotEmpty(t, staleFlowID, "expected an unused test class id")
+	require.NotEmpty(t, flowID, "expected an unused test class id")
 
 	t.Cleanup(func() {
-		bestEffortDeleteBridgeFiltersForFlowID(t, bridgeName, staleFlowID)
-		_ = exec.Command(tcForTest(t), "qdisc", "del", "dev", bridgeName, "parent", staleFlowID).Run()
-		_ = exec.Command(tcForTest(t), "class", "del", "dev", bridgeName, "classid", staleFlowID).Run()
+		bestEffortDeleteBridgeFiltersForFlowID(t, bridgeName, flowID)
+		_ = exec.Command(tcForTest(t), "qdisc", "del", "dev", bridgeName, "parent", flowID).Run()
+		_ = exec.Command(tcForTest(t), "class", "del", "dev", bridgeName, "classid", flowID).Run()
 	})
 
 	runTCForTest(t, "class", "add", "dev", bridgeName, "parent", "1:1",
-		"classid", staleFlowID, "htb", "rate", "1mbit", "ceil", "1mbit")
-	runTCForTest(t, "qdisc", "add", "dev", bridgeName, "parent", staleFlowID, "fq_codel")
+		"classid", flowID, "htb", "rate", "1mbit", "ceil", "1mbit")
+	runTCForTest(t, "qdisc", "add", "dev", bridgeName, "parent", flowID, "fq_codel")
 	runTCForTest(t, "filter", "add", "dev", bridgeName, "parent", "1:",
 		"protocol", "all", "prio", "1", "basic",
-		"match", "meta(rt_iif eq 1)", "flowid", staleFlowID)
+		"match", fmt.Sprintf("meta(rt_iif eq %d)", rtIif), "flowid", flowID)
 
-	require.True(t, bridgeClassExists(t, bridgeName, staleFlowID), "staged stale class should exist")
-	require.True(t, bridgeFilterExistsForFlowID(t, bridgeName, staleFlowID), "staged stale filter should exist")
-	return staleFlowID
+	require.True(t, bridgeClassExists(t, bridgeName, flowID), "staged bridge tc class should exist")
+	require.True(t, bridgeFilterExistsForFlowID(t, bridgeName, flowID), "staged bridge tc filter should exist")
+	return flowID
 }
 
 func bestEffortDeleteBridgeFiltersForFlowID(t *testing.T, bridgeName, flowID string) {

--- a/lib/instances/tap_gc.go
+++ b/lib/instances/tap_gc.go
@@ -63,10 +63,12 @@ func (m *manager) reconcileTAPs(ctx context.Context) {
 		// CleanupOrphanedTAPs short-circuits on empty preserve set to avoid
 		// clobbering TAPs from concurrent hypeman processes/tests. Mirror that here
 		// rather than calling it with an empty slice.
-		log.DebugContext(ctx, "TAP GC: no preserve candidates, skipping pass")
-		return
-	}
-	if deleted := m.networkManager.CleanupOrphanedTAPs(ctx, preserve, tapGCMinAge); deleted > 0 {
+		log.DebugContext(ctx, "TAP GC: no preserve candidates, skipping TAP pass")
+	} else if deleted := m.networkManager.CleanupOrphanedTAPs(ctx, preserve, tapGCMinAge); deleted > 0 {
 		log.InfoContext(ctx, "TAP GC: cleaned up orphaned TAP devices", "count", deleted)
+	}
+
+	if deleted := m.networkManager.CleanupOrphanedClasses(ctx); deleted > 0 {
+		log.InfoContext(ctx, "TAP GC: cleaned up orphaned tc filters/classes", "count", deleted)
 	}
 }

--- a/lib/instances/tap_gc.go
+++ b/lib/instances/tap_gc.go
@@ -49,23 +49,27 @@ func (m *manager) reconcileTAPs(ctx context.Context) {
 	// Initializing, and Unknown. "Better to leave a stale TAP than crash a
 	// running VM."
 	insts, err := m.ListInstances(ctx, nil)
+	var preserve []string
 	if err != nil {
-		log.WarnContext(ctx, "TAP GC: failed to list instances, skipping pass", "error", err)
-		return
-	}
-	preserve := make([]string, 0, len(insts))
-	for _, inst := range insts {
-		if inst.State == StateRunning || inst.State == StateInitializing || inst.State == StateUnknown {
-			preserve = append(preserve, inst.Id)
+		log.WarnContext(ctx, "TAP GC: failed to list instances, skipping TAP pass", "error", err)
+	} else {
+		preserve = make([]string, 0, len(insts))
+		for _, inst := range insts {
+			if inst.State == StateRunning || inst.State == StateInitializing || inst.State == StateUnknown {
+				preserve = append(preserve, inst.Id)
+			}
 		}
 	}
-	if len(preserve) == 0 {
-		// CleanupOrphanedTAPs short-circuits on empty preserve set to avoid
-		// clobbering TAPs from concurrent hypeman processes/tests. Mirror that here
-		// rather than calling it with an empty slice.
-		log.DebugContext(ctx, "TAP GC: no preserve candidates, skipping TAP pass")
-	} else if deleted := m.networkManager.CleanupOrphanedTAPs(ctx, preserve, tapGCMinAge); deleted > 0 {
-		log.InfoContext(ctx, "TAP GC: cleaned up orphaned TAP devices", "count", deleted)
+
+	if err == nil {
+		if len(preserve) == 0 {
+			// CleanupOrphanedTAPs short-circuits on empty preserve set to avoid
+			// clobbering TAPs from concurrent hypeman processes/tests. Mirror that here
+			// rather than calling it with an empty slice.
+			log.DebugContext(ctx, "TAP GC: no preserve candidates, skipping TAP pass")
+		} else if deleted := m.networkManager.CleanupOrphanedTAPs(ctx, preserve, tapGCMinAge); deleted > 0 {
+			log.InfoContext(ctx, "TAP GC: cleaned up orphaned TAP devices", "count", deleted)
+		}
 	}
 
 	if deleted := m.networkManager.CleanupOrphanedClasses(ctx); deleted > 0 {

--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -62,7 +62,7 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 	err = m.createTAPDevice(tapCtx, netConfig.TAPDevice, network.Bridge, network.Isolated)
 	tapSpanEnd(err)
 	if err != nil {
-		cleanupErr := m.deleteTAPDeviceForInstanceSerialized(req.InstanceID, netConfig.TAPDevice)
+		cleanupErr := m.deleteTAPDeviceForInstanceSerialized(ctx, req.InstanceID, netConfig.TAPDevice)
 		if cleanupErr != nil {
 			log.WarnContext(ctx, "failed to clean up TAP after create failure", "tap", netConfig.TAPDevice, "error", cleanupErr)
 		}
@@ -146,7 +146,7 @@ func (m *manager) RecreateAllocation(ctx context.Context, instanceID string, dow
 	err = m.createTAPDevice(tapCtx, alloc.TAPDevice, network.Bridge, network.Isolated)
 	tapSpanEnd(err)
 	if err != nil {
-		_ = m.deleteTAPDeviceForInstanceSerialized(instanceID, alloc.TAPDevice)
+		_ = m.deleteTAPDeviceForInstanceSerialized(ctx, instanceID, alloc.TAPDevice)
 		return fmt.Errorf("create TAP device: %w", err)
 	}
 	m.recordTAPOperation(ctx, "create")
@@ -389,7 +389,7 @@ func (m *manager) ReleaseAllocation(ctx context.Context, alloc *Allocation) erro
 	// 1. Delete TAP device (best effort), using the TAP's live tc filter for HTB cleanup.
 	// Serialize with async tc setup so queued rate-limit work cannot race with
 	// class removal and leave stale bridge state behind.
-	if err := m.deleteTAPDeviceForInstanceSerialized(alloc.InstanceID, alloc.TAPDevice); err != nil {
+	if err := m.deleteTAPDeviceForInstanceSerialized(ctx, alloc.InstanceID, alloc.TAPDevice); err != nil {
 		log.WarnContext(ctx, "failed to delete TAP device", "tap", alloc.TAPDevice, "error", err)
 	} else {
 		m.recordTAPOperation(ctx, "delete")
@@ -403,16 +403,16 @@ func (m *manager) ReleaseAllocation(ctx context.Context, alloc *Allocation) erro
 	return nil
 }
 
-func (m *manager) deleteTAPDeviceSerialized(tapName string) error {
+func (m *manager) deleteTAPDeviceSerialized(ctx context.Context, tapName string) error {
 	m.tcMu.Lock()
 	defer m.tcMu.Unlock()
-	return m.deleteTAPDevice(tapName)
+	return m.deleteTAPDevice(ctx, tapName)
 }
 
-func (m *manager) deleteTAPDeviceForInstanceSerialized(instanceID, tapName string) error {
+func (m *manager) deleteTAPDeviceForInstanceSerialized(ctx context.Context, instanceID, tapName string) error {
 	m.tcMu.Lock()
 	defer m.tcMu.Unlock()
-	if err := m.deleteTAPDevice(tapName); err != nil {
+	if err := m.deleteTAPDevice(ctx, tapName); err != nil {
 		return err
 	}
 	m.clearClassID(instanceID)

--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -62,7 +62,7 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 	err = m.createTAPDevice(tapCtx, netConfig.TAPDevice, network.Bridge, network.Isolated)
 	tapSpanEnd(err)
 	if err != nil {
-		cleanupErr := m.deleteTAPDeviceSerialized(netConfig.TAPDevice, "")
+		cleanupErr := m.deleteTAPDeviceForInstanceSerialized(req.InstanceID, netConfig.TAPDevice)
 		if cleanupErr != nil {
 			log.WarnContext(ctx, "failed to clean up TAP after create failure", "tap", netConfig.TAPDevice, "error", cleanupErr)
 		}
@@ -146,7 +146,7 @@ func (m *manager) RecreateAllocation(ctx context.Context, instanceID string, dow
 	err = m.createTAPDevice(tapCtx, alloc.TAPDevice, network.Bridge, network.Isolated)
 	tapSpanEnd(err)
 	if err != nil {
-		_ = m.deleteTAPDeviceSerialized(alloc.TAPDevice, alloc.ClassID)
+		_ = m.deleteTAPDeviceForInstanceSerialized(instanceID, alloc.TAPDevice)
 		return fmt.Errorf("create TAP device: %w", err)
 	}
 	m.recordTAPOperation(ctx, "create")
@@ -386,10 +386,10 @@ func (m *manager) ReleaseAllocation(ctx context.Context, alloc *Allocation) erro
 	}
 	m.forgetPendingAllocation(alloc.InstanceID)
 
-	// 1. Delete TAP device (best effort), using stored class ID for correct HTB cleanup.
+	// 1. Delete TAP device (best effort), using the TAP's live tc filter for HTB cleanup.
 	// Serialize with async tc setup so queued rate-limit work cannot race with
 	// class removal and leave stale bridge state behind.
-	if err := m.deleteTAPDeviceForInstanceSerialized(alloc.InstanceID, alloc.TAPDevice, alloc.ClassID); err != nil {
+	if err := m.deleteTAPDeviceForInstanceSerialized(alloc.InstanceID, alloc.TAPDevice); err != nil {
 		log.WarnContext(ctx, "failed to delete TAP device", "tap", alloc.TAPDevice, "error", err)
 	} else {
 		m.recordTAPOperation(ctx, "delete")
@@ -403,26 +403,20 @@ func (m *manager) ReleaseAllocation(ctx context.Context, alloc *Allocation) erro
 	return nil
 }
 
-func (m *manager) deleteTAPDeviceSerialized(tapName, classID string) error {
+func (m *manager) deleteTAPDeviceSerialized(tapName string) error {
 	m.tcMu.Lock()
 	defer m.tcMu.Unlock()
-	return m.deleteTAPDevice(tapName, classID)
+	return m.deleteTAPDevice(tapName)
 }
 
-func (m *manager) deleteTAPDeviceForInstanceSerialized(instanceID, tapName, classID string) error {
+func (m *manager) deleteTAPDeviceForInstanceSerialized(instanceID, tapName string) error {
 	m.tcMu.Lock()
 	defer m.tcMu.Unlock()
-	return m.deleteTAPDevice(tapName, m.classIDForDelete(instanceID, classID))
-}
-
-func (m *manager) classIDForDelete(instanceID, fallback string) string {
-	if instanceID == "" {
-		return fallback
+	if err := m.deleteTAPDevice(tapName); err != nil {
+		return err
 	}
-	if classID := m.loadClassID(instanceID); classID != "" {
-		return classID
-	}
-	return fallback
+	m.clearClassID(instanceID)
+	return nil
 }
 
 // getOrInitDefaultNetwork resolves the default network and self-heals by running

--- a/lib/network/bridge_darwin.go
+++ b/lib/network/bridge_darwin.go
@@ -50,7 +50,7 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 }
 
 // deleteTAPDevice is a no-op on macOS as we use NAT networking.
-func (m *manager) deleteTAPDevice(tapName string) error {
+func (m *manager) deleteTAPDevice(ctx context.Context, tapName string) error {
 	return nil
 }
 

--- a/lib/network/bridge_darwin.go
+++ b/lib/network/bridge_darwin.go
@@ -50,7 +50,7 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 }
 
 // deleteTAPDevice is a no-op on macOS as we use NAT networking.
-func (m *manager) deleteTAPDevice(tapName, classID string) error {
+func (m *manager) deleteTAPDevice(tapName string) error {
 	return nil
 }
 

--- a/lib/network/bridge_darwin.go
+++ b/lib/network/bridge_darwin.go
@@ -79,3 +79,7 @@ func (m *manager) CleanupOrphanedTAPs(ctx context.Context, preserveInstanceIDs [
 func (m *manager) CleanupOrphanedClasses(ctx context.Context) int {
 	return 0
 }
+
+func (m *manager) bridgeHTBClassCount(ctx context.Context) (int64, error) {
+	return 0, nil
+}

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -950,15 +950,21 @@ func planOrphanedBridgeTC(liveTapIndexes map[int]bool, filters []bridgeFilter, c
 		return nil, nil, false
 	}
 
-	liveClassIDs := make(map[string]bool)
+	protectedClassIDs := make(map[string]bool)
 	staleFilters := make([]bridgeFilter, 0)
 	for _, filter := range filters {
 		if filter.handle == "" || filter.flowID == "" {
 			continue
 		}
+		if filter.rtIif < 0 {
+			if classID, ok := minorClassID(filter.flowID); ok {
+				protectedClassIDs[classID] = true
+			}
+			continue
+		}
 		if liveTapIndexes[filter.rtIif] {
 			if classID, ok := minorClassID(filter.flowID); ok {
-				liveClassIDs[classID] = true
+				protectedClassIDs[classID] = true
 			}
 			continue
 		}
@@ -974,7 +980,7 @@ func planOrphanedBridgeTC(liveTapIndexes map[int]bool, filters []bridgeFilter, c
 		if !ok {
 			continue
 		}
-		if !liveClassIDs[classID] {
+		if !protectedClassIDs[classID] {
 			staleClasses = append(staleClasses, fullClassID)
 		}
 	}

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -914,6 +914,27 @@ func parseBridgeClasses(output string) []string {
 	return classes
 }
 
+func countBridgeHTBClasses(classes []string) int64 {
+	var count int64
+	for _, class := range classes {
+		if class == htbRootClassID {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func (m *manager) bridgeHTBClassCount(ctx context.Context) (int64, error) {
+	bridgeName := m.config.Network.BridgeName
+	cmd := exec.CommandContext(ctx, "tc", "class", "show", "dev", bridgeName)
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("tc class show: %w", err)
+	}
+	return countBridgeHTBClasses(parseBridgeClasses(string(output))), nil
+}
+
 func planOrphanedBridgeTC(liveTapIndexes map[int]bool, filters []bridgeFilter, classes []string) ([]bridgeFilter, []string, bool) {
 	candidates, parsed := 0, 0
 	for _, filter := range filters {

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -510,7 +511,7 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 			attribute.String("operation", "delete_existing"),
 			attribute.String("tap", tapName),
 		)
-		err := m.deleteTAPDeviceSerialized(tapName, "")
+		err := m.deleteTAPDeviceSerialized(tapName)
 		deleteEnd(err)
 		if err != nil {
 			return fmt.Errorf("delete existing TAP: %w", err)
@@ -794,57 +795,103 @@ func (m *manager) addVMClass(ctx context.Context, bridgeName, tapName string, ra
 	return "", fmt.Errorf("tc class add failed after %d attempts: %w", maxAttempts, lastErr)
 }
 
-// removeVMClass removes the HTB class for a VM from the bridge.
-// If classID is non-empty, it is used directly; otherwise falls back to deriveClassID.
-func (m *manager) removeVMClass(bridgeName, tapName, classID string) error {
-	if classID == "" {
-		classID = deriveClassID(tapName)
-	}
-	fullClassID := fmt.Sprintf("1:%s", classID)
+type bridgeFilter struct {
+	handle string
+	flowID string
+	rtIif  int
+}
 
-	// Delete filter first (by matching flowid)
-	// List filters and delete matching ones
+func bridgeFiltersForTAP(output string, tapIndex int) []bridgeFilter {
+	var filters []bridgeFilter
+	var current bridgeFilter
+	haveCurrent := false
+
+	flush := func() {
+		if haveCurrent && current.handle != "" && current.flowID != "" && current.rtIif == tapIndex {
+			filters = append(filters, current)
+		}
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "filter ") {
+			flush()
+			current = bridgeFilter{rtIif: -1}
+			haveCurrent = true
+
+			fields := strings.Fields(line)
+			for i, field := range fields {
+				if i+1 >= len(fields) {
+					break
+				}
+				switch field {
+				case "handle":
+					current.handle = fields[i+1]
+				case "flowid":
+					current.flowID = fields[i+1]
+				}
+			}
+			continue
+		}
+
+		if !haveCurrent {
+			continue
+		}
+		if idx := strings.Index(line, "rt_iif eq "); idx >= 0 {
+			rest := line[idx+len("rt_iif eq "):]
+			if end := strings.IndexFunc(rest, func(r rune) bool { return r < '0' || r > '9' }); end >= 0 {
+				rest = rest[:end]
+			}
+			if rtIif, err := strconv.Atoi(rest); err == nil {
+				current.rtIif = rtIif
+			}
+		}
+	}
+	flush()
+
+	return filters
+}
+
+// removeVMClass removes bridge tc state proven to belong to a TAP.
+func (m *manager) removeVMClass(bridgeName string, tapIndex int) error {
+	if tapIndex <= 0 {
+		return nil
+	}
+
 	listCmd := exec.Command("tc", "filter", "show", "dev", bridgeName, "parent", htbRootHandle)
 	listCmd.SysProcAttr = &syscall.SysProcAttr{
 		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 	}
-	output, _ := listCmd.Output()
+	output, err := listCmd.Output()
+	if err != nil {
+		return nil
+	}
 
-	// Parse filter output to find handle for this flowid
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if strings.Contains(line, fullClassID) && strings.Contains(line, "filter") {
-			// Extract filter handle (e.g., "filter parent 1: protocol all pref 1 basic chain 0 handle 0x1")
-			fields := strings.Fields(line)
-			for i, f := range fields {
-				if f == "handle" && i+1 < len(fields) {
-					handle := fields[i+1]
-					delCmd := exec.Command("tc", "filter", "del", "dev", bridgeName, "parent", htbRootHandle,
-						"protocol", "all", "prio", "1", "handle", handle, "basic")
-					delCmd.SysProcAttr = &syscall.SysProcAttr{
-						AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-					}
-					delCmd.Run() // Best effort
-					break
-				}
-			}
+	deletedClasses := make(map[string]struct{})
+	for _, filter := range bridgeFiltersForTAP(string(output), tapIndex) {
+		delCmd := exec.Command("tc", "filter", "del", "dev", bridgeName, "parent", htbRootHandle,
+			"protocol", "all", "prio", "1", "handle", filter.handle, "basic")
+		delCmd.SysProcAttr = &syscall.SysProcAttr{
+			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
 		}
-	}
+		delCmd.Run() // Best effort
 
-	// Delete child qdisc (fq_codel) before deleting the class
-	qdiscCmd := exec.Command("tc", "qdisc", "del", "dev", bridgeName, "parent", fullClassID)
-	qdiscCmd.SysProcAttr = &syscall.SysProcAttr{
-		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-	}
-	qdiscCmd.Run() // Best effort - may not exist
+		if _, ok := deletedClasses[filter.flowID]; ok {
+			continue
+		}
+		deletedClasses[filter.flowID] = struct{}{}
 
-	// Delete the class
-	cmd := exec.Command("tc", "class", "del", "dev", bridgeName, "classid", fullClassID)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+		qdiscCmd := exec.Command("tc", "qdisc", "del", "dev", bridgeName, "parent", filter.flowID)
+		qdiscCmd.SysProcAttr = &syscall.SysProcAttr{
+			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+		}
+		qdiscCmd.Run() // Best effort - may not exist
+
+		cmd := exec.Command("tc", "class", "del", "dev", bridgeName, "classid", filter.flowID)
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+		}
+		cmd.Run() // Best effort - class may not exist
 	}
-	// Ignore errors - class may not exist
-	cmd.Run()
 
 	return nil
 }
@@ -868,16 +915,15 @@ func deriveClassID(tapName string) string {
 }
 
 // deleteTAPDevice removes TAP device and its associated HTB class on the bridge.
-// If classID is non-empty, it is used for removeVMClass; otherwise falls back to deriveClassID.
-func (m *manager) deleteTAPDevice(tapName, classID string) error {
-	// Remove HTB class from bridge before deleting TAP
-	m.removeVMClass(m.config.Network.BridgeName, tapName, classID)
-
+func (m *manager) deleteTAPDevice(tapName string) error {
 	link, err := netlink.LinkByName(tapName)
 	if err != nil {
 		// TAP doesn't exist, nothing to do
 		return nil
 	}
+
+	// Remove HTB class from bridge before deleting TAP
+	m.removeVMClass(m.config.Network.BridgeName, link.Attrs().Index)
 
 	if err := netlink.LinkDel(link); err != nil {
 		return fmt.Errorf("delete TAP device: %w", err)
@@ -991,8 +1037,8 @@ func (m *manager) CleanupOrphanedTAPs(ctx context.Context, preserveInstanceIDs [
 			}
 		}
 
-		// Orphaned TAP - delete it (no stored classID available, falls back to deriveClassID)
-		if err := m.deleteTAPDeviceSerialized(name, ""); err != nil {
+		// Orphaned TAP - delete it by tc filters anchored to the TAP ifindex.
+		if err := m.deleteTAPDeviceSerialized(name); err != nil {
 			log.WarnContext(ctx, "failed to delete orphaned TAP", "tap", name, "error", err)
 			continue
 		}

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -989,6 +989,12 @@ func (m *manager) removeVMClass(bridgeName string, tapIndex int) error {
 
 	filters, err := listBridgeFilters(bridgeName)
 	if err != nil {
+		logger.FromContext(context.Background()).ErrorContext(context.Background(),
+			"failed to list bridge filters for TAP tc cleanup",
+			"bridge", bridgeName,
+			"tap_ifindex", tapIndex,
+			"error", err,
+		)
 		return nil
 	}
 

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -801,13 +801,13 @@ type bridgeFilter struct {
 	rtIif  int
 }
 
-func bridgeFiltersForTAP(output string, tapIndex int) []bridgeFilter {
+func parseBridgeFilters(output string) []bridgeFilter {
 	var filters []bridgeFilter
 	var current bridgeFilter
 	haveCurrent := false
 
 	flush := func() {
-		if haveCurrent && current.handle != "" && current.flowID != "" && current.rtIif == tapIndex {
+		if haveCurrent && current.handle != "" && current.flowID != "" {
 			filters = append(filters, current)
 		}
 	}
@@ -851,46 +851,137 @@ func bridgeFiltersForTAP(output string, tapIndex int) []bridgeFilter {
 	return filters
 }
 
+func listBridgeFilters(bridgeName string) ([]bridgeFilter, error) {
+	cmd := exec.Command("tc", "filter", "show", "dev", bridgeName, "parent", htbRootHandle)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+	}
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("tc filter show: %w", err)
+	}
+	return parseBridgeFilters(string(output)), nil
+}
+
+func deleteBridgeFilter(bridgeName, handle string) error {
+	cmd := exec.Command("tc", "filter", "del", "dev", bridgeName, "parent", htbRootHandle,
+		"protocol", "all", "prio", "1", "handle", handle, "basic")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+	}
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tc filter del: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func deleteBridgeClass(bridgeName, fullClassID string) error {
+	qdiscCmd := exec.Command("tc", "qdisc", "del", "dev", bridgeName, "parent", fullClassID)
+	qdiscCmd.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+	}
+	qdiscCmd.Run() // Best effort - may not exist
+
+	cmd := exec.Command("tc", "class", "del", "dev", bridgeName, "classid", fullClassID)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+	}
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tc class del: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func minorClassID(fullClassID string) (string, bool) {
+	major, minor, ok := strings.Cut(fullClassID, ":")
+	if !ok || major != "1" || minor == "" {
+		return "", false
+	}
+	return minor, true
+}
+
+func parseBridgeClasses(output string) []string {
+	var classes []string
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "class htb 1:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 3 {
+			classes = append(classes, fields[2])
+		}
+	}
+	return classes
+}
+
+func planOrphanedBridgeTC(liveTapIndexes map[int]bool, filters []bridgeFilter, classes []string) ([]bridgeFilter, []string, bool) {
+	candidates, parsed := 0, 0
+	for _, filter := range filters {
+		if filter.handle == "" || filter.flowID == "" {
+			continue
+		}
+		candidates++
+		if filter.rtIif >= 0 {
+			parsed++
+		}
+	}
+	if candidates > 0 && parsed == 0 {
+		return nil, nil, false
+	}
+
+	liveClassIDs := make(map[string]bool)
+	staleFilters := make([]bridgeFilter, 0)
+	for _, filter := range filters {
+		if filter.handle == "" || filter.flowID == "" {
+			continue
+		}
+		if liveTapIndexes[filter.rtIif] {
+			if classID, ok := minorClassID(filter.flowID); ok {
+				liveClassIDs[classID] = true
+			}
+			continue
+		}
+		staleFilters = append(staleFilters, filter)
+	}
+
+	staleClasses := make([]string, 0)
+	for _, fullClassID := range classes {
+		if fullClassID == htbRootClassID {
+			continue
+		}
+		classID, ok := minorClassID(fullClassID)
+		if !ok {
+			continue
+		}
+		if !liveClassIDs[classID] {
+			staleClasses = append(staleClasses, fullClassID)
+		}
+	}
+	return staleFilters, staleClasses, true
+}
+
 // removeVMClass removes bridge tc state proven to belong to a TAP.
 func (m *manager) removeVMClass(bridgeName string, tapIndex int) error {
 	if tapIndex <= 0 {
 		return nil
 	}
 
-	listCmd := exec.Command("tc", "filter", "show", "dev", bridgeName, "parent", htbRootHandle)
-	listCmd.SysProcAttr = &syscall.SysProcAttr{
-		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-	}
-	output, err := listCmd.Output()
+	filters, err := listBridgeFilters(bridgeName)
 	if err != nil {
 		return nil
 	}
 
 	deletedClasses := make(map[string]struct{})
-	for _, filter := range bridgeFiltersForTAP(string(output), tapIndex) {
-		delCmd := exec.Command("tc", "filter", "del", "dev", bridgeName, "parent", htbRootHandle,
-			"protocol", "all", "prio", "1", "handle", filter.handle, "basic")
-		delCmd.SysProcAttr = &syscall.SysProcAttr{
-			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+	for _, filter := range filters {
+		if filter.rtIif != tapIndex {
+			continue
 		}
-		delCmd.Run() // Best effort
-
+		_ = deleteBridgeFilter(bridgeName, filter.handle)
 		if _, ok := deletedClasses[filter.flowID]; ok {
 			continue
 		}
 		deletedClasses[filter.flowID] = struct{}{}
-
-		qdiscCmd := exec.Command("tc", "qdisc", "del", "dev", bridgeName, "parent", filter.flowID)
-		qdiscCmd.SysProcAttr = &syscall.SysProcAttr{
-			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-		}
-		qdiscCmd.Run() // Best effort - may not exist
-
-		cmd := exec.Command("tc", "class", "del", "dev", bridgeName, "classid", filter.flowID)
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-		}
-		cmd.Run() // Best effort - class may not exist
+		_ = deleteBridgeClass(bridgeName, filter.flowID)
 	}
 
 	return nil
@@ -1067,126 +1158,69 @@ func tapDeviceAge(name string, now time.Time) (time.Duration, error) {
 	return now.Sub(ctime), nil
 }
 
-// CleanupOrphanedClasses removes HTB classes on the bridge that don't have matching TAP devices.
-// This handles the case where a TAP was deleted externally (manual deletion, reboot, etc.)
-// but the HTB class persists on the bridge.
-// Returns the number of classes deleted.
+// CleanupOrphanedClasses removes bridge filters and HTB classes that are no
+// longer referenced by a live TAP's filter. Returns the number of tc objects
+// deleted.
 func (m *manager) CleanupOrphanedClasses(ctx context.Context) int {
 	log := logger.FromContext(ctx)
 	bridgeName := m.config.Network.BridgeName
 
-	// List all HTB classes on the bridge
+	m.tcMu.Lock()
+	defer m.tcMu.Unlock()
+
 	cmd := exec.Command("tc", "class", "show", "dev", bridgeName)
 	output, err := cmd.Output()
 	if err != nil {
 		log.DebugContext(ctx, "no HTB classes to clean up", "bridge", bridgeName)
 		return 0
 	}
-
-	// Build set of class IDs that belong to existing TAP devices.
-	// Include both derived class IDs and stored class IDs from allocations
-	// (which may differ if a collision was resolved by probing).
-	validClassIDs := make(map[string]bool)
-	links, err := netlink.LinkList()
-	if err == nil {
-		for _, link := range links {
-			name := link.Attrs().Name
-			if strings.HasPrefix(name, TAPPrefix) {
-				validClassIDs[deriveClassID(name)] = true
-			}
-		}
-	}
-	// Also include stored class IDs from allocations (handles probed IDs).
-	// If ListAllocations fails, bail out to avoid deleting valid probed classes.
-	allocs, allocErr := m.ListAllocations(ctx)
-	if allocErr != nil {
-		log.WarnContext(ctx, "skipping orphaned class cleanup: failed to list allocations", "error", allocErr)
+	classes := parseBridgeClasses(string(output))
+	if len(classes) == 0 {
 		return 0
 	}
-	for _, alloc := range allocs {
-		if alloc.ClassID != "" {
-			validClassIDs[alloc.ClassID] = true
+
+	liveTapIndexes := make(map[int]bool)
+	links, err := netlink.LinkList()
+	if err != nil {
+		log.WarnContext(ctx, "skipping orphaned tc cleanup: failed to list links", "error", err)
+		return 0
+	}
+	for _, link := range links {
+		name := link.Attrs().Name
+		if strings.HasPrefix(name, TAPPrefix) {
+			liveTapIndexes[link.Attrs().Index] = true
 		}
 	}
 
-	// Parse class output and find orphaned classes
-	// Format: "class htb 1:xxxx parent 1:1 ..."
+	filters, err := listBridgeFilters(bridgeName)
+	if err != nil {
+		log.WarnContext(ctx, "skipping orphaned tc cleanup: failed to list filters", "error", err)
+		return 0
+	}
+
+	staleFilters, staleClasses, safe := planOrphanedBridgeTC(liveTapIndexes, filters, classes)
+	if !safe {
+		log.WarnContext(ctx, "skipping orphaned tc cleanup: no rt_iif matches parsed from tc filter output",
+			"bridge", bridgeName, "filters", len(filters))
+		return 0
+	}
+
 	deleted := 0
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if !strings.Contains(line, "class htb 1:") {
+	for _, filter := range staleFilters {
+		log.WarnContext(ctx, "cleaning up orphaned tc filter",
+			"handle", filter.handle, "flowid", filter.flowID, "rt_iif", filter.rtIif, "bridge", bridgeName)
+		if err := deleteBridgeFilter(bridgeName, filter.handle); err != nil {
+			log.WarnContext(ctx, "failed to delete orphaned tc filter",
+				"handle", filter.handle, "error", err)
 			continue
 		}
+		deleted++
+	}
 
-		// Extract class ID (e.g., "1:a3f2")
-		fields := strings.Fields(line)
-		if len(fields) < 3 {
-			continue
-		}
-		fullClassID := fields[2] // "1:xxxx"
-
-		// Skip root class
-		if fullClassID == htbRootClassID {
-			continue
-		}
-
-		// Extract just the minor part (after "1:")
-		parts := strings.Split(fullClassID, ":")
-		if len(parts) != 2 {
-			continue
-		}
-		classID := parts[1]
-
-		// Check if this class belongs to an existing TAP
-		if validClassIDs[classID] {
-			continue
-		}
-
-		// Orphaned class - delete it with warning
+	for _, fullClassID := range staleClasses {
 		log.WarnContext(ctx, "cleaning up orphaned HTB class", "class", fullClassID, "bridge", bridgeName)
-
-		// Delete filter first (find and delete by flowid)
-		// Filters are created with 'basic' classifier, format: "handle 0xN flowid 1:xxxx"
-		filterCmd := exec.Command("tc", "filter", "show", "dev", bridgeName)
-		filterCmd.SysProcAttr = &syscall.SysProcAttr{
-			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-		}
-		if filterOutput, err := filterCmd.Output(); err == nil {
-			filterLines := strings.Split(string(filterOutput), "\n")
-			for _, fline := range filterLines {
-				if strings.Contains(fline, fullClassID) {
-					// Extract filter handle (format: "handle 0x2 flowid 1:ffd")
-					ffields := strings.Fields(fline)
-					for i, f := range ffields {
-						if f == "handle" && i+1 < len(ffields) {
-							handle := ffields[i+1]
-							// Use 'basic' classifier (not u32) to match how filters were created
-							delCmd := exec.Command("tc", "filter", "del", "dev", bridgeName, "parent", "1:", "handle", handle, "prio", "1", "basic")
-							delCmd.SysProcAttr = &syscall.SysProcAttr{
-								AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-							}
-							delCmd.Run() // Best effort
-							break
-						}
-					}
-				}
-			}
-		}
-
-		// Delete child qdisc (fq_codel) before deleting the class
-		delQdiscCmd := exec.Command("tc", "qdisc", "del", "dev", bridgeName, "parent", fullClassID)
-		delQdiscCmd.SysProcAttr = &syscall.SysProcAttr{
-			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-		}
-		delQdiscCmd.Run() // Best effort - may not exist
-
-		// Delete the class
-		delClassCmd := exec.Command("tc", "class", "del", "dev", bridgeName, "classid", fullClassID)
-		delClassCmd.SysProcAttr = &syscall.SysProcAttr{
-			AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
-		}
-		if output, err := delClassCmd.CombinedOutput(); err != nil {
-			log.WarnContext(ctx, "failed to delete orphaned class", "class", fullClassID, "error", err, "output", string(output))
+		if err := deleteBridgeClass(bridgeName, fullClassID); err != nil {
+			log.WarnContext(ctx, "failed to delete orphaned class", "class", fullClassID, "error", err)
 			continue
 		}
 		deleted++

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -511,7 +511,7 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 			attribute.String("operation", "delete_existing"),
 			attribute.String("tap", tapName),
 		)
-		err := m.deleteTAPDeviceSerialized(tapName)
+		err := m.deleteTAPDeviceSerialized(ctx, tapName)
 		deleteEnd(err)
 		if err != nil {
 			return fmt.Errorf("delete existing TAP: %w", err)
@@ -928,6 +928,9 @@ func countBridgeHTBClasses(classes []string) int64 {
 func (m *manager) bridgeHTBClassCount(ctx context.Context) (int64, error) {
 	bridgeName := m.config.Network.BridgeName
 	cmd := exec.CommandContext(ctx, "tc", "class", "show", "dev", bridgeName)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{unix.CAP_NET_ADMIN},
+	}
 	output, err := cmd.Output()
 	if err != nil {
 		return 0, fmt.Errorf("tc class show: %w", err)
@@ -988,14 +991,14 @@ func planOrphanedBridgeTC(liveTapIndexes map[int]bool, filters []bridgeFilter, c
 }
 
 // removeVMClass removes bridge tc state proven to belong to a TAP.
-func (m *manager) removeVMClass(bridgeName string, tapIndex int) error {
+func (m *manager) removeVMClass(ctx context.Context, bridgeName string, tapIndex int) error {
 	if tapIndex <= 0 {
 		return nil
 	}
 
 	filters, err := listBridgeFilters(bridgeName)
 	if err != nil {
-		logger.FromContext(context.Background()).ErrorContext(context.Background(),
+		logger.FromContext(ctx).ErrorContext(ctx,
 			"failed to list bridge filters for TAP tc cleanup",
 			"bridge", bridgeName,
 			"tap_ifindex", tapIndex,
@@ -1039,7 +1042,7 @@ func deriveClassID(tapName string) string {
 }
 
 // deleteTAPDevice removes TAP device and its associated HTB class on the bridge.
-func (m *manager) deleteTAPDevice(tapName string) error {
+func (m *manager) deleteTAPDevice(ctx context.Context, tapName string) error {
 	link, err := netlink.LinkByName(tapName)
 	if err != nil {
 		// TAP doesn't exist, nothing to do
@@ -1047,7 +1050,7 @@ func (m *manager) deleteTAPDevice(tapName string) error {
 	}
 
 	// Remove HTB class from bridge before deleting TAP
-	m.removeVMClass(m.config.Network.BridgeName, link.Attrs().Index)
+	m.removeVMClass(ctx, m.config.Network.BridgeName, link.Attrs().Index)
 
 	if err := netlink.LinkDel(link); err != nil {
 		return fmt.Errorf("delete TAP device: %w", err)
@@ -1162,7 +1165,7 @@ func (m *manager) CleanupOrphanedTAPs(ctx context.Context, preserveInstanceIDs [
 		}
 
 		// Orphaned TAP - delete it by tc filters anchored to the TAP ifindex.
-		if err := m.deleteTAPDeviceSerialized(name); err != nil {
+		if err := m.deleteTAPDeviceSerialized(ctx, name); err != nil {
 			log.WarnContext(ctx, "failed to delete orphaned TAP", "tap", name, "error", err)
 			continue
 		}

--- a/lib/network/bridge_linux_test.go
+++ b/lib/network/bridge_linux_test.go
@@ -28,6 +28,15 @@ func TestParseBridgeFiltersEmpty(t *testing.T) {
 	assert.Empty(t, parseBridgeFilters(""))
 }
 
+func TestCountBridgeHTBClassesExcludesRoot(t *testing.T) {
+	output := `class htb 1:1 root rate 100Mbit ceil 100Mbit burst 1600b cburst 1600b
+class htb 1:a3f2 parent 1:1 leaf e001: prio 1 rate 1Mbit ceil 1Mbit burst 1600b cburst 1600b
+class htb 1:b001 parent 1:1 leaf e002: prio 1 rate 1Mbit ceil 1Mbit burst 1600b cburst 1600b
+`
+
+	assert.Equal(t, int64(2), countBridgeHTBClasses(parseBridgeClasses(output)))
+}
+
 func TestPlanOrphanedBridgeTC(t *testing.T) {
 	staleFilters, staleClasses, safe := planOrphanedBridgeTC(
 		map[int]bool{42: true},

--- a/lib/network/bridge_linux_test.go
+++ b/lib/network/bridge_linux_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBridgeFiltersForTAP(t *testing.T) {
+func TestParseBridgeFilters(t *testing.T) {
 	output := `filter parent 1: protocol all pref 1 basic chain 0
 filter parent 1: protocol all pref 1 basic chain 0 handle 0x1 flowid 1:a3f2
   meta(rt_iif eq 42)
@@ -19,9 +19,42 @@ filter parent 1: protocol all pref 1 basic chain 0 handle 0x3 flowid 1:000c
 
 	assert.Equal(t, []bridgeFilter{
 		{handle: "0x1", flowID: "1:a3f2", rtIif: 42},
-	}, bridgeFiltersForTAP(output, 42))
+		{handle: "0x2", flowID: "1:b001", rtIif: 57},
+		{handle: "0x3", flowID: "1:000c", rtIif: -1},
+	}, parseBridgeFilters(output))
 }
 
-func TestBridgeFiltersForTAPEmpty(t *testing.T) {
-	assert.Empty(t, bridgeFiltersForTAP("", 42))
+func TestParseBridgeFiltersEmpty(t *testing.T) {
+	assert.Empty(t, parseBridgeFilters(""))
+}
+
+func TestPlanOrphanedBridgeTC(t *testing.T) {
+	staleFilters, staleClasses, safe := planOrphanedBridgeTC(
+		map[int]bool{42: true},
+		[]bridgeFilter{
+			{handle: "0x1", flowID: "1:a3f2", rtIif: 42},
+			{handle: "0x2", flowID: "1:b001", rtIif: 57},
+			{handle: "0x3", flowID: "1:000c", rtIif: -1},
+		},
+		[]string{"1:1", "1:a3f2", "1:b001", "1:000c", "1:9999"},
+	)
+
+	assert.True(t, safe)
+	assert.Equal(t, []bridgeFilter{
+		{handle: "0x2", flowID: "1:b001", rtIif: 57},
+		{handle: "0x3", flowID: "1:000c", rtIif: -1},
+	}, staleFilters)
+	assert.Equal(t, []string{"1:b001", "1:000c", "1:9999"}, staleClasses)
+}
+
+func TestPlanOrphanedBridgeTCBailsWhenNoRTIIFParses(t *testing.T) {
+	staleFilters, staleClasses, safe := planOrphanedBridgeTC(
+		map[int]bool{42: true},
+		[]bridgeFilter{{handle: "0x1", flowID: "1:a3f2", rtIif: -1}},
+		[]string{"1:a3f2"},
+	)
+
+	assert.False(t, safe)
+	assert.Nil(t, staleFilters)
+	assert.Nil(t, staleClasses)
 }

--- a/lib/network/bridge_linux_test.go
+++ b/lib/network/bridge_linux_test.go
@@ -51,9 +51,8 @@ func TestPlanOrphanedBridgeTC(t *testing.T) {
 	assert.True(t, safe)
 	assert.Equal(t, []bridgeFilter{
 		{handle: "0x2", flowID: "1:b001", rtIif: 57},
-		{handle: "0x3", flowID: "1:000c", rtIif: -1},
 	}, staleFilters)
-	assert.Equal(t, []string{"1:b001", "1:000c", "1:9999"}, staleClasses)
+	assert.Equal(t, []string{"1:b001", "1:9999"}, staleClasses)
 }
 
 func TestPlanOrphanedBridgeTCBailsWhenNoRTIIFParses(t *testing.T) {

--- a/lib/network/bridge_linux_test.go
+++ b/lib/network/bridge_linux_test.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBridgeFiltersForTAP(t *testing.T) {
+	output := `filter parent 1: protocol all pref 1 basic chain 0
+filter parent 1: protocol all pref 1 basic chain 0 handle 0x1 flowid 1:a3f2
+  meta(rt_iif eq 42)
+filter parent 1: protocol all pref 1 basic chain 0 handle 0x2 flowid 1:b001
+  meta(rt_iif eq 57)
+filter parent 1: protocol all pref 1 basic chain 0 handle 0x3 flowid 1:000c
+`
+
+	assert.Equal(t, []bridgeFilter{
+		{handle: "0x1", flowID: "1:a3f2", rtIif: 42},
+	}, bridgeFiltersForTAP(output, 42))
+}
+
+func TestBridgeFiltersForTAPEmpty(t *testing.T) {
+	assert.Empty(t, bridgeFiltersForTAP("", 42))
+}

--- a/lib/network/manager.go
+++ b/lib/network/manager.go
@@ -40,6 +40,10 @@ type Manager interface {
 	// against in-flight CreateAllocation calls whose metadata hasn't been persisted.
 	CleanupOrphanedTAPs(ctx context.Context, preserveInstanceIDs []string, minAge time.Duration) int
 
+	// CleanupOrphanedClasses removes bridge tc filters/classes not referenced by
+	// a live TAP's filter.
+	CleanupOrphanedClasses(ctx context.Context) int
+
 	// GetUploadBurstMultiplier returns the configured multiplier for upload burst ceiling.
 	GetUploadBurstMultiplier() int
 

--- a/lib/network/manager_test.go
+++ b/lib/network/manager_test.go
@@ -127,21 +127,6 @@ func TestPendingAllocationLoadsPersistedClassID(t *testing.T) {
 	assert.Equal(t, "00ab", alloc.ClassID)
 }
 
-func TestClassIDForDeletePrefersPersistedClassID(t *testing.T) {
-	m := &manager{
-		paths:  paths.New(t.TempDir()),
-		config: &config.Config{},
-	}
-
-	const instanceID = "inst-delete"
-	require.NoError(t, os.MkdirAll(m.paths.InstanceDir(instanceID), 0755))
-	require.NoError(t, m.saveClassID(instanceID, "00ab"))
-
-	assert.Equal(t, "00ab", m.classIDForDelete(instanceID, "0010"))
-	assert.Equal(t, "0010", m.classIDForDelete("missing", "0010"))
-	assert.Equal(t, "0010", m.classIDForDelete("", "0010"))
-}
-
 func TestDefaultNetworkCacheReturnsCopy(t *testing.T) {
 	m := &manager{}
 	m.setDefaultNetwork(&Network{

--- a/lib/network/metrics.go
+++ b/lib/network/metrics.go
@@ -32,16 +32,29 @@ func newNetworkMetrics(meter metric.Meter, m *manager) (*Metrics, error) {
 		return nil, err
 	}
 
+	bridgeHTBClassCount, err := meter.Int64ObservableGauge(
+		"hypeman_network_bridge_htb_class_count",
+		metric.WithDescription("Current number of non-root HTB classes on the network bridge"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	_, err = meter.RegisterCallback(
 		func(ctx context.Context, o metric.Observer) error {
 			allocs, err := m.ListAllocations(ctx)
-			if err != nil {
-				return nil
+			if err == nil {
+				o.ObserveInt64(allocationsTotal, int64(len(allocs)))
 			}
-			o.ObserveInt64(allocationsTotal, int64(len(allocs)))
+
+			classCount, err := m.bridgeHTBClassCount(ctx)
+			if err == nil {
+				o.ObserveInt64(bridgeHTBClassCount, classCount)
+			}
 			return nil
 		},
 		allocationsTotal,
+		bridgeHTBClassCount,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Linear: KERNEL-1500

## Summary

This changes TAP deletion to remove bridge tc state only when ownership is proven by the TAP’s live filter. Before deleting a TAP, hypeman now reads the TAP ifindex, finds bridge filters whose `meta(rt_iif)` matches that ifindex, deletes those filter handles, and deletes the classes referenced by their flowids.

It also extends the existing TAP GC cadence to reap orphaned bridge tc state. The reaper uses live `hype-*` TAP ifindexes as the source of truth, deletes filters whose `rt_iif` is not live, then deletes non-root HTB classes not referenced by the remaining live filters. If filters exist but no `rt_iif` values parse, it bails without deleting anything.

The read-only dev-host probe matched this model: 16 live TAPs, 109 bridge filters/classes, and 93 stale filters/classes that the reaper would prune.

Finally, it adds a raw host accounting metric, `hypeman_network_bridge_htb_class_count`, which observes the current number of non-root HTB classes on the configured bridge by listing tc state directly.

## Tests

- `go test ./lib/network`
- `GOOS=darwin go test -c ./lib/network -o /tmp/hypeman-network-darwin.test`
- Updated `TestCreateInstanceWithNetwork` to exercise real bridge tc state: it creates upload shaping, stages one stale bridge filter/class pair, runs cleanup, and asserts the live filter/class remains while the stale pair is removed.
- `go test ./lib/instances -run TestCreateInstanceWithNetwork -count=1` did not run locally because required embedded binaries are absent from this checkout:
  - `lib/vmm/binaries_linux.go: pattern binaries/cloud-hypervisor/v49.0/aarch64/cloud-hypervisor: no matching files found`
  - `lib/system/guest_agent_binary.go: pattern guest_agent/guest-agent: no matching files found`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Linux host bridge traffic-control delete/GC paths; mistakes could remove live shaping or leave stale state, though parsing failures skip destructive cleanup and live TAP filters are explicitly protected.
> 
> **Overview**
> **Bridge upload shaping cleanup now keys off live `tc` ownership instead of persisted or hash-derived class IDs.** On TAP delete/release, hypeman resolves the TAP ifindex, finds bridge `basic` filters whose `meta(rt_iif)` matches it, removes those handles, then drops the referenced HTB classes—so probed/collision class IDs are torn down correctly without relying on `classid` files for deletion.
> 
> **Orphaned bridge `tc` reaping is reworked** to treat live `hype-*` TAP ifindexes as truth: `CleanupOrphanedClasses` parses filter output, deletes filters whose `rt_iif` is not live, then removes non-root classes not protected by remaining filters; it **no-ops** if filters exist but no `rt_iif` values parse. The periodic TAP GC reconciler **still runs this pass when instance listing fails** (TAP cleanup may be skipped, but stale filters/classes can still be pruned).
> 
> Adds **`hypeman_network_bridge_htb_class_count`** (non-root HTB classes on the bridge), unit tests for filter/class planning, and integration coverage that stages live vs stale bridge `tc` and asserts cleanup keeps the live pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa42934c26c4d35f0c2ae343ce42385681cc5059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->