### PR TITLE
Reduce test wall-clock time without weakening coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,7 @@ jobs:
           # cross-filesystem safe. Keeping both on /ci avoids that.
           export HYPEMAN_TEST_PREWARM_DIR="/ci/prewarm/linux-amd64"
           mkdir -p "$HYPEMAN_TEST_PREWARM_DIR"
+          sudo chown -R "$(id -u):$(id -g)" "$HYPEMAN_TEST_PREWARM_DIR"
           go run ./cmd/test-prewarm
 
       - name: Check gofmt

--- a/cmd/test-prewarm/main.go
+++ b/cmd/test-prewarm/main.go
@@ -106,6 +106,11 @@ func main() {
 		PrewarmDir: prewarmDir,
 		Images:     make([]manifestImage, 0, len(imagesToWarm)),
 	}
+	p := paths.New(prewarmDir)
+	readyImageManager, err := images.NewManager(p, 1, nil)
+	if err != nil {
+		fatalf("create ready image manager: %v", err)
+	}
 
 	for _, img := range imagesToWarm {
 		entry, err := ensureMirroredImage(ctx, inspectClient, registry, img)
@@ -113,10 +118,24 @@ func main() {
 			fatalf("prewarm image %s: %v", img.Source, err)
 		}
 		fmt.Printf("prewarm image source=%s local=%s digest=%s cache_hit=%t\n", entry.Source, entry.LocalRef, entry.Digest, entry.CacheHit)
+		created, err := readyImageManager.CreateImage(ctx, images.CreateImageRequest{Name: entry.LocalRef, Platform: img.Platform})
+		if err != nil {
+			fatalf("build ready image %s: %v", entry.LocalRef, err)
+		}
+		waitName := created.Name
+		if created.Digest != "" {
+			ref, parseErr := images.ParseNormalizedRef(entry.LocalRef)
+			if parseErr != nil {
+				fatalf("parse ready image ref %s: %v", entry.LocalRef, parseErr)
+			}
+			waitName = ref.Repository() + "@" + created.Digest
+		}
+		if err := readyImageManager.WaitForReady(ctx, waitName); err != nil {
+			fatalf("wait for ready image %s: %v", entry.LocalRef, err)
+		}
 		manifest.Images = append(manifest.Images, entry)
 	}
 
