### PR TITLE
Recover Docker before macOS tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,6 +188,27 @@ jobs:
         with:
           go-version: '1.25.4'
           cache: false
+      - name: Ensure Docker is running
+        run: |
+          if docker info >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          colima stop --force || true
+          if ! colima start; then
+            colima delete --force
+            colima start
+          fi
+
+          for attempt in {1..30}; do
+            if docker info >/dev/null 2>&1; then
+              exit 0
+            fi
+            echo "waiting for Docker daemon (${attempt}/30)"
+            sleep 2
+          done
+
+          docker info
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,10 +194,16 @@ jobs:
             exit 0
           fi
 
-          colima stop --force || true
+          if colima status >/dev/null 2>&1; then
+            colima stop --force
+          fi
+
           if ! colima start; then
-            colima delete --force
-            colima start
+            colima stop --force || true
+            if ! colima start; then
+              colima delete --force
+              colima start
+            fi
           fi
 
           for attempt in {1..30}; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,7 +195,7 @@ jobs:
           fi
 
           if colima status >/dev/null 2>&1; then
-            colima stop --force
+            colima stop --force || true
           fi
 
           if ! colima start; then


### PR DESCRIPTION
## summary

- verify the Docker daemon before the macOS test job uses it
- start Colima directly when it is stopped
- force-restart Colima only when Docker is unhealthy or a normal start fails
- recreate the Colima VM if recovery still fails
- wait up to 60 seconds for the daemon to become ready before continuing

## why

The self-hosted macOS runner can retain a stopped or broken Colima VM between jobs. The prewarm step requires Docker to start its local registry, so the job currently fails before running tests when that daemon is unavailable.

## validation

- parsed `.github/workflows/test.yml` as YAML
- checked the recovery script with `bash -n`
- `git diff --check`
- `test-darwin` passed end to end, including normal startup, stale-state recovery, prewarm, formatting, and tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change on macOS runners; no application, auth, or data-path impact.
> 
> **Overview**
> Adds an **Ensure Docker is running** step at the start of the `test-darwin` job so a stopped or broken Colima VM on the self-hosted macOS runner does not fail the job before prewarm (which needs Docker for the local registry).
> 
> The step exits early if `docker info` succeeds; otherwise it tries `colima start`, escalates to force-stop/restart and then `colima delete` if needed, and polls up to ~60s for the daemon before failing with `docker info`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce45c8a3bcdb3d76cc3040d913e0a645333ee91f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->