### PR TITLE
Keep waiting for build image while registry import is in flight

### DIFF
--- a/lib/builds/manager.go
+++ b/lib/builds/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -958,20 +959,40 @@ func (m *manager) updateBuildComplete(id string, status string, digest *string, 
 	m.notifyStatusChange(id, status)
 }
 
+// imageImportRetryInterval is the delay between retries when the build's
+// image has not yet been imported by the registry. Var so tests can shorten it.
+var imageImportRetryInterval = time.Second
+
 // waitForImageReady blocks until the build's image reaches a terminal state.
 // imageRef should be the short repo name (e.g., "builds/abc123" or "myapp")
 // matching what triggerConversion stores in the image manager.
 // This ensures that when a build reports "ready", the image is actually usable
 // for instance creation (fixes KERNEL-863 race condition).
+//
+// The registry imports pushed images asynchronously, and under concurrent
+// build bursts the import (OCI layout copy) can outlast the image manager's
+// internal existence deadline. By the time this is called the builder has
+// already pushed the image, so "not found" means "import still in flight",
+// not "push failed" — keep retrying until the build context expires.
 func (m *manager) waitForImageReady(ctx context.Context, imageRef string) error {
 	m.logger.Debug("waiting for image to be ready", "image_ref", imageRef)
 
-	if err := m.imageManager.WaitForReady(ctx, imageRef); err != nil {
-		return err
+	for {
+		err := m.imageManager.WaitForReady(ctx, imageRef)
+		if err == nil {
+			m.logger.Debug("image is ready", "image_ref", imageRef)
+			return nil
+		}
+		if !errors.Is(err, images.ErrNotFound) {
+			return err
+		}
+		m.logger.Info("build image not yet imported by registry, retrying", "image_ref", imageRef)
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(imageImportRetryInterval):
+		}
 	}
-
-	m.logger.Debug("image is ready", "image_ref", imageRef)
-	return nil
 }
 
 // subscribeToStatus adds a subscriber channel for status updates on a build

--- a/lib/builds/manager_test.go
+++ b/lib/builds/manager_test.go
@@ -360,6 +360,12 @@ func (m *mockImageManager) WaitForReady(ctx context.Context, name string) error 
 			status = img.Status
 		}
 		m.mu.RUnlock()
+		// Mirror the real manager: a missing image is reported as not found
+		// (the real implementation polls for 30s first; return immediately
+		// to keep tests fast).
+		if !ok {
+			return fmt.Errorf("get image: %w", images.ErrNotFound)
+		}
 		switch status {
 		case images.StatusReady:
 			return nil

--- a/lib/builds/race_test.go
+++ b/lib/builds/race_test.go
@@ -121,6 +121,63 @@ func TestWaitForImageReady_WaitsForConversion(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond, "should have waited for conversion")
 }
 