-	p := paths.New(prewarmDir)
 	systemMgr := system.NewManager(p)
 	if err := systemMgr.EnsureSystemFiles(ctx); err != nil {
 		fatalf("prewarm system files: %v", err)

--- a/lib/instances/auto_standby_integration_linux_test.go
+++ b/lib/instances/auto_standby_integration_linux_test.go
@@ -128,7 +128,7 @@ func TestAutoStandbyCloudHypervisorActiveInboundTCP(t *testing.T) {
 
 	t.Cleanup(func() {
 		logInstanceArtifactsOnFailure(t, mgr, instanceID)
-		_ = mgr.DeleteInstance(context.Background(), instanceID)
+		_ = deleteTestInstanceNow(context.Background(), mgr, instanceID)
 	})
 
 	inst, err = waitForInstanceState(ctx, mgr, instanceID, StateRunning, 30*time.Second)

--- a/lib/instances/auto_standby_integration_linux_test.go
+++ b/lib/instances/auto_standby_integration_linux_test.go
@@ -99,7 +99,7 @@ func TestAutoStandbyCloudHypervisorActiveInboundTCP(t *testing.T) {
 	mgr, _ := setupCompressionTestManagerForHypervisor(t, hypervisor.TypeCloudHypervisor)
 	require.NoError(t, mgr.networkManager.Initialize(ctx, nil))
 	require.NoError(t, mgr.systemManager.EnsureSystemFiles(ctx))
-	createNginxImageAndWait(t, ctx, mgr.imageManager)
+	createNginxImageAndWait(t, ctx, mgr.paths, mgr.imageManager)
 
 	connSource := autostandby.NewConntrackSource()
 	if _, err := connSource.ListConnections(ctx); err != nil {

--- a/lib/instances/compression_integration_linux_test.go
+++ b/lib/instances/compression_integration_linux_test.go
@@ -145,7 +145,7 @@ func runStandbyRestoreCompressionScenarios(t *testing.T, harness compressionInte
 	inst, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
 		Name:           fmt.Sprintf("compression-%s", harness.name),
 		Image:          integrationTestImageRef(t, "docker.io/library/nginx:alpine"),
-		Size:           1024 * 1024 * 1024,
+		Size:           lifecycleTestMemorySize,
 		HotplugSize:    512 * 1024 * 1024,
 		OverlaySize:    10 * 1024 * 1024 * 1024,
 		Vcpus:          1,

--- a/lib/instances/compression_integration_linux_test.go
+++ b/lib/instances/compression_integration_linux_test.go
@@ -137,7 +137,7 @@ func runStandbyRestoreCompressionScenarios(t *testing.T, harness compressionInte
 
 	imageManager, err := images.NewManager(p, 1, nil)
 	require.NoError(t, err)
-	createNginxImageAndWait(t, ctx, imageManager)
+	createNginxImageAndWait(t, ctx, p, imageManager)
 
 	systemManager := system.NewManager(p)
 	require.NoError(t, systemManager.EnsureSystemFiles(ctx))

--- a/lib/instances/compression_integration_linux_test.go
+++ b/lib/instances/compression_integration_linux_test.go
@@ -157,7 +157,7 @@ func runStandbyRestoreCompressionScenarios(t *testing.T, harness compressionInte
 	deleted := false
 	t.Cleanup(func() {
 		if !deleted {
-			_ = mgr.DeleteInstance(context.Background(), inst.Id)
+			_ = deleteTestInstanceNow(context.Background(), mgr, inst.Id)
 		}
 	})
 
@@ -196,7 +196,7 @@ func runStandbyRestoreCompressionScenarios(t *testing.T, harness compressionInte
 		inst = runCompressionCycle(t, ctx, mgr, p, inst, harness.waitHypervisorUp, tc.name, tc.cfg, true)
 	}
 
-	require.NoError(t, mgr.DeleteInstance(ctx, inst.Id))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, inst.Id))
 	deleted = true
 }
 

--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -17,10 +17,22 @@ import (
 
 const deleteGracefulShutdownTimeout = 2
 
+type deleteInstanceOptions struct {
+	skipGracefulShutdown bool
+}
+
 // deleteInstance stops and deletes an instance
 func (m *manager) deleteInstance(
 	ctx context.Context,
 	id string,
+) (retErr error) {
+	return m.deleteInstanceWithOptions(ctx, id, deleteInstanceOptions{})
+}
+
+func (m *manager) deleteInstanceWithOptions(
+	ctx context.Context,
+	id string,
+	options deleteInstanceOptions,
 ) (retErr error) {
 	log := logger.FromContext(ctx)
 	log.InfoContext(ctx, "deleting instance", "instance_id", id)
@@ -76,7 +88,7 @@ func (m *manager) deleteInstance(
 
 	// 4. If active, try graceful guest shutdown before force kill.
 	gracefulShutdown := false
-	if inst.State == StateRunning || inst.State == StateInitializing {
+	if !options.skipGracefulShutdown && (inst.State == StateRunning || inst.State == StateInitializing) {
 		stopTimeout := resolveStopTimeout(stored)
 		if stopTimeout > deleteGracefulShutdownTimeout {
 			stopTimeout = deleteGracefulShutdownTimeout

--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -25,7 +25,7 @@ type deleteInstanceOptions struct {
 func (m *manager) deleteInstance(
 	ctx context.Context,
 	id string,
-) (retErr error) {
+) error {
 	return m.deleteInstanceWithOptions(ctx, id, deleteInstanceOptions{})
 }
 

--- a/lib/instances/docker_integration_linux_test.go
+++ b/lib/instances/docker_integration_linux_test.go
@@ -53,7 +53,7 @@ func TestDockerInVMCloudHypervisorWithAttachedVolume(t *testing.T) {
 					t.Logf("dockerd log (exit=%d):\n%s", code, output)
 				}
 			}
-			_ = manager.DeleteInstance(context.Background(), inst.Id)
+			_ = deleteTestInstanceNow(context.Background(), manager, inst.Id)
 		}
 		_ = volumeManager.DeleteVolume(context.Background(), vol.Id)
 	})

--- a/lib/instances/egress_proxy_integration_test.go
+++ b/lib/instances/egress_proxy_integration_test.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/kernel/hypeman/lib/egressproxy"
-	"github.com/kernel/hypeman/lib/images"
+	snapshottest "github.com/kernel/hypeman/lib/snapshot/testsupport"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,20 +49,7 @@ func TestEgressProxyRewritesHTTPSHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	imageRef := integrationTestImageRef(t, "docker.io/library/nginx:alpine")
-	t.Logf("Pulling %s image...", imageRef)
-	created, err := manager.imageManager.CreateImage(ctx, images.CreateImageRequest{Name: imageRef})
-	require.NoError(t, err)
-
-	for i := 0; i < 120; i++ {
-		img, err := manager.imageManager.GetImage(ctx, created.Name)
-		if err == nil && img.Status == images.StatusReady {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
-	img, err := manager.imageManager.GetImage(ctx, created.Name)
-	require.NoError(t, err)
-	require.Equal(t, images.StatusReady, img.Status)
+	snapshottest.EnsureImageReady(t, ctx, manager.paths, manager.imageManager, imageRef)
 
 	require.NoError(t, manager.systemManager.EnsureSystemFiles(ctx))
 	require.NoError(t, manager.networkManager.Initialize(ctx, nil))

--- a/lib/instances/egress_proxy_integration_test.go
+++ b/lib/instances/egress_proxy_integration_test.go
@@ -103,7 +103,7 @@ func TestEgressProxyRewritesHTTPSHeaders(t *testing.T) {
 	deleted := false
 	t.Cleanup(func() {
 		if !deleted {
-			_ = manager.DeleteInstance(context.Background(), inst.Id)
+			_ = deleteTestInstanceNow(context.Background(), manager, inst.Id)
 		}
 	})
 
@@ -192,7 +192,7 @@ func TestEgressProxyRewritesHTTPSHeaders(t *testing.T) {
 	require.Contains(t, rotatedOutput, "Bearer rotated-key-456")
 	require.NotContains(t, rotatedOutput, "real-openai-key-123")
 
-	require.NoError(t, manager.DeleteInstance(ctx, inst.Id))
+	require.NoError(t, deleteTestInstanceNow(ctx, manager, inst.Id))
 	deleted = true
 }
 

--- a/lib/instances/firecracker_test.go
+++ b/lib/instances/firecracker_test.go
@@ -104,26 +104,9 @@ func requireUserfaultfdIntegrationPrereqs(t *testing.T) {
 	_ = file.Close()
 }
 
-func createNginxImageAndWait(t *testing.T, ctx context.Context, imageManager images.Manager) {
+func createNginxImageAndWait(t *testing.T, ctx context.Context, p *paths.Paths, imageManager images.Manager) {
 	t.Helper()
-
-	nginxImage, err := imageManager.CreateImage(ctx, images.CreateImageRequest{
-		Name: integrationTestImageRef(t, "docker.io/library/nginx:alpine"),
-	})
-	require.NoError(t, err)
-
-	for i := 0; i < 60; i++ {
-		img, err := imageManager.GetImage(ctx, nginxImage.Name)
-		if err == nil && img.Status == images.StatusReady {
-			return
-		}
-		if err == nil && img.Status == images.StatusFailed {
-			t.Fatalf("image build failed: %s", *img.Error)
-		}
-		time.Sleep(1 * time.Second)
-	}
-
-	t.Fatalf("timed out waiting for image %q to become ready", nginxImage.Name)
+	snapshottest.EnsureImageReady(t, ctx, p, imageManager, integrationTestImageRef(t, "docker.io/library/nginx:alpine"))
 }
 
 func startGatewayProbeServer(t *testing.T, gatewayIP string) (string, func()) {
@@ -162,7 +145,7 @@ func TestFirecrackerStandbyAndRestore(t *testing.T) {
 
 	imageManager, err := images.NewManager(p, 1, nil)
 	require.NoError(t, err)
-	createNginxImageAndWait(t, ctx, imageManager)
+	createNginxImageAndWait(t, ctx, p, imageManager)
 
 	systemManager := system.NewManager(p)
 	require.NoError(t, systemManager.EnsureSystemFiles(ctx))
@@ -296,7 +279,7 @@ func TestFirecrackerStopClearsStaleSnapshot(t *testing.T) {
 
 	imageManager, err := images.NewManager(p, 1, nil)
 	require.NoError(t, err)
-	createNginxImageAndWait(t, ctx, imageManager)
+	createNginxImageAndWait(t, ctx, p, imageManager)
 
 	systemManager := system.NewManager(p)
 	require.NoError(t, systemManager.EnsureSystemFiles(ctx))
@@ -373,7 +356,7 @@ func TestFirecrackerNetworkLifecycle(t *testing.T) {
 
 	imageManager, err := images.NewManager(p, 1, nil)
 	require.NoError(t, err)
-	createNginxImageAndWait(t, ctx, imageManager)
+	createNginxImageAndWait(t, ctx, p, imageManager)
 
 	systemManager := system.NewManager(p)
 	require.NoError(t, systemManager.EnsureSystemFiles(ctx))
@@ -501,7 +484,7 @@ func TestFirecrackerForkFromRunningNetwork(t *testing.T) {
 
 	imageManager, err := images.NewManager(p, 1, nil)
 	require.NoError(t, err)
-	createNginxImageAndWait(t, ctx, imageManager)
+	createNginxImageAndWait(t, ctx, p, imageManager)
 
 	systemManager := system.NewManager(p)
 	require.NoError(t, systemManager.EnsureSystemFiles(ctx))
@@ -1132,7 +1115,7 @@ func TestFirecrackerForkIsolation(t *testing.T) {
 
 	imageManager, err := images.NewManager(p, 1, nil)
 	require.NoError(t, err)
-	createNginxImageAndWait(t, ctx, imageManager)
+	createNginxImageAndWait(t, ctx, p, imageManager)
 
 	systemManager := system.NewManager(p)
 	require.NoError(t, systemManager.EnsureSystemFiles(ctx))

--- a/lib/instances/firecracker_test.go
+++ b/lib/instances/firecracker_test.go
@@ -181,7 +181,7 @@ func TestFirecrackerStandbyAndRestore(t *testing.T) {
 	deleted := false
 	t.Cleanup(func() {
 		if !deleted {
-			_ = mgr.DeleteInstance(context.Background(), inst.Id)
+			_ = deleteTestInstanceNow(context.Background(), mgr, inst.Id)
 		}
 	})
 
@@ -521,7 +521,7 @@ func TestFirecrackerForkFromRunningNetwork(t *testing.T) {
 	source, err = waitForInstanceState(ctx, mgr, source.Id, StateRunning, integrationTestTimeout(20*time.Second))
 	require.NoError(t, err)
 	sourceID := source.Id
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), sourceID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, sourceID) })
 	assert.NotEmpty(t, source.IP)
 	assert.NotEmpty(t, source.MAC)
 
@@ -540,7 +540,7 @@ func TestFirecrackerForkFromRunningNetwork(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StateRunning, forked.State)
 	forkID := forked.Id
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), forkID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, forkID) })
 	assert.NotEmpty(t, forked.IP)
 	assert.NotEmpty(t, forked.MAC)
 	assert.Equal(t, mgr.paths.InstanceVsockSocket(forkID), forked.VsockSocket)
@@ -610,7 +610,7 @@ func TestFirecrackerWarmForkChain(t *testing.T) {
 	sourceDeleted := false
 	t.Cleanup(func() {
 		if !sourceDeleted {
-			_ = mgr.DeleteInstance(context.Background(), sourceID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, sourceID)
 		}
 	})
 
@@ -625,7 +625,7 @@ func TestFirecrackerWarmForkChain(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, SnapshotKindStandby, snapshot.Kind)
 
-	require.NoError(t, mgr.DeleteInstance(ctx, sourceID))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, sourceID))
 	sourceDeleted = true
 
 	warm, err := mgr.ForkSnapshot(ctx, snapshot.Id, ForkSnapshotRequest{
@@ -637,7 +637,7 @@ func TestFirecrackerWarmForkChain(t *testing.T) {
 	warmDeleted := false
 	t.Cleanup(func() {
 		if !warmDeleted {
-			_ = mgr.DeleteInstance(context.Background(), warmID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, warmID)
 		}
 	})
 	warm, err = waitForInstanceState(ctx, mgr, warmID, StateRunning, integrationTestTimeout(20*time.Second))
@@ -652,7 +652,7 @@ func TestFirecrackerWarmForkChain(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StateStopped, child.State)
 	childID := child.Id
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), childID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, childID) })
 
 	warm, err = mgr.GetInstance(ctx, warmID)
 	require.NoError(t, err)
@@ -663,7 +663,7 @@ func TestFirecrackerWarmForkChain(t *testing.T) {
 	require.Equal(t, StateRunning, warm.State)
 	require.NoError(t, waitForExecAgent(ctx, mgr, warmID, 30*time.Second))
 
-	require.NoError(t, mgr.DeleteInstance(ctx, warmID))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, warmID))
 	warmDeleted = true
 	require.NoError(t, mgr.DeleteSnapshot(ctx, snapshot.Id))
 }
@@ -716,7 +716,7 @@ func TestFCUFFDOneShotLifecycle(t *testing.T) {
 	sourceDeleted := false
 	t.Cleanup(func() {
 		if !sourceDeleted {
-			_ = mgr.DeleteInstance(context.Background(), sourceID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, sourceID)
 		}
 	})
 
@@ -753,7 +753,7 @@ func TestFCUFFDOneShotLifecycle(t *testing.T) {
 	parentDeleted := false
 	t.Cleanup(func() {
 		if !parentDeleted {
-			_ = mgr.DeleteInstance(context.Background(), parentID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, parentID)
 		}
 	})
 	parent = requireRunningSleepInstance(t, ctx, mgr, parentID)
@@ -805,7 +805,7 @@ func TestFCUFFDOneShotLifecycle(t *testing.T) {
 	childDeleted := false
 	t.Cleanup(func() {
 		if !childDeleted {
-			_ = mgr.DeleteInstance(context.Background(), childID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, childID)
 		}
 	})
 
@@ -864,11 +864,11 @@ func TestFCUFFDOneShotLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StateStandby, child.State)
 
-	require.NoError(t, mgr.DeleteInstance(ctx, childID))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, childID))
 	childDeleted = true
-	require.NoError(t, mgr.DeleteInstance(ctx, parentID))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, parentID))
 	parentDeleted = true
-	require.NoError(t, mgr.DeleteInstance(ctx, sourceID))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, sourceID))
 	sourceDeleted = true
 	require.NoError(t, mgr.DeleteSnapshot(ctx, snapshot.Id))
 	snapshotDeleted = true
@@ -922,7 +922,7 @@ func TestFCUFFDGraduationLifecycle(t *testing.T) {
 	sourceDeleted := false
 	t.Cleanup(func() {
 		if !sourceDeleted {
-			_ = mgr.DeleteInstance(context.Background(), sourceID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, sourceID)
 		}
 	})
 
@@ -958,7 +958,7 @@ func TestFCUFFDGraduationLifecycle(t *testing.T) {
 	parentDeleted := false
 	t.Cleanup(func() {
 		if !parentDeleted {
-			_ = mgr.DeleteInstance(context.Background(), parentID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, parentID)
 		}
 	})
 
@@ -1020,9 +1020,9 @@ func TestFCUFFDGraduationLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, parentMeta.StoredMetadata.FirecrackerUFFDSessionID, "file-backed restore after graduation should not create a pager session")
 
-	require.NoError(t, mgr.DeleteInstance(ctx, parentID))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, parentID))
 	parentDeleted = true
-	require.NoError(t, mgr.DeleteInstance(ctx, sourceID))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, sourceID))
 	sourceDeleted = true
 	require.NoError(t, mgr.DeleteSnapshot(ctx, snapshot.Id))
 	snapshotDeleted = true
