### PR TITLE
Pin Redis image for entrypoint env tests

### DIFF
--- a/cmd/test-prewarm/main.go
+++ b/cmd/test-prewarm/main.go
@@ -40,7 +40,8 @@ var defaultImages = []prewarmImage{
 	{Source: "docker.io/library/alpine:3.18"},
 	{Source: "docker.io/library/debian:12-slim"},
 	{Source: "docker.io/library/nginx:alpine"},
-	{Source: "docker.io/bitnami/redis:latest"},
+	// Keep in sync with redisEntrypointEnvImage in lib/instances tests.
+	{Source: "docker.io/bitnamilegacy/redis:7.2.5-debian-12-r0"},
 	{Source: "docker.io/jrei/systemd-ubuntu:22.04"},
 	// amd64-only mirror for the Rosetta x86 image E2E (single-platform manifest;
 	// see toLocalRegistryRef for why it must be the only mirror of this tag).

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -1159,6 +1159,8 @@ func TestOOMExitPropagation(t *testing.T) {
 	t.Skipf("OOM did not trigger reliably on this host after %d attempts (last observed state: %s)", retries, lastObservedState)
 }
 
+const redisEntrypointEnvImage = "docker.io/bitnamilegacy/redis:7.2.5-debian-12-r0"
+
 // TestEntrypointEnvVars verifies that environment variables are passed to the entrypoint process.
 // This uses bitnami/redis which configures REDIS_PASSWORD from an env var - if auth is required,
 // it proves the entrypoint received and used the env var.
@@ -1180,7 +1182,7 @@ func TestEntrypointEnvVars(t *testing.T) {
 	// Pull bitnami/redis image
 	t.Log("Pulling bitnami/redis image...")
 	redisImage, err := imageManager.CreateImage(ctx, images.CreateImageRequest{
-		Name: integrationTestImageRef(t, "docker.io/bitnami/redis:latest"),
+		Name: integrationTestImageRef(t, redisEntrypointEnvImage),
 	})
 	require.NoError(t, err)
 
@@ -1218,7 +1220,7 @@ func TestEntrypointEnvVars(t *testing.T) {
 	testPassword := "test_secret_password_123"
 	req := CreateInstanceRequest{
 		Name:           "test-redis-env",
-		Image:          integrationTestImageRef(t, "docker.io/bitnami/redis:latest"),
+		Image:          integrationTestImageRef(t, redisEntrypointEnvImage),
 		Size:           2 * 1024 * 1024 * 1024,
 		HotplugSize:    512 * 1024 * 1024,
 		OverlaySize:    10 * 1024 * 1024 * 1024,

--- a/lib/instances/qemu_test.go
+++ b/lib/instances/qemu_test.go
@@ -606,7 +606,7 @@ func TestQEMUEntrypointEnvVars(t *testing.T) {
 	// Pull bitnami/redis image
 	t.Log("Pulling bitnami/redis image...")
 	redisImage, err := imageManager.CreateImage(ctx, images.CreateImageRequest{
-		Name: integrationTestImageRef(t, "docker.io/bitnami/redis:latest"),
+		Name: integrationTestImageRef(t, redisEntrypointEnvImage),
 	})
 	require.NoError(t, err)
 
@@ -648,7 +648,7 @@ func TestQEMUEntrypointEnvVars(t *testing.T) {
 	testPassword := "test_secret_password_123"
 	req := CreateInstanceRequest{
 		Name:           "test-redis-env",
-		Image:          integrationTestImageRef(t, "docker.io/bitnami/redis:latest"),
+		Image:          integrationTestImageRef(t, redisEntrypointEnvImage),
 		Size:           2 * 1024 * 1024 * 1024,
 		HotplugSize:    512 * 1024 * 1024,
 		OverlaySize:    10 * 1024 * 1024 * 1024,


### PR DESCRIPTION
## Summary
- replace mutable bitnami/redis:latest in entrypoint env tests with the legacy Bitnami Redis 7.2.5 Debian image
- share the pinned image ref across Cloud Hypervisor and QEMU variants

## Why
Main was failing on deft-kernel-dev with misleading vsock errors in TestEntrypointEnvVars and TestQEMUEntrypointEnvVars. The VM logs showed the guest agent did become ready, but the current bitnami/redis:latest image exited immediately with:

`Fatal error, can't open config file '/opt/bitnami/redis/etc/redis.conf': Permission denied`

That powered off the VM, so later guest exec attempts reported missing/no-device vsock.

## Validation
- On deft-kernel-dev, after mirroring docker.io/bitnamilegacy/redis:7.2.5-debian-12-r0 into the local CI registry:
  `go test -tags containers_image_openpgp -run "Test(EntrypointEnvVars|QEMUEntrypointEnvVars)$" -count=1 -v -timeout=8m ./lib/instances`
- Both tests passed in 6.826s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI prewarm image list only; no production runtime or auth logic changes.
> 
> **Overview**
> Replaces the floating **`docker.io/bitnami/redis:latest`** reference with a pinned **`docker.io/bitnamilegacy/redis:7.2.5-debian-12-r0`** so entrypoint env integration tests stop failing when upstream `latest` breaks in the guest (e.g. Redis exiting on config permission errors and surfacing as vsock/exec failures).
> 
> Adds a shared **`redisEntrypointEnvImage`** constant in `manager_test.go` and uses it in **`TestEntrypointEnvVars`** and **`TestQEMUEntrypointEnvVars`** for both image pull and instance create. **`cmd/test-prewarm`** mirrors the same tag in **`defaultImages`**, with a comment to keep it aligned with the test constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c911cf692a932dea2682f90ad267180c1f23f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->