### PR TITLE
Sync guest wall clock from KVM PTP after standby restore

### DIFF
--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -1551,6 +1551,10 @@ func TestStandbyAndRestore(t *testing.T) {
 	assert.True(t, inst.HasSnapshot)
 	t.Log("Instance in standby")
 
+	// Let real time advance while the guest is paused so its wall clock,
+	// frozen at snapshot time, lags measurably after restore.
+	time.Sleep(10 * time.Second)
+
 	// Verify snapshot exists
 	p := paths.New(tmpDir)
 	snapshotDir := p.InstanceSnapshotLatest(inst.Id)
@@ -1582,6 +1586,23 @@ func TestStandbyAndRestore(t *testing.T) {
 	inst, err = waitForInstanceState(ctx, manager, inst.Id, StateRunning, integrationTestTimeout(20*time.Second))
 	require.NoError(t, err)
 	t.Log("Instance restored and running")
+
+	// The guest-agent clock keeper should step the wall clock back to host
+	// time; without it the guest stays behind by the standby duration.
+	require.Eventually(t, func() bool {
+		out, code, err := execInInstance(ctx, inst, "date", "+%s")
+		if err != nil || code != 0 {
+			return false
+		}
+		epoch, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			return false
+		}
+		lag := time.Now().Unix() - epoch
+		t.Logf("guest clock lag: %ds", lag)
+		return lag >= -5 && lag <= 5
+	}, integrationTestTimeout(60*time.Second), 3*time.Second,
+		"guest clock should converge to host time after restore")
 
 	// DEBUG: Check app.log file size after restore
 	if info, err := os.Stat(consoleLogPath); err == nil {

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -1543,6 +1543,13 @@ func TestStandbyAndRestore(t *testing.T) {
 	err = waitForVMReady(ctx, inst.SocketPath, 5*time.Second)
 	require.NoError(t, err, "VM should reach running state")
 
+	// Skew the guest clock back an hour so the post-restore check proves the
+	// clock keeper corrected it, rather than passing on a small natural lag.
+	skewOut, skewCode, err := execInInstance(ctx, inst, "date", "-u", "-s",
+		fmt.Sprintf("@%d", time.Now().Add(-time.Hour).Unix()))
+	require.NoError(t, err)
+	require.Equal(t, 0, skewCode, "skewing guest clock should succeed: %s", skewOut)
+
 	// Standby instance
 	t.Log("Standing by instance...")
 	inst, err = manager.StandbyInstance(ctx, inst.Id, StandbyInstanceRequest{})
@@ -1550,10 +1557,6 @@ func TestStandbyAndRestore(t *testing.T) {
 	assert.Equal(t, StateStandby, inst.State)
 	assert.True(t, inst.HasSnapshot)
 	t.Log("Instance in standby")
-
-	// Let real time advance while the guest is paused so its wall clock,
-	// frozen at snapshot time, lags measurably after restore.
-	time.Sleep(10 * time.Second)
 
 	// Verify snapshot exists
 	p := paths.New(tmpDir)
@@ -1587,8 +1590,8 @@ func TestStandbyAndRestore(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("Instance restored and running")
 
-	// The guest-agent clock keeper should step the wall clock back to host
-	// time; without it the guest stays behind by the standby duration.
+	// The guest-agent clock keeper should step the skewed wall clock back to
+	// host time; without it the guest stays about an hour behind.
 	require.Eventually(t, func() bool {
 		out, code, err := execInInstance(ctx, inst, "date", "+%s")
 		if err != nil || code != 0 {

--- a/lib/system/guest_agent/clock_linux.go
+++ b/lib/system/guest_agent/clock_linux.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	ptpDevicePath = "/dev/ptp0"
+
+	// Logged by the vmgenid driver when the hypervisor bumps the VM
+	// generation ID, which happens on every snapshot restore.
+	vmForkKmsgSignal = "crng reseeded due to virtual machine fork"
+
+	driftCheckPeriod = 30 * time.Second
+	maxClockDrift    = time.Second
+)
+
+// startClockKeeper keeps the guest realtime clock aligned with the host. The
+// wall clock resumes from the snapshot's saved time after a standby restore
+// and nothing else corrects it (the guest runs no NTP daemon, and VMGenID
+// only reseeds the RNG). The keeper reads host time from the KVM PTP device
+// and steps CLOCK_REALTIME whenever it drifts, checking periodically and
+// immediately after a restore is detected via the vmgenid kmsg line.
+func startClockKeeper() {
+	ptp, err := os.Open(ptpDevicePath)
+	if err != nil {
+		log.Printf("[guest-agent] clock keeper disabled: %v", err)
+		return
+	}
+
+	restored := make(chan struct{}, 1)
+	go watchVMForkKmsg(restored)
+	go runClockKeeper(ptp, restored)
+}
+
+func runClockKeeper(ptp *os.File, restored <-chan struct{}) {
+	ticker := time.NewTicker(driftCheckPeriod)
+	defer ticker.Stop()
+	for {
+		if err := syncClockFromPTP(ptp); err != nil {
+			log.Printf("[guest-agent] clock sync failed: %v", err)
+		}
+		select {
+		case <-ticker.C:
+		case <-restored:
+		}
+	}
+}
+
+func syncClockFromPTP(ptp *os.File) error {
+	// FD_TO_CLOCKID from linux/posix-timers.h
+	clockID := int32((^int(ptp.Fd()) << 3) | 3)
+
+	var hostTS unix.Timespec
+	if err := unix.ClockGettime(clockID, &hostTS); err != nil {
+		return fmt.Errorf("read %s: %w", ptpDevicePath, err)
+	}
+	var guestTS unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_REALTIME, &guestTS); err != nil {
+		return fmt.Errorf("read realtime clock: %w", err)
+	}
+
+	drift := time.Duration(hostTS.Nano() - guestTS.Nano())
+	if drift.Abs() <= maxClockDrift {
+		return nil
+	}
+	if err := unix.ClockSettime(unix.CLOCK_REALTIME, &hostTS); err != nil {
+		return fmt.Errorf("set realtime clock: %w", err)
+	}
+	log.Printf("[guest-agent] stepped realtime clock by %s to %s",
+		drift, time.Unix(0, hostTS.Nano()).UTC().Format(time.RFC3339Nano))
+	return nil
+}
+
+func watchVMForkKmsg(restored chan<- struct{}) {
+	f, err := os.Open("/dev/kmsg")
+	if err != nil {
+		log.Printf("[guest-agent] clock keeper kmsg watch disabled: %v", err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		log.Printf("[guest-agent] warning: failed to seek /dev/kmsg to end: %v", err)
+	}
+
+	// Each read returns one log record. EPIPE means the buffer wrapped and
+	// records were overwritten; the next read continues from the oldest
+	// available record.
+	buf := make([]byte, 8192)
+	for {
+		n, err := f.Read(buf)
+		if err != nil {
+			if errors.Is(err, unix.EPIPE) {
+				continue
+			}
+			log.Printf("[guest-agent] clock keeper kmsg watch stopped: %v", err)
+			return
+		}
+		if strings.Contains(string(buf[:n]), vmForkKmsgSignal) {
+			select {
+			case restored <- struct{}{}:
+			default:
+			}
+		}
+	}
+}

--- a/lib/system/guest_agent/clock_other.go
+++ b/lib/system/guest_agent/clock_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package main
+
+func startClockKeeper() {}

--- a/lib/system/guest_agent/main.go
+++ b/lib/system/guest_agent/main.go
@@ -52,6 +52,8 @@ func main() {
 		log.Printf("[guest-agent] warning: failed to write readiness file: %v", err)
 	}
 
+	startClockKeeper()
+
 	// Create gRPC server
 	grpcServer := grpc.NewServer()
 	pb.RegisterGuestServiceServer(grpcServer, &guestServer{})


### PR DESCRIPTION
## Summary

The guest wall clock lags after a standby restore: `CLOCK_REALTIME` resumes from the snapshot's saved time and nothing corrects it. The guest runs no NTP daemon, and VMGenID's only guest-side effect is an RNG reseed (`add_vmfork_randomness`) — it never touches the clock. Verified on a live instance: guest was ~5–6 minutes behind after standby cycles, while `/dev/ptp0` (KVM virtual PTP, `CONFIG_PTP_1588_CLOCK_KVM=y` in the current guest kernel) returned correct host time the whole while.

This adds a clock keeper to guest-agent that consumes that already-present time source:

- reads host time via `clock_gettime` on `/dev/ptp0` (`FD_TO_CLOCKID`) and steps `CLOCK_REALTIME` when drift exceeds 1s
- checks every 30s, plus immediately when the vmgenid kmsg line (`crng reseeded due to virtual machine fork`) signals a restore, so correction is near-instant on resume
- no-ops with a log line if `/dev/ptp0` is absent

No host-side changes, no RPC/proto changes, no kernel or hypervisor version bump. Works with the kernels and VMMs already deployed.

## Alternative considered: VMClock kernel backport

A VMClock-based path exists (`ch-6.16.9-kernel-0.1-202605301` carries the backported generation-counter/notification driver, previously wired up in #254) but was deliberately not taken: even with VMClock the kernel never sets `CLOCK_REALTIME` itself, so a userspace clock-setter is needed either way. That path would additionally require jumping guests from 6.12.8 to 6.16.9 and bumping Firecracker to v1.15.1 for the notification support — a much larger blast radius for the same end result. VMClock remains a clean future upgrade for the *trigger* (device notification instead of the kmsg line), without changing this keeper's structure.

## Test plan

- [x] `go build` (linux + darwin), `go vet`, guest_agent unit tests pass locally
- [x] `TestStandbyAndRestore` extended minimally: the guest clock is skewed back an hour before standby, and after restore the test asserts it converges to within 5s of host time. Deterministic and adds no test wall time; fails without the keeper (guest would stay an hour behind)
- [ ] The extended integration test was NOT run locally (local KVM test environment issues) — needs a CI run or a machine with working `/dev/kvm` nested virt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Guest-side `clock_settime` on every restore and periodic drift checks could affect time-sensitive workloads; scope is limited to Linux guests with `/dev/ptp0` and no host API changes.
> 
> **Overview**
> Adds a **guest-agent clock keeper** (Linux only) so `CLOCK_REALTIME` realigns with the host after standby restore, when the guest resumes from snapshot time with no NTP.
> 
> The keeper reads time from **`/dev/ptp0`** via `clock_gettime`, steps the wall clock when drift exceeds **1s**, runs a **30s** periodic check, and triggers an immediate sync when **`/dev/kmsg`** shows the vmgenid fork line (`crng reseeded due to virtual machine fork`). It starts after guest-agent readiness; non-Linux builds no-op. **No host, RPC, or kernel changes.**
> 
> **`TestStandbyAndRestore`** skews the guest clock back one hour before standby and asserts it converges to within **±5s** of host time after restore, so the test fails without the keeper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 210cf466f6406251b14dc9f03cab53b25ffa0a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->