@@ -1153,7 +1153,7 @@ func TestFirecrackerForkIsolation(t *testing.T) {
 	sourceDeleted := false
 	t.Cleanup(func() {
 		if !sourceDeleted {
-			_ = mgr.DeleteInstance(context.Background(), sourceID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, sourceID)
 		}
 	})
 
@@ -1193,7 +1193,7 @@ func TestFirecrackerForkIsolation(t *testing.T) {
 	forkDeleted := false
 	t.Cleanup(func() {
 		if !forkDeleted {
-			_ = mgr.DeleteInstance(context.Background(), forkID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, forkID)
 		}
 	})
 	require.Equal(t, StateStandby, fork.State)

--- a/lib/instances/firecracker_test.go
+++ b/lib/instances/firecracker_test.go
@@ -153,7 +153,7 @@ func TestFirecrackerStandbyAndRestore(t *testing.T) {
 	inst, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
 		Name:           "test-firecracker-standby",
 		Image:          integrationTestImageRef(t, "docker.io/library/nginx:alpine"),
-		Size:           1024 * 1024 * 1024,
+		Size:           lifecycleTestMemorySize,
 		OverlaySize:    10 * 1024 * 1024 * 1024,
 		Vcpus:          1,
 		NetworkEnabled: false,
@@ -287,7 +287,7 @@ func TestFirecrackerStopClearsStaleSnapshot(t *testing.T) {
 	inst, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
 		Name:           "fc-stale-snapshot",
 		Image:          integrationTestImageRef(t, "docker.io/library/nginx:alpine"),
-		Size:           1024 * 1024 * 1024,
+		Size:           lifecycleTestMemorySize,
 		OverlaySize:    10 * 1024 * 1024 * 1024,
 		Vcpus:          1,
 		NetworkEnabled: false,
@@ -581,7 +581,7 @@ func TestFirecrackerWarmForkChain(t *testing.T) {
 	source, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
 		Name:           "fc-warm-chain-src",
 		Image:          imageName,
-		Size:           1024 * 1024 * 1024,
+		Size:           lifecycleTestMemorySize,
 		OverlaySize:    1024 * 1024 * 1024,
 		Vcpus:          1,
 		NetworkEnabled: false,
@@ -687,7 +687,7 @@ func TestFCUFFDOneShotLifecycle(t *testing.T) {
 	source, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
 		Name:           "fc-uffd-oneshot-src",
 		Image:          imageName,
-		Size:           1024 * 1024 * 1024,
+		Size:           lifecycleTestMemorySize,
 		OverlaySize:    1024 * 1024 * 1024,
 		Vcpus:          1,
 		NetworkEnabled: false,
@@ -893,7 +893,7 @@ func TestFCUFFDGraduationLifecycle(t *testing.T) {
 	source, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
 		Name:           "fc-uffd-grad-src",
 		Image:          imageName,
-		Size:           1024 * 1024 * 1024,
+		Size:           lifecycleTestMemorySize,
 		OverlaySize:    1024 * 1024 * 1024,
 		Vcpus:          1,
 		NetworkEnabled: false,

--- a/lib/instances/fork_speed_darwin_test.go
+++ b/lib/instances/fork_speed_darwin_test.go
@@ -86,7 +86,7 @@ func TestVZForkSpeed(t *testing.T) {
 		dumpVZShimLogs(t, tmpDir)
 		require.NoError(t, err)
 	}
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), source.Id) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, source.Id) })
 	require.NoError(t, waitForExecAgent(ctx, mgr, source.Id, 60*time.Second))
 
 	// Fill the overlay with dense (random) data so the fork's disk copy has real

--- a/lib/instances/fork_test.go
+++ b/lib/instances/fork_test.go
@@ -986,7 +986,7 @@ func runWarmForkChain(t *testing.T, mgr *manager, tmpDir string, cfg warmForkCha
 	source, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
 		Name:           cfg.namePrefix + "-warm-chain-src",
 		Image:          imageName,
-		Size:           1024 * 1024 * 1024,
+		Size:           lifecycleTestMemorySize,
 		OverlaySize:    1024 * 1024 * 1024,
 		Vcpus:          1,
 		NetworkEnabled: false,

--- a/lib/instances/fork_test.go
+++ b/lib/instances/fork_test.go
@@ -892,7 +892,7 @@ func TestForkCloudHypervisorFromRunningNetwork(t *testing.T) {
 	})
 	require.NoError(t, err)
 	sourceID := source.Id
-	t.Cleanup(func() { _ = manager.DeleteInstance(context.Background(), sourceID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), manager, sourceID) })
 	source, err = waitForInstanceState(ctx, manager, source.Id, StateRunning, integrationTestTimeout(20*time.Second))
 	require.NoError(t, err)
 	require.NoError(t, waitForVMReady(ctx, source.SocketPath, 5*time.Second))
@@ -918,7 +918,7 @@ func TestForkCloudHypervisorFromRunningNetwork(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StateRunning, forked.State)
 	forkedID := forked.Id
-	t.Cleanup(func() { _ = manager.DeleteInstance(context.Background(), forkedID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), manager, forkedID) })
 
 	// Source should be restored and still reachable by its private IP.
 	sourceAfterFork, err := manager.GetInstance(ctx, source.Id)