+// TestWaitForImageReady_RetriesWhileImportInFlight tests that waitForImageReady
+// keeps waiting when the image doesn't exist yet. The registry imports pushed
+// images asynchronously, so under concurrent build bursts the image record can
+// appear well after the builder reports success — "not found" at this point
+// means the import is still in flight, not that the push failed.
+func TestWaitForImageReady_RetriesWhileImportInFlight(t *testing.T) {
+	mgr, _, _, imageMgr, tempDir := setupTestManagerWithImageMgr(t)
+	defer os.RemoveAll(tempDir)
+
+	prevInterval := imageImportRetryInterval
+	imageImportRetryInterval = 20 * time.Millisecond
+	defer func() { imageImportRetryInterval = prevInterval }()
+
+	ctx := context.Background()
+	buildID := "test-build-late-import"
+	imageRef := "builds/" + buildID
+
+	// Image does not exist at all yet. Simulate the registry's async import
+	// registering it (pending) and conversion completing shortly after.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		imageMgr.mu.Lock()
+		imageMgr.images[imageRef] = &images.Image{
+			Name:   imageRef,
+			Status: images.StatusPending,
+		}
+		imageMgr.mu.Unlock()
+		time.Sleep(100 * time.Millisecond)
+		imageMgr.SetImageStatus(imageRef, images.StatusReady)
+	}()
+
+	start := time.Now()
+	err := mgr.waitForImageReady(ctx, imageRef)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond, "should have waited for the import to land")
+}
+
+// TestWaitForImageReady_NotFoundUntilContextExpires tests that a build whose
+// image never gets imported still fails once the build context expires.
+func TestWaitForImageReady_NotFoundUntilContextExpires(t *testing.T) {
+	mgr, _, _, _, tempDir := setupTestManagerWithImageMgr(t)
+	defer os.RemoveAll(tempDir)
+
+	prevInterval := imageImportRetryInterval
+	imageImportRetryInterval = 20 * time.Millisecond
+	defer func() { imageImportRetryInterval = prevInterval }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := mgr.waitForImageReady(ctx, "builds/test-build-never-imported")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, images.ErrNotFound)
+}
+
 // TestWaitForImageReady_Timeout tests that waitForImageReady times out if image never becomes ready
 func TestWaitForImageReady_ContextCancelled(t *testing.T) {
 	mgr, _, _, imageMgr, tempDir := setupTestManagerWithImageMgr(t)


### PR DESCRIPTION
## Summary

Fixes spurious `image conversion failed: get image: image not found` build failures under concurrent deploy bursts.

The registry imports pushed images asynchronously: after the manifest PUT returns 201, `triggerConversion` copies blobs into the OCI layout and only then calls `ImportLocalImage`, which creates the image record. Under a burst of concurrent builds this import is disk-bound and can take well over 30 seconds — longer than the fixed `maxWaitForExist` existence deadline inside `images.WaitForReady`. The build manager then fails the build even though the push succeeded and the image reaches `ready` seconds later. Observed in production: a build declared failed at its 30s deadline whose image record went `ready` 5 seconds after; ~15% of deploys failed this way during bursts, and retries succeeded.

Since `waitForImageReady` only runs after the builder has successfully pushed (buildctl pushes synchronously before reporting `build_result`), a not-found at this point means the import is still in flight — not that the push failed. This change makes the build flow keep retrying on `images.ErrNotFound` until the build context (`policy.TimeoutSeconds`) expires, instead of giving up on the first existence timeout. Other errors (conversion failure, context cancellation) still fail immediately, and a genuinely-missing image now fails at the build timeout with the same error message.

The 30s default inside `images.WaitForReady` is unchanged, so the instance-start pull path keeps its existing behavior.

## Changes
- `lib/builds/manager.go`: retry `WaitForReady` on `ErrNotFound` in `waitForImageReady`, bounded by the build context
- `lib/builds/manager_test.go`: mock `WaitForReady` now returns not-found for missing images, mirroring the real manager
- `lib/builds/race_test.go`: regression tests for late import and never-imported cases

## Testing
- `go test ./lib/builds/` passes locally (full package, including the two new regression tests)
- Not exercised against a live hypeman host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-build completion timing and failure semantics for the build→image handoff; bounded by existing build timeout and limited to ErrNotFound retries.
> 
> **Overview**
> Fixes false **failed** builds when the push succeeded but the image record is not in the image manager yet because registry import is still running.
> 
> **`waitForImageReady`** no longer treats a single `images.ErrNotFound` from `WaitForReady` as terminal. After a successful builder push, not-found is interpreted as import in flight; the build manager loops with a 1s **`imageImportRetryInterval`** until the image is ready or the **build context** (`policy.TimeoutSeconds`) ends. Conversion failures and other non–not-found errors still fail immediately.
> 
> Test support: the mock **`WaitForReady`** returns not-found for missing images (matching production), plus regression tests for late import and never-imported timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24d9b5207b74edfecce52c336629d996bf57e132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->