### PR TITLE
Add lifecycle tracing spans to instance delete path

### DIFF
--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/logger"
 	"github.com/kernel/hypeman/lib/network"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const deleteGracefulShutdownTimeout = 2
@@ -20,9 +21,15 @@ const deleteGracefulShutdownTimeout = 2
 func (m *manager) deleteInstance(
 	ctx context.Context,
 	id string,
-) error {
+) (retErr error) {
 	log := logger.FromContext(ctx)
 	log.InfoContext(ctx, "deleting instance", "instance_id", id)
+
+	ctx, span := m.startLifecycleSpan(ctx, "instances.delete",
+		attribute.String("instance_id", id),
+		attribute.String("operation", "delete"),
+	)
+	defer func() { finishInstancesSpan(span, retErr) }()
 
 	// 1. Load instance
 	meta, err := m.loadMetadata(id)
@@ -33,9 +40,18 @@ func (m *manager) deleteInstance(
 
 	inst := m.toInstance(ctx, meta)
 	stored := &meta.StoredMetadata
+	ctx = enrichInstancesTrace(ctx,
+		attribute.String("hypervisor", string(stored.HypervisorType)),
+		attribute.String("instance_state", string(inst.State)),
+	)
 	log.DebugContext(ctx, "loaded instance", "instance_id", id, "state", inst.State)
 
-	target, err := m.cancelAndWaitCompressionJob(ctx, m.snapshotJobKeyForInstance(id))
+	compressionCtx, compressionSpanEnd := m.startLifecycleStep(ctx, "cancel_compression_job",
+		attribute.String("instance_id", id),
+		attribute.String("operation", "cancel_compression_job"),
+	)
+	target, err := m.cancelAndWaitCompressionJob(compressionCtx, m.snapshotJobKeyForInstance(id))
+	compressionSpanEnd(err)
 	if err != nil {
 		return fmt.Errorf("wait for instance compression to stop: %w", err)
 	}
@@ -65,8 +81,16 @@ func (m *manager) deleteInstance(
 		if stopTimeout > deleteGracefulShutdownTimeout {
 			stopTimeout = deleteGracefulShutdownTimeout
 		}
-		gracefulShutdown = m.tryGracefulGuestShutdown(ctx, &inst, stopTimeout)
-		if !gracefulShutdown {
+		gracefulCtx, gracefulSpanEnd := m.startLifecycleStep(ctx, "graceful_guest_shutdown",
+			attribute.String("instance_id", id),
+			attribute.String("hypervisor", string(stored.HypervisorType)),
+			attribute.String("operation", "graceful_guest_shutdown"),
+		)
+		gracefulShutdown = m.tryGracefulGuestShutdown(gracefulCtx, &inst, stopTimeout)
+		if gracefulShutdown {
+			gracefulSpanEnd(nil)
+		} else {
+			gracefulSpanEnd(errGracefulShutdownFailed)
 			log.DebugContext(ctx, "graceful shutdown before delete did not complete", "instance_id", id)
 		}
 	}
@@ -75,7 +99,14 @@ func (m *manager) deleteInstance(
 	// Also attempt kill for StateUnknown since we can't be sure if hypervisor is running
 	if !gracefulShutdown && (inst.State.RequiresVMM() || inst.State == StateUnknown) {
 		log.DebugContext(ctx, "stopping hypervisor", "instance_id", id, "state", inst.State)
-		if err := m.killHypervisor(ctx, &inst); err != nil {
+		killCtx, killSpanEnd := m.startLifecycleStep(ctx, "force_kill_hypervisor",
+			attribute.String("instance_id", id),
+			attribute.String("hypervisor", string(stored.HypervisorType)),
+			attribute.String("operation", "force_kill_hypervisor"),
+		)
+		err := m.killHypervisor(killCtx, &inst)
+		killSpanEnd(err)
+		if err != nil {
 			// Log error but continue with cleanup
 			// Best effort to clean up even if hypervisor is unresponsive
 			log.WarnContext(ctx, "failed to kill hypervisor, continuing with cleanup", "instance_id", id, "error", err)
@@ -87,7 +118,14 @@ func (m *manager) deleteInstance(
 	if inst.NetworkEnabled {
 		m.unregisterEgressProxyInstance(ctx, id)
 		log.DebugContext(ctx, "releasing network", "instance_id", id, "network", "default")
-		if err := m.networkManager.ReleaseAllocation(ctx, networkAlloc); err != nil {
+		releaseNetworkCtx, releaseNetworkSpanEnd := m.startLifecycleStep(ctx, "release_network",
+			attribute.String("instance_id", id),
+			attribute.String("hypervisor", string(stored.HypervisorType)),
+			attribute.String("operation", "release_network"),
+		)
+		err := m.networkManager.ReleaseAllocation(releaseNetworkCtx, networkAlloc)
+		releaseNetworkSpanEnd(err)
+		if err != nil {
 			// Log error but continue with cleanup
 			log.WarnContext(ctx, "failed to release network, continuing with cleanup", "instance_id", id, "error", err)
 		}
@@ -132,10 +170,16 @@ func (m *manager) deleteInstance(
 
 	// 8. Delete all instance data
 	log.DebugContext(ctx, "deleting instance data", "instance_id", id)
+	_, dataSpanEnd := m.startLifecycleStep(ctx, "delete_instance_data",
+		attribute.String("instance_id", id),
+		attribute.String("operation", "delete_instance_data"),
+	)
 	if err := m.deleteInstanceData(id); err != nil {
+		dataSpanEnd(err)
 		log.ErrorContext(ctx, "failed to delete instance data", "instance_id", id, "error", err)
 		return fmt.Errorf("delete instance data: %w", err)
 	}
+	dataSpanEnd(nil)
 
 	log.InfoContext(ctx, "instance deleted successfully", "instance_id", id)
 	return nil


### PR DESCRIPTION
## Summary

`DELETE /instances/{id}` shows a heavy latency tail in production (p50 ~300ms, p95 ~3.4s), but its trace spans are opaque: the delete path in `lib/instances/delete.go` runs the same teardown sequence as stop (graceful guest shutdown, hypervisor kill, network release, data removal) without any of the lifecycle step spans that `stop.go` already emits, so the slow phase is invisible in traces.

This wraps each blocking phase of `deleteInstance` in the existing `startLifecycleSpan`/`startLifecycleStep` helpers, mirroring `stop.go`:

- top-level `instances.delete` span with `hypervisor` and `instance_state` attributes
- `cancel_compression_job`
- `graceful_guest_shutdown` (marked as error on timeout, same as stop)
- `force_kill_hypervisor`
- `release_network`
- `delete_instance_data`

No behavior changes — instrumentation only.

## Test plan

- [x] `go build ./lib/instances/` and `go vet ./lib/instances/`
- [x] `go test ./lib/instances/ -run TestDeleteInstance` passes
- [ ] Full `lib/instances` suite not run to completion locally: Firecracker VM lifecycle tests require real hypervisor binaries/network and fail identically on unmodified main in this environment
- [ ] After deploy, verify delete step spans appear under `/instances/{id}` DELETE traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes around existing delete flow; no logic or API changes.
> 
> **Overview**
> Adds OpenTelemetry lifecycle instrumentation to `deleteInstance` so DELETE latency can be broken down in traces, matching the pattern already used on stop/create.
> 
> A top-level **`instances.delete`** span records `instance_id`, `hypervisor`, and `instance_state` via `enrichInstancesTrace`, with the function signature updated to named `retErr` so `finishInstancesSpan` runs on exit. **Child step spans** wrap the blocking teardown phases: `cancel_compression_job`, `graceful_guest_shutdown` (failed attempts end the step with `errGracefulShutdownFailed`, same as stop), `force_kill_hypervisor`, `release_network`, and `delete_instance_data`.
> 
> Teardown logic, timeouts, and error handling are unchanged—only tracing hooks around existing calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38dea8a73c9484bb19acd7a9b49132919caad7ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->