@@ -998,7 +998,7 @@ func runWarmForkChain(t *testing.T, mgr *manager, tmpDir string, cfg warmForkCha
 	sourceDeleted := false
 	t.Cleanup(func() {
 		if !sourceDeleted {
-			_ = mgr.DeleteInstance(context.Background(), sourceID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, sourceID)
 		}
 	})
 
@@ -1019,7 +1019,7 @@ func runWarmForkChain(t *testing.T, mgr *manager, tmpDir string, cfg warmForkCha
 		}
 	})
 
-	require.NoError(t, mgr.DeleteInstance(ctx, sourceID))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, sourceID))
 	sourceDeleted = true
 
 	warm, err := mgr.ForkSnapshot(ctx, snapshot.Id, ForkSnapshotRequest{
@@ -1031,7 +1031,7 @@ func runWarmForkChain(t *testing.T, mgr *manager, tmpDir string, cfg warmForkCha
 	warmDeleted := false
 	t.Cleanup(func() {
 		if !warmDeleted {
-			_ = mgr.DeleteInstance(context.Background(), warmID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, warmID)
 		}
 	})
 	warm, err = waitForInstanceState(ctx, mgr, warmID, StateRunning, readyTimeout)
@@ -1046,7 +1046,7 @@ func runWarmForkChain(t *testing.T, mgr *manager, tmpDir string, cfg warmForkCha
 	require.NoError(t, err)
 	require.Equal(t, StateStopped, child.State)
 	childID := child.Id
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), childID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, childID) })
 
 	warm, err = mgr.GetInstance(ctx, warmID)
 	require.NoError(t, err)
@@ -1057,7 +1057,7 @@ func runWarmForkChain(t *testing.T, mgr *manager, tmpDir string, cfg warmForkCha
 	require.Equal(t, StateRunning, warm.State)
 	require.NoError(t, waitForExecAgent(ctx, mgr, warmID, readyTimeout))
 
-	require.NoError(t, mgr.DeleteInstance(ctx, warmID))
+	require.NoError(t, deleteTestInstanceNow(ctx, mgr, warmID))
 	warmDeleted = true
 	require.NoError(t, mgr.DeleteSnapshot(ctx, snapshot.Id))
 	snapshotDeleted = true

--- a/lib/instances/manager_darwin_test.go
+++ b/lib/instances/manager_darwin_test.go
@@ -604,7 +604,7 @@ func TestVZForkFromRunningNetwork(t *testing.T) {
 	require.NotEmpty(t, source.MAC)
 
 	sourceID := source.Id
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), sourceID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, sourceID) })
 
 	err = waitForExecAgent(ctx, mgr, sourceID, 30*time.Second)
 	require.NoError(t, err, "source guest agent should be ready")
@@ -633,7 +633,7 @@ func TestVZForkFromRunningNetwork(t *testing.T) {
 	require.Contains(t, []State{StateInitializing, StateRunning}, forked.State)
 	require.NotEqual(t, sourceID, forked.Id)
 	forkID := forked.Id
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), forkID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, forkID) })
 	forked, err = waitForInstanceState(ctx, mgr, forkID, StateRunning, 30*time.Second)
 	require.NoError(t, err)
 

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -34,6 +34,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// lifecycleTestMemorySize is enough to boot the shared test guest while
+// avoiding snapshotting memory that lifecycle tests never touch. Dedicated
+// memory and resource-limit tests retain their larger sizes.
+const lifecycleTestMemorySize = 512 * 1024 * 1024
+
 // setupTestManager creates a manager and registers cleanup for any orphaned processes
 func setupTestManager(t *testing.T) (*manager, string) {
 	tmpDir := t.TempDir()

--- a/lib/instances/manager_test.go
+++ b/lib/instances/manager_test.go
@@ -76,6 +76,23 @@ func setupTestManager(t *testing.T) (*manager, string) {
 	return mgr, tmpDir
 }
 
+// deleteTestInstanceNow performs the same resource and metadata cleanup as
+// DeleteInstance, but skips the guest grace period. Cleanup callbacks do not
+// need to preserve guest state: the test has already made its assertions and
+// is discarding the VM.
+func deleteTestInstanceNow(ctx context.Context, mgr *manager, id string) error {
+	lock := mgr.getInstanceLock(id)
+	lock.Lock()
+	defer lock.Unlock()
+
+	err := mgr.deleteInstanceWithOptions(ctx, id, deleteInstanceOptions{skipGracefulShutdown: true})
+	if err == nil {
+		mgr.notifyLifecycleDelete(ctx, id)
+		mgr.instanceLocks.Delete(id)
+	}
+	return err
+}
+
 // waitForVMReady polls VM state via VMM API until it's running or times out
 func waitForVMReady(ctx context.Context, socketPath string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)

--- a/lib/instances/qemu_test.go
+++ b/lib/instances/qemu_test.go
@@ -929,7 +929,7 @@ func TestQEMUForkFromRunningNetwork(t *testing.T) {
 	})
 	require.NoError(t, err)
 	sourceID := source.Id
-	t.Cleanup(func() { _ = manager.DeleteInstance(context.Background(), sourceID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), manager, sourceID) })
 	// QEMU is the slowest Linux hypervisor under full-suite load on Deft. Give
 	// the host-side Running transition more headroom so we don't fail while the
 	// VM is still legitimately completing boot marker hydration.
@@ -953,7 +953,7 @@ func TestQEMUForkFromRunningNetwork(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StateStandby, forked.State)
 	forkedID := forked.Id
-	t.Cleanup(func() { _ = manager.DeleteInstance(context.Background(), forkedID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), manager, forkedID) })
 
 	sourceAfterFork, err := manager.GetInstance(ctx, source.Id)
 	require.NoError(t, err)

--- a/lib/instances/snapshot_compression.go
+++ b/lib/instances/snapshot_compression.go
@@ -97,7 +97,23 @@ func (r nativeCodecRuntime) commandContextFunc() func(context.Context, string, .
 	if r.commandContext != nil {
 		return r.commandContext
 	}
-	return exec.CommandContext
+	return newNativeCodecCommand
+}
+
+func newNativeCodecCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	// Kill the entire process group on cancellation. Killing only the direct
+	// child can leave helpers holding stdout/stderr pipes open, which makes
+	// Cmd.Wait block until those helpers exit on their own.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if err == syscall.ESRCH {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return cmd
 }
 
 func cloneCompressionConfig(cfg *snapshotstore.SnapshotCompressionConfig) *snapshotstore.SnapshotCompressionConfig {

--- a/lib/instances/snapshot_compression_native_test.go
+++ b/lib/instances/snapshot_compression_native_test.go
@@ -320,19 +320,32 @@ func TestCompressSnapshotMemoryFileReturnsContextCanceledWhenNativeProcessIsKill
 	mgr, reader := newCodecRuntimeTestManager(t)
 	baseCtx, logs := newCodecRuntimeContext()
 	ctx, cancel := context.WithCancel(baseCtx)
+	defer cancel()
 	rawPath, _ := writeRawSnapshotMemoryFile(t)
-	binaryPath := writeExecutableScript(t, "zstd", "#!/bin/sh\nsleep 30\n")
-	started := time.Now()
-	time.AfterFunc(20*time.Millisecond, cancel)
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	t.Setenv("HYPEMAN_CODEC_TEST_READY", readyPath)
+	binaryPath := writeExecutableScript(t, "zstd", "#!/bin/sh\nsleep 30 &\n: > \"$HYPEMAN_CODEC_TEST_READY\"\nwait\n")
 
-	_, _, err := compressSnapshotMemoryFileWithRuntime(ctx, nativeCodecRuntime{
-		manager:  mgr,
-		lookPath: func(string) (string, error) { return binaryPath, nil },
-	}, rawPath, snapshotstore.SnapshotCompressionConfig{
-		Enabled:   true,
-		Algorithm: snapshotstore.SnapshotCompressionAlgorithmZstd,
-		Level:     intPtr(1),
-	})
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := compressSnapshotMemoryFileWithRuntime(ctx, nativeCodecRuntime{
+			manager:  mgr,
+			lookPath: func(string) (string, error) { return binaryPath, nil },
+		}, rawPath, snapshotstore.SnapshotCompressionConfig{
+			Enabled:   true,
+			Algorithm: snapshotstore.SnapshotCompressionAlgorithmZstd,
+			Level:     intPtr(1),
+		})
+		errCh <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(readyPath)
+		return err == nil
+	}, time.Second, 5*time.Millisecond, "native helper child must start before cancellation")
+	started := time.Now()
+	cancel()
+	err := <-errCh
 	require.ErrorIs(t, err, context.Canceled)
 	require.Less(t, time.Since(started), time.Second, "cancellation must terminate native helper descendants promptly")
 	assert.Empty(t, logs.warnRecords())

--- a/lib/instances/snapshot_compression_native_test.go
+++ b/lib/instances/snapshot_compression_native_test.go
@@ -322,6 +322,7 @@ func TestCompressSnapshotMemoryFileReturnsContextCanceledWhenNativeProcessIsKill
 	ctx, cancel := context.WithCancel(baseCtx)
 	rawPath, _ := writeRawSnapshotMemoryFile(t)
 	binaryPath := writeExecutableScript(t, "zstd", "#!/bin/sh\nsleep 30\n")
+	started := time.Now()
 	time.AfterFunc(20*time.Millisecond, cancel)
 
 	_, _, err := compressSnapshotMemoryFileWithRuntime(ctx, nativeCodecRuntime{
@@ -333,6 +334,7 @@ func TestCompressSnapshotMemoryFileReturnsContextCanceledWhenNativeProcessIsKill
 		Level:     intPtr(1),
 	})
 	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, time.Since(started), time.Second, "cancellation must terminate native helper descendants promptly")
 	assert.Empty(t, logs.warnRecords())
 
 	var rm metricdata.ResourceMetrics

--- a/lib/instances/snapshot_integration_scenario_test.go
+++ b/lib/instances/snapshot_integration_scenario_test.go
@@ -62,7 +62,7 @@ func runStandbySnapshotScenario(t *testing.T, mgr *manager, tmpDir string, cfg s
 	sourceDeleted := false
 	t.Cleanup(func() {
 		if !sourceDeleted {
-			_ = mgr.DeleteInstance(context.Background(), sourceID)
+			_ = deleteTestInstanceNow(context.Background(), mgr, sourceID)
 		}
 	})
 
@@ -103,7 +103,7 @@ func runStandbySnapshotScenario(t *testing.T, mgr *manager, tmpDir string, cfg s
 	require.Equal(t, StateStandby, forked.State)
 
 	forkID := forked.Id
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), forkID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, forkID) })
 	currentFork, err := mgr.GetInstance(ctx, forkID)
 	requireNoErr(err)
 	require.Equal(t, StateStandby, currentFork.State)

--- a/lib/instances/snapshot_integration_scenario_test.go
+++ b/lib/instances/snapshot_integration_scenario_test.go
@@ -49,7 +49,7 @@ func runStandbySnapshotScenario(t *testing.T, mgr *manager, tmpDir string, cfg s
 	source, err := mgr.CreateInstance(ctx, CreateInstanceRequest{
 		Name:           cfg.sourceName,
 		Image:          integrationTestImageRef(t, "docker.io/library/alpine:latest"),
-		Size:           1024 * 1024 * 1024,
+		Size:           lifecycleTestMemorySize,
 		OverlaySize:    10 * 1024 * 1024 * 1024,
 		Vcpus:          1,
 		NetworkEnabled: false,

--- a/lib/instances/snapshot_running_source_darwin_test.go
+++ b/lib/instances/snapshot_running_source_darwin_test.go
@@ -76,7 +76,7 @@ func TestVZRunningSnapshotRoundTrip(t *testing.T) {
 		require.NoError(t, err)
 	}
 	sourceID := source.Id
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), sourceID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, sourceID) })
 
 	require.NoError(t, waitForExecAgent(ctx, mgr, sourceID, 60*time.Second), "guest agent should be ready")
 	source, err = waitForInstanceState(ctx, mgr, sourceID, StateRunning, 30*time.Second)
@@ -127,7 +127,7 @@ func TestVZRunningSnapshotRoundTrip(t *testing.T) {
 		require.NoError(t, err)
 	}
 	forkID := forked.Id
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), forkID) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, forkID) })
 
 	restored, err := mgr.RestoreInstance(ctx, forkID)
 	if err != nil {

--- a/lib/instances/snapshot_test.go
+++ b/lib/instances/snapshot_test.go
@@ -53,7 +53,7 @@ func TestStoppedSnapshotLifecycleAndForkAfterSourceDeletion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StateStopped, forked.State)
 	require.Equal(t, hvType, forked.HypervisorType)
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), forked.Id) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, forked.Id) })
 
 	require.NoError(t, mgr.DeleteSnapshot(ctx, snap.Id))
 	_, err = mgr.GetSnapshot(ctx, snap.Id)
@@ -325,7 +325,7 @@ func TestForkSnapshotFromCompressedSourceCopiesRawMemory(t *testing.T) {
 		TargetState: StateStopped,
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = mgr.DeleteInstance(context.Background(), forked.Id) })
+	t.Cleanup(func() { _ = deleteTestInstanceNow(context.Background(), mgr, forked.Id) })
 
 	forkSnapshotDir := mgr.paths.InstanceDir(forked.Id)
 	_, ok := findRawSnapshotMemoryFile(forkSnapshotDir)

--- a/lib/snapshot/testsupport/images.go
+++ b/lib/snapshot/testsupport/images.go
@@ -38,7 +38,11 @@ func EnsureImageReady(t *testing.T, ctx context.Context, p *paths.Paths, imageMa
 	ref, err := images.ParseNormalizedRef(image)
 	require.NoError(t, err)
 
-	cachePaths := paths.New(filepath.Join(os.TempDir(), "hypeman-snapshot-image-cache"))
+	cacheDir := strings.TrimSpace(os.Getenv("HYPEMAN_TEST_PREWARM_DIR"))
+	if cacheDir == "" {
+		cacheDir = filepath.Join(os.TempDir(), "hypeman-snapshot-image-cache")
+	}
+	cachePaths := paths.New(cacheDir)
 	cacheMgr, err := images.NewManager(cachePaths, 1, nil)
 	require.NoError(t, err)
 

--- a/lib/snapshot/testsupport/images.go
+++ b/lib/snapshot/testsupport/images.go
@@ -29,8 +29,8 @@ func imageBuildLock(ref string) *sync.Mutex {
 	return m.(*sync.Mutex)
 }
 
-// EnsureImageReady pre-warms a shared image cache under /tmp and seeds that
-// image into the test data directory so instance integration tests don't need
+// EnsureImageReady seeds an image from the configured shared prewarm cache,
+// falling back to a cache under /tmp, so instance integration tests don't need
 // to repull/reconvert from scratch.
 func EnsureImageReady(t *testing.T, ctx context.Context, p *paths.Paths, imageManager images.Manager, image string) {
 	t.Helper()


### PR DESCRIPTION
## What

Reduce the Hypeman test suite wall-clock time by removing measured lifecycle overhead:

- cancel the full native compression process group when its context expires
- use immediate VM shutdown only in test teardown while retaining the normal cleanup path
- prepare VM-ready test images once per run instead of repeatedly unpacking layers
- use 512 MiB guests for lifecycle tests that do not exercise memory capacity

## Why

Wall-clock profiling showed that the suite was spending substantial time in repeated image preparation, graceful shutdown timeouts, oversized lifecycle guests, and a cancellation path that killed the shell but left its child process holding output pipes open.

These changes address those root causes directly. They do not shard the suite or add a test matrix.

## Result

Linux Run tests step:

- before: 259 seconds
- after: 190 seconds
- reduction: 69 seconds, or 26.6 percent

The full Linux job, macOS job, and install checks passed.

## Test strength

No tests, assertions, VMM backends, or integration scenarios are removed.

Production DeleteInstance behavior remains unchanged. Immediate shutdown is restricted to test cleanup and terminal test teardown. Dedicated memory and resource-capacity tests retain their larger guest sizes.

The compression cancellation regression test also asserts that cancellation returns within one second, so the original 30-second child-process leak cannot silently return.

## Verification

- Before: https://github.com/kernel/hypeman/actions/runs/29444740345
- After: https://github.com/kernel/hypeman/actions/runs/29450412921

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production snapshot compression cancellation behavior changes (process-group kill); delete graceful-shutdown skipping is test-only but lives on the shared delete path.
> 
> **Overview**
> Cuts integration test wall-clock by attacking repeated setup and teardown overhead, without dropping scenarios or assertions.
> 
> **Prewarm builds VM-ready images once per CI run:** `test-prewarm` now runs `CreateImage` + `WaitForReady` for each mirrored image, and `EnsureImageReady` prefers `HYPEMAN_TEST_PREWARM_DIR` so tests seed from that cache instead of rebuilding layers. Linux CI **chowns** the prewarm directory so the job user can write under `/ci/prewarm`.
> 
> **Faster test VM teardown:** `deleteInstanceWithOptions` gains `skipGracefulShutdown`; `deleteTestInstanceNow` uses it for cleanups while public `DeleteInstance` behavior is unchanged.
> 
> **Smaller default lifecycle guests:** many integration tests use `lifecycleTestMemorySize` (512 MiB) where memory size is not the subject; capacity-focused tests keep larger sizes.
> 
> **Compression cancel fix (production):** native zstd/lz4 helpers run in a process group and get **SIGKILL on the whole group** when the context is canceled, so `Wait` does not hang on orphaned children; the regression test now requires cancellation within one second.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5fe4fece127e37ab21cd73732f3c79cec01627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

