### PR TITLE
Fix e2e-install test failing on tag pushes

### DIFF
--- a/scripts/e2e-install-test.sh
+++ b/scripts/e2e-install-test.sh
@@ -36,7 +36,8 @@ KEEP_DATA=false bash scripts/uninstall.sh 2>/dev/null || true
 # Phase 2: Install from source
 # =============================================================================
 info "Phase 2: Installing from source..."
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+# Use the ref GitHub provides; on tag pushes rev-parse returns a detached "HEAD"
+BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
 # Build CLI from source too when CLI_BRANCH is set (e.g., for testing unreleased CLI features)
 BRANCH="$BRANCH" CLI_BRANCH="${CLI_BRANCH:-}" bash scripts/install.sh
 


### PR DESCRIPTION
## Summary
- The `e2e-install` job in the Test workflow runs on every push, tags included. On a tag push the checkout is a detached HEAD, so `git rev-parse --abbrev-ref HEAD` in `scripts/e2e-install-test.sh` returns the literal string `HEAD` instead of a ref name.
- That value is passed to `install.sh` as `BRANCH`, producing `git clone --branch HEAD`, which fails with `fatal: Remote branch HEAD not found in upstream origin` and aborts the job.
- Fix: prefer `GITHUB_REF_NAME` (the tag or branch GitHub provides), falling back to `git rev-parse` for local runs. A tag is a valid `--branch` argument to `git clone`, so the source build resolves correctly on release tags.

Not a new regression: the `e2e-install` job has failed with this same error on every tag whose Test run completed (v0.1.0 and v0.2.0). It went unnoticed because it runs in the Test workflow, separate from the release workflow that publishes the tag.

## Validation
- `bash -n scripts/e2e-install-test.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI script change with no production runtime impact.
> 
> **Overview**
> **Fixes `e2e-install` failing on tag pushes** when the workflow checks out a detached HEAD.
> 
> `scripts/e2e-install-test.sh` now sets `BRANCH` from **`GITHUB_REF_NAME`** when GitHub Actions provides it (tag or branch name), and only falls back to `git rev-parse --abbrev-ref HEAD` for local runs. Previously, detached tag checkouts produced `BRANCH=HEAD`, which made `install.sh` run `git clone --branch HEAD` and fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f079907738b61daba8d113a78e43cad7402930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->