### PR TITLE
Run auto-standby operations on bounded workers

### DIFF
--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -158,6 +158,13 @@ type InstancesConfig struct {
 	LifecycleEventBufferSize int `koanf:"lifecycle_event_buffer_size"`
 }
 
+// AutoStandbyConfig holds auto-standby controller settings.
+type AutoStandbyConfig struct {
+	// MaxConcurrent caps how many auto-standby operations (VM pause + memory
+	// snapshot write) run at once per host.
+	MaxConcurrent int `koanf:"max_concurrent"`
+}
+
 // RegistryConfig holds OCI registry settings.
 type RegistryConfig struct {
 	URL        string `koanf:"url"`
@@ -272,6 +279,7 @@ type Config struct {
 	Images           ImagesConfig           `koanf:"images"`
 	Build            BuildConfig            `koanf:"build"`
 	Instances        InstancesConfig        `koanf:"instances"`
+	AutoStandby      AutoStandbyConfig      `koanf:"auto_standby"`
 	Registry         RegistryConfig         `koanf:"registry"`
 	Limits           LimitsConfig           `koanf:"limits"`
 	Oversubscription OversubscriptionConfig `koanf:"oversubscription"`
@@ -388,6 +396,10 @@ func defaultConfig() *Config {
 
 		Instances: InstancesConfig{
 			LifecycleEventBufferSize: 256,
+		},
+
+		AutoStandby: AutoStandbyConfig{
+			MaxConcurrent: 16,
 		},
 
 		Registry: RegistryConfig{
@@ -622,6 +634,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Instances.LifecycleEventBufferSize <= 0 {
 		return fmt.Errorf("instances.lifecycle_event_buffer_size must be positive, got %d", c.Instances.LifecycleEventBufferSize)
+	}
+	if c.AutoStandby.MaxConcurrent <= 0 {
+		return fmt.Errorf("auto_standby.max_concurrent must be positive, got %d", c.AutoStandby.MaxConcurrent)
 	}
 	if err := validateDuration("images.auto_delete.unused_for", c.Images.AutoDelete.UnusedFor); err != nil {
 		return err

--- a/cmd/api/wire_gen.go
+++ b/cmd/api/wire_gen.go
@@ -70,8 +70,8 @@ func initializeApp() (*application, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	autostandbyController := providers.ProvideAutoStandbyController(instancesManager, logger)
-	healthcheckController := providers.ProvideHealthCheckController(instancesManager, logger)
+	autostandbyController := providers.ProvideAutoStandbyController(instancesManager, config, logger)
+	healthCheckController := providers.ProvideHealthCheckController(instancesManager, logger)
 	vm_metricsManager, err := providers.ProvideVMMetricsManager(instancesManager, config, logger)
 	if err != nil {
 		return nil, nil, err
@@ -96,7 +96,7 @@ func initializeApp() (*application, func(), error) {
 		ResourceManager:       resourcesManager,
 		GuestMemoryController: controller,
 		AutoStandbyController: autostandbyController,
-		HealthCheckController: healthcheckController,
+		HealthCheckController: healthCheckController,
 		VMMetricsManager:      vm_metricsManager,
 		Registry:              registry,
 		ApiService:            apiService,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,15 @@ data_dir: /var/lib/hypeman
 #       per_vm_cooldown: 5s
 
 # =============================================================================
+# Auto Standby
+# =============================================================================
+# auto_standby:
+#   # Caps concurrent auto-standby operations (VM pause + memory snapshot write)
+#   # per host. Standby demand above the cap queues; raise or lower to trade
+#   # snapshot IO pressure against standby latency.
+#   max_concurrent: 16
+
+# =============================================================================
 # Network Configuration
 # =============================================================================
 # network:

--- a/lib/autostandby/README.md
+++ b/lib/autostandby/README.md
@@ -32,6 +32,12 @@ When the active inbound TCP connection count reaches zero, Hypeman starts an idl
 - if a new inbound TCP connection appears before the timer expires, the timer is cleared
 - if the count stays at zero for the full `idle_timeout`, Hypeman places the VM into `Standby`
 
+Standby operations execute on background workers so the controller keeps processing
+conntrack and instance lifecycle events while snapshots are written. Concurrency is
+capped by `auto_standby.max_concurrent` in the server config (default 16); demand
+above the cap queues. Inbound activity observed while an instance's standby is
+queued cancels that attempt.
+
 The idle timestamps are also persisted in instance metadata.
 
 - if Hypeman restarts and a startup conntrack snapshot shows current inbound connections, the instance is treated as active immediately and any old idle countdown is cleared

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -494,7 +494,6 @@ func (c *Controller) handleInstanceEvent(ctx context.Context, event InstanceEven
 func (c *Controller) refreshInstanceLocked(ctx context.Context, inst Instance, conns []Connection, now time.Time) error {
 	state := c.ensureStateLocked(inst.ID)
 	state.instance = cloneInstance(inst)
-	state.standbyRequested = false
 
 	if !eligible(inst) {
 		hadRuntime := inst.Runtime != nil || state.idleSince != nil || state.lastInboundAt != nil
@@ -516,6 +515,10 @@ func (c *Controller) refreshInstanceLocked(ctx context.Context, inst Instance, c
 	if err != nil {
 		return err
 	}
+	// Cancel any queued standby attempt only once the refresh is guaranteed to
+	// re-establish a countdown or reconcile below; an erroring refresh above
+	// leaves the queued attempt to proceed on the last known idle state.
+	state.standbyRequested = false
 	state.activeInbound = activeSet
 
 	runtime := cloneRuntime(inst.Runtime)
@@ -547,8 +550,11 @@ func (c *Controller) refreshInstanceLocked(ctx context.Context, inst Instance, c
 			IdleSince:             cloneTimePtr(state.idleSince),
 			LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
 		}
+		// Persist failures must not strand the instance without a countdown;
+		// the runtime only matters for recovery across controller restarts.
 		if err := c.persistRuntime(ctx, inst.ID, runtime); err != nil {
-			return err
+			c.recordControllerError("persist_runtime")
+			c.log.Warn("auto-standby failed to persist runtime during refresh", "instance_id", inst.ID, "error", err)
 		}
 	}
 	c.armTimerLocked(inst.ID, state, now)

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -20,7 +20,12 @@ const (
 	defaultReconnectDelay            = 2 * time.Second
 	defaultReconcileDelay            = 2 * time.Second
 	defaultSnapshotSyncInterval      = 5 * time.Minute
+	defaultMaxConcurrentStandbys     = 16
 )
+
+// ErrInstanceNotFound signals that a standby target no longer exists. The
+// controller drops its tracking state instead of re-arming the idle timer.
+var ErrInstanceNotFound = errors.New("instance not found")
 
 // InstanceEventAction identifies an instance lifecycle change relevant to auto-standby.
 type InstanceEventAction string
@@ -88,6 +93,10 @@ type ControllerOptions struct {
 	ReconnectDelay       time.Duration
 	ReconcileDelay       time.Duration
 	SnapshotSyncInterval time.Duration
+	// MaxConcurrentStandbys caps how many standby operations run at once.
+	// Standby writes the VM's memory snapshot to disk, so the cap bounds
+	// concurrent snapshot IO. Defaults to 16 when unset.
+	MaxConcurrentStandbys int
 }
 
 type controllerState struct {
@@ -118,9 +127,12 @@ type Controller struct {
 	timerFired           chan string
 	reconcileFired       chan string
 	streamReady          chan ConnectionStream
+	standbySlots         chan struct{}
+	standbyWG            sync.WaitGroup
 
 	mu                sync.RWMutex
 	states            map[string]*controllerState
+	standbyInFlight   int
 	observerConnected bool
 	lastObserverErr   error
 }
@@ -147,6 +159,10 @@ func NewController(store InstanceStore, source ConnectionSource, opts Controller
 	if snapshotSyncInterval <= 0 {
 		snapshotSyncInterval = defaultSnapshotSyncInterval
 	}
+	maxConcurrentStandbys := opts.MaxConcurrentStandbys
+	if maxConcurrentStandbys <= 0 {
+		maxConcurrentStandbys = defaultMaxConcurrentStandbys
+	}
 
 	c := &Controller{
 		store:                store,
@@ -160,6 +176,7 @@ func NewController(store InstanceStore, source ConnectionSource, opts Controller
 		timerFired:           make(chan string, 128),
 		reconcileFired:       make(chan string, 128),
 		streamReady:          make(chan ConnectionStream, 4),
+		standbySlots:         make(chan struct{}, maxConcurrentStandbys),
 		states:               make(map[string]*controllerState),
 	}
 	c.metrics = newMetrics(opts.Meter, opts.Tracer, c)
@@ -169,7 +186,13 @@ func NewController(store InstanceStore, source ConnectionSource, opts Controller
 // Run starts the controller and blocks until ctx is cancelled.
 func (c *Controller) Run(ctx context.Context) error {
 	log := c.log.With("tracking_mode", trackingModeConntrackEventsV4TCP)
-	log.Info("auto-standby controller started", "snapshot_sync_interval", c.snapshotSyncInterval)
+	log.Info("auto-standby controller started", "snapshot_sync_interval", c.snapshotSyncInterval, "max_concurrent_standbys", cap(c.standbySlots))
+
+	// Standby workers outlive individual loop iterations; cancel them when the
+	// loop exits for any reason (not just ctx) and wait for in-flight work.
+	workerCtx, cancelWorkers := context.WithCancel(ctx)
+	defer c.standbyWG.Wait()
+	defer cancelWorkers()
 
 	var stream ConnectionStream
 	if c.source != nil {
@@ -253,7 +276,7 @@ func (c *Controller) Run(ctx context.Context) error {
 				log.Warn("auto-standby instance event handling failed", "action", event.Action, "instance_id", event.InstanceID, "error", err)
 			}
 		case id := <-c.timerFired:
-			c.handleStandbyTimer(ctx, id)
+			c.handleStandbyTimer(workerCtx, id)
 		case id := <-c.reconcileFired:
 			c.handleActiveReconcile(ctx, id)
 		case <-snapshotTicker.C:
@@ -626,7 +649,39 @@ func (c *Controller) handleConnectionEvent(ctx context.Context, event Connection
 	}
 }
 
+// handleStandbyTimer marks the instance as standby-requested and hands the
+// standby call to a bounded worker so the event loop never blocks on snapshot
+// IO. Inbound activity observed while the work is queued clears
+// standbyRequested and cancels the attempt.
 func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
+	c.mu.Lock()
+	state := c.states[id]
+	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || state.standbyRequested {
+		c.mu.Unlock()
+		return
+	}
+	state.timer = nil
+	state.nextStandbyAt = nil
+	state.standbyRequested = true
+	instanceName := state.instance.Name
+	c.mu.Unlock()
+
+	c.log.Info("auto-standby standby timer fired", "instance_id", id, "instance_name", instanceName)
+
+	c.standbyWG.Add(1)
+	go func() {
+		defer c.standbyWG.Done()
+		select {
+		case c.standbySlots <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
+		defer func() { <-c.standbySlots }()
+		c.executeStandby(ctx, id, instanceName)
+	}()
+}
+
+func (c *Controller) executeStandby(ctx context.Context, id string, instanceName string) {
 	ctx, span := c.startSpan(ctx, "AutoStandbyStandbyAttempt",
 		attribute.String("instance_id", id),
 	)
@@ -638,27 +693,32 @@ func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
 
 	c.mu.Lock()
 	state := c.states[id]
-	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 {
+	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || !state.standbyRequested {
 		c.mu.Unlock()
 		return
 	}
-	state.timer = nil
-	state.nextStandbyAt = nil
-	state.standbyRequested = true
-	instanceName := state.instance.Name
 	idleTimeout := state.idleTimeout
+	c.standbyInFlight++
 	c.mu.Unlock()
-
-	c.log.Info("auto-standby standby timer fired", "instance_id", id, "instance_name", instanceName)
+	defer func() {
+		c.mu.Lock()
+		c.standbyInFlight--
+		c.mu.Unlock()
+	}()
 
 	if err := c.store.StandbyInstance(ctx, id); err != nil {
 		recordSpanError(span, err)
 		c.recordStandbyAttempt("error")
 		c.recordControllerError("standby")
-		c.log.Warn("auto-standby standby attempt failed", "instance_id", id, "instance_name", instanceName, "error", err)
 
 		c.mu.Lock()
 		defer c.mu.Unlock()
+		if errors.Is(err, ErrInstanceNotFound) {
+			c.log.Info("auto-standby target instance no longer exists, dropping state", "instance_id", id, "instance_name", instanceName)
+			c.removeStateLocked(id)
+			return
+		}
+		c.log.Warn("auto-standby standby attempt failed", "instance_id", id, "instance_name", instanceName, "error", err)
 		if state := c.states[id]; state != nil {
 			state.standbyRequested = false
 			idleSince := c.now().UTC()

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -683,6 +683,12 @@ func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
 }
 
 func (c *Controller) executeStandby(ctx context.Context, id string, instanceName string) {
+	// The slot may have been acquired in the same instant shutdown began;
+	// never start a new standby after cancellation.
+	if ctx.Err() != nil {
+		return
+	}
+
 	ctx, span := c.startSpan(ctx, "AutoStandbyStandbyAttempt",
 		attribute.String("instance_id", id),
 	)
@@ -695,6 +701,9 @@ func (c *Controller) executeStandby(ctx context.Context, id string, instanceName
 	c.mu.Lock()
 	state := c.states[id]
 	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || !state.standbyRequested || state.standbyExecuting {
+		if state != nil && len(state.activeInbound) > 0 {
+			state.standbyRequested = false
+		}
 		c.mu.Unlock()
 		return
 	}
@@ -728,6 +737,12 @@ func (c *Controller) executeStandby(ctx context.Context, id string, instanceName
 		c.log.Warn("auto-standby standby attempt failed", "instance_id", id, "instance_name", instanceName, "error", err)
 		if state := c.states[id]; state != nil {
 			state.standbyRequested = false
+			// Inbound activity that arrived during the attempt owns the state
+			// now; the reconcile/destroy flow restarts the countdown once the
+			// connections drain.
+			if len(state.activeInbound) > 0 {
+				return
+			}
 			idleSince := c.now().UTC()
 			state.idleSince = &idleSince
 			c.armTimerLocked(id, state, idleSince)

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -110,6 +110,7 @@ type controllerState struct {
 	timer            *time.Timer
 	reconcileTimer   *time.Timer
 	standbyRequested bool
+	standbyExecuting bool
 }
 
 // Controller decides when eligible instances should transition to standby.
@@ -656,7 +657,7 @@ func (c *Controller) handleConnectionEvent(ctx context.Context, event Connection
 func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
 	c.mu.Lock()
 	state := c.states[id]
-	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || state.standbyRequested {
+	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || state.standbyRequested || state.standbyExecuting {
 		c.mu.Unlock()
 		return
 	}
@@ -693,15 +694,21 @@ func (c *Controller) executeStandby(ctx context.Context, id string, instanceName
 
 	c.mu.Lock()
 	state := c.states[id]
-	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || !state.standbyRequested {
+	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || !state.standbyRequested || state.standbyExecuting {
 		c.mu.Unlock()
 		return
 	}
+	// standbyExecuting survives state refreshes (which reset standbyRequested),
+	// so resyncs racing a running standby cannot dispatch a duplicate worker.
+	state.standbyExecuting = true
 	idleTimeout := state.idleTimeout
 	c.standbyInFlight++
 	c.mu.Unlock()
 	defer func() {
 		c.mu.Lock()
+		if state := c.states[id]; state != nil {
+			state.standbyExecuting = false
+		}
 		c.standbyInFlight--
 		c.mu.Unlock()
 	}()
@@ -785,6 +792,7 @@ func (c *Controller) handleActiveReconcile(ctx context.Context, id string) {
 
 	state.activeInbound = activeSet
 	if len(activeSet) > 0 {
+		state.standbyRequested = false
 		c.armReconcileLocked(id, state)
 		return
 	}

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -21,6 +21,7 @@ type fakeInstanceStore struct {
 	events           chan InstanceEvent
 	standbyErr       error
 	listErr          error
+	setRuntimeErr    error
 	standbyStarted   chan string
 	standbyRelease   chan struct{}
 }
@@ -68,6 +69,9 @@ func (f *fakeInstanceStore) standbyCalls() []string {
 func (f *fakeInstanceStore) SetRuntime(_ context.Context, id string, runtime *Runtime) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.setRuntimeErr != nil {
+		return f.setRuntimeErr
+	}
 	f.persistedRuntime[id] = cloneRuntime(runtime)
 	for i := range f.instances {
 		if f.instances[i].ID == id {
@@ -863,4 +867,79 @@ func TestShutdownCancelsQueuedStandbyAndDrainsWorkers(t *testing.T) {
 
 	assert.Equal(t, []string{"inst-active-slot"}, store.standbyCalls(),
 		"queued standby must be abandoned on shutdown, in-flight one must drain")
+}
+
+func TestErroringRefreshDoesNotCancelQueuedStandby(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-holder", "192.168.100.98", idleSince),
+		idleTestInstance("inst-refresh-err", "192.168.100.99", idleSince),
+	})
+	store.standbyStarted = make(chan string, 2)
+	store.standbyRelease = make(chan struct{})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now:                   func() time.Time { return idleSince.Add(time.Minute) },
+		MaxConcurrentStandbys: 1,
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), "inst-holder")
+	require.Equal(t, "inst-holder", <-store.standbyStarted)
+	controller.handleStandbyTimer(context.Background(), "inst-refresh-err")
+
+	// A refresh that errors after the queued dispatch (invalid instance IP
+	// fails connection matching) must leave the queued attempt intact.
+	broken := idleTestInstance("inst-refresh-err", "not-an-ip", idleSince)
+	require.Error(t, controller.handleInstanceEvent(context.Background(), InstanceEvent{
+		Action:     InstanceEventUpdate,
+		InstanceID: "inst-refresh-err",
+		Instance:   &broken,
+	}))
+
+	controller.mu.RLock()
+	require.NotNil(t, controller.states["inst-refresh-err"])
+	assert.True(t, controller.states["inst-refresh-err"].standbyRequested)
+	controller.mu.RUnlock()
+
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
+	assert.ElementsMatch(t, []string{"inst-holder", "inst-refresh-err"}, store.standbyCalls())
+}
+
+func TestRefreshPersistFailureStillArmsIdleTimer(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	inst := Instance{
+		ID:             "inst-persist-err",
+		Name:           "inst-persist-err",
+		State:          StateRunning,
+		NetworkEnabled: true,
+		IP:             "192.168.100.100",
+		AutoStandby:    &Policy{Enabled: true, IdleTimeout: "1m"},
+	}
+	store := newFakeInstanceStore([]Instance{inst})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return idleSince },
+	})
+	store.setRuntimeErr = errors.New("metadata write failed")
+
+	// Fresh idle state forces the persist that fails; the countdown must be
+	// armed regardless.
+	refreshed := cloneInstance(inst)
+	require.NoError(t, controller.handleInstanceEvent(context.Background(), InstanceEvent{
+		Action:     InstanceEventCreate,
+		InstanceID: "inst-persist-err",
+		Instance:   &refreshed,
+	}))
+
+	controller.mu.RLock()
+	state := controller.states["inst-persist-err"]
+	require.NotNil(t, state)
+	assert.NotNil(t, state.nextStandbyAt)
+	assert.NotNil(t, state.idleSince)
+	controller.mu.RUnlock()
 }

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -3,7 +3,9 @@ package autostandby
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/netip"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,12 +14,15 @@ import (
 )
 
 type fakeInstanceStore struct {
+	mu               sync.Mutex
 	instances        []Instance
 	standbyIDs       []string
 	persistedRuntime map[string]*Runtime
 	events           chan InstanceEvent
 	standbyErr       error
 	listErr          error
+	standbyStarted   chan string
+	standbyRelease   chan struct{}
 }
 
 func newFakeInstanceStore(instances []Instance) *fakeInstanceStore {
@@ -29,6 +34,8 @@ func newFakeInstanceStore(instances []Instance) *fakeInstanceStore {
 }
 
 func (f *fakeInstanceStore) ListInstances(context.Context) ([]Instance, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -40,11 +47,27 @@ func (f *fakeInstanceStore) ListInstances(context.Context) ([]Instance, error) {
 }
 
 func (f *fakeInstanceStore) StandbyInstance(_ context.Context, id string) error {
+	if f.standbyStarted != nil {
+		f.standbyStarted <- id
+	}
+	if f.standbyRelease != nil {
+		<-f.standbyRelease
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.standbyIDs = append(f.standbyIDs, id)
 	return f.standbyErr
 }
 
+func (f *fakeInstanceStore) standbyCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.standbyIDs...)
+}
+
 func (f *fakeInstanceStore) SetRuntime(_ context.Context, id string, runtime *Runtime) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.persistedRuntime[id] = cloneRuntime(runtime)
 	for i := range f.instances {
 		if f.instances[i].ID == id {
@@ -477,8 +500,9 @@ func TestHandleStandbyTimerCallsStandbyAndClearsState(t *testing.T) {
 	require.NoError(t, controller.startupResync(context.Background()))
 
 	controller.handleStandbyTimer(context.Background(), "inst-standby")
+	controller.standbyWG.Wait()
 
-	require.Equal(t, []string{"inst-standby"}, store.standbyIDs)
+	require.Equal(t, []string{"inst-standby"}, store.standbyCalls())
 	require.Nil(t, store.persistedRuntime["inst-standby"])
 
 	controller.mu.RLock()
@@ -517,8 +541,9 @@ func TestHandleStandbyTimerFailureRearmsIdleCountdown(t *testing.T) {
 	require.NoError(t, controller.startupResync(context.Background()))
 
 	controller.handleStandbyTimer(context.Background(), "inst-standby-fail")
+	controller.standbyWG.Wait()
 
-	require.Equal(t, []string{"inst-standby-fail"}, store.standbyIDs)
+	require.Equal(t, []string{"inst-standby-fail"}, store.standbyCalls())
 	require.NotNil(t, store.persistedRuntime["inst-standby-fail"])
 	require.NotNil(t, store.persistedRuntime["inst-standby-fail"].IdleSince)
 	assert.Equal(t, now, *store.persistedRuntime["inst-standby-fail"].IdleSince)
@@ -537,4 +562,141 @@ func TestHandleStandbyTimerFailureRearmsIdleCountdown(t *testing.T) {
 
 func mustAddr(raw string) netip.Addr {
 	return netip.MustParseAddr(raw)
+}
+
+func idleTestInstance(id, ip string, idleSince time.Time) Instance {
+	since := idleSince
+	return Instance{
+		ID:             id,
+		Name:           id,
+		State:          StateRunning,
+		NetworkEnabled: true,
+		IP:             ip,
+		AutoStandby:    &Policy{Enabled: true, IdleTimeout: "1m"},
+		Runtime:        &Runtime{IdleSince: &since},
+	}
+}
+
+func TestStandbyExecutionBoundedByMaxConcurrent(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-a", "192.168.100.70", idleSince),
+		idleTestInstance("inst-b", "192.168.100.71", idleSince),
+		idleTestInstance("inst-c", "192.168.100.72", idleSince),
+		idleTestInstance("inst-d", "192.168.100.73", idleSince),
+	})
+	store.standbyStarted = make(chan string, 4)
+	store.standbyRelease = make(chan struct{})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now:                   func() time.Time { return idleSince.Add(time.Minute) },
+		MaxConcurrentStandbys: 2,
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	for _, id := range []string{"inst-a", "inst-b", "inst-c", "inst-d"} {
+		controller.handleStandbyTimer(context.Background(), id)
+	}
+
+	started := map[string]struct{}{}
+	for len(started) < 2 {
+		started[<-store.standbyStarted] = struct{}{}
+	}
+	select {
+	case id := <-store.standbyStarted:
+		t.Fatalf("standby for %s started beyond the concurrency cap", id)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
+	assert.Len(t, store.standbyCalls(), 4)
+}
+
+func TestStandbyCancelledByInboundActivityWhileQueued(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-first", "192.168.100.80", idleSince),
+		idleTestInstance("inst-queued", "192.168.100.81", idleSince),
+	})
+	store.standbyStarted = make(chan string, 2)
+	store.standbyRelease = make(chan struct{})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now:                   func() time.Time { return idleSince.Add(time.Minute) },
+		MaxConcurrentStandbys: 1,
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), "inst-first")
+	require.Equal(t, "inst-first", <-store.standbyStarted)
+	controller.handleStandbyTimer(context.Background(), "inst-queued")
+
+	controller.handleConnectionEvent(context.Background(), ConnectionEvent{
+		Type: ConnectionEventNew,
+		Connection: Connection{
+			OriginalSourceIP:        mustAddr("1.2.3.4"),
+			OriginalSourcePort:      50002,
+			OriginalDestinationIP:   mustAddr("192.168.100.81"),
+			OriginalDestinationPort: 8080,
+			TCPState:                TCPStateEstablished,
+		},
+		ObservedAt: idleSince.Add(time.Minute),
+	})
+
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
+	assert.Equal(t, []string{"inst-first"}, store.standbyCalls())
+}
+
+func TestStandbyDispatchDeduplicatesPendingRequests(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-dup", "192.168.100.90", idleSince),
+	})
+	store.standbyStarted = make(chan string, 2)
+	store.standbyRelease = make(chan struct{})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), "inst-dup")
+	require.Equal(t, "inst-dup", <-store.standbyStarted)
+	controller.handleStandbyTimer(context.Background(), "inst-dup")
+
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
+	assert.Equal(t, []string{"inst-dup"}, store.standbyCalls())
+}
+
+func TestStandbyNotFoundDropsStateWithoutRearming(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-gone", "192.168.100.91", idleSince),
+	})
+	store.standbyErr = fmt.Errorf("%w: deleted concurrently", ErrInstanceNotFound)
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), "inst-gone")
+	controller.standbyWG.Wait()
+
+	require.Equal(t, []string{"inst-gone"}, store.standbyCalls())
+	controller.mu.RLock()
+	_, tracked := controller.states["inst-gone"]
+	controller.mu.RUnlock()
+	assert.False(t, tracked)
 }

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -782,3 +782,85 @@ func TestActiveReconcileClearsPendingStandbyRequest(t *testing.T) {
 	controller.standbyWG.Wait()
 	assert.Equal(t, []string{"inst-busy"}, store.standbyCalls())
 }
+
+func TestStandbyFailureWithMidFlightActivityDoesNotRearmIdle(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-fail-busy", "192.168.100.95", idleSince),
+	})
+	store.standbyErr = errors.New("standby failed")
+	store.standbyStarted = make(chan string, 1)
+	store.standbyRelease = make(chan struct{})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), "inst-fail-busy")
+	require.Equal(t, "inst-fail-busy", <-store.standbyStarted)
+
+	// Inbound activity lands while the standby attempt is executing.
+	controller.handleConnectionEvent(context.Background(), ConnectionEvent{
+		Type: ConnectionEventNew,
+		Connection: Connection{
+			OriginalSourceIP:        mustAddr("1.2.3.4"),
+			OriginalSourcePort:      50004,
+			OriginalDestinationIP:   mustAddr("192.168.100.95"),
+			OriginalDestinationPort: 8080,
+			TCPState:                TCPStateEstablished,
+		},
+		ObservedAt: idleSince.Add(time.Minute),
+	})
+
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
+
+	controller.mu.RLock()
+	state := controller.states["inst-fail-busy"]
+	require.NotNil(t, state)
+	assert.Len(t, state.activeInbound, 1)
+	assert.False(t, state.standbyRequested)
+	assert.Nil(t, state.idleSince)
+	assert.Nil(t, state.nextStandbyAt)
+	controller.mu.RUnlock()
+
+	store.mu.Lock()
+	persisted := cloneRuntime(store.persistedRuntime["inst-fail-busy"])
+	store.mu.Unlock()
+	require.NotNil(t, persisted)
+	assert.Nil(t, persisted.IdleSince, "failure must not persist a false idle window while connections are active")
+}
+
+func TestShutdownCancelsQueuedStandbyAndDrainsWorkers(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-active-slot", "192.168.100.96", idleSince),
+		idleTestInstance("inst-waiting", "192.168.100.97", idleSince),
+	})
+	store.standbyStarted = make(chan string, 2)
+	store.standbyRelease = make(chan struct{})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now:                   func() time.Time { return idleSince.Add(time.Minute) },
+		MaxConcurrentStandbys: 1,
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	controller.handleStandbyTimer(ctx, "inst-active-slot")
+	require.Equal(t, "inst-active-slot", <-store.standbyStarted)
+	controller.handleStandbyTimer(ctx, "inst-waiting")
+
+	// Shutdown while one worker holds the slot and the other waits on it.
+	cancel()
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
+
+	assert.Equal(t, []string{"inst-active-slot"}, store.standbyCalls(),
+		"queued standby must be abandoned on shutdown, in-flight one must drain")
+}

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -700,3 +700,85 @@ func TestStandbyNotFoundDropsStateWithoutRearming(t *testing.T) {
 	controller.mu.RUnlock()
 	assert.False(t, tracked)
 }
+
+func TestResyncDuringExecutingStandbyDoesNotDoubleDispatch(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	inst := idleTestInstance("inst-racing", "192.168.100.92", idleSince)
+	store := newFakeInstanceStore([]Instance{inst})
+	store.standbyStarted = make(chan string, 2)
+	store.standbyRelease = make(chan struct{})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), "inst-racing")
+	require.Equal(t, "inst-racing", <-store.standbyStarted)
+
+	// A lifecycle refresh while the standby executes resets standbyRequested
+	// and re-arms an already-elapsed idle timer.
+	refreshed := cloneInstance(inst)
+	require.NoError(t, controller.handleInstanceEvent(context.Background(), InstanceEvent{
+		Action:     InstanceEventUpdate,
+		InstanceID: "inst-racing",
+		Instance:   &refreshed,
+	}))
+	controller.handleStandbyTimer(context.Background(), "inst-racing")
+
+	select {
+	case <-store.standbyStarted:
+		t.Fatal("second standby dispatched while one was executing")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
+	assert.Equal(t, []string{"inst-racing"}, store.standbyCalls())
+}
+
+func TestActiveReconcileClearsPendingStandbyRequest(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-busy", "192.168.100.93", idleSince),
+		idleTestInstance("inst-pending", "192.168.100.94", idleSince),
+	})
+	store.standbyStarted = make(chan string, 2)
+	store.standbyRelease = make(chan struct{})
+	source := &fakeConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now:                   func() time.Time { return idleSince.Add(time.Minute) },
+		MaxConcurrentStandbys: 1,
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), "inst-busy")
+	require.Equal(t, "inst-busy", <-store.standbyStarted)
+	controller.handleStandbyTimer(context.Background(), "inst-pending")
+
+	// Reconcile discovers an active inbound connection for the queued instance.
+	source.connections = []Connection{{
+		OriginalSourceIP:        mustAddr("1.2.3.4"),
+		OriginalSourcePort:      50003,
+		OriginalDestinationIP:   mustAddr("192.168.100.94"),
+		OriginalDestinationPort: 8080,
+		TCPState:                TCPStateEstablished,
+	}}
+	controller.handleActiveReconcile(context.Background(), "inst-pending")
+
+	controller.mu.RLock()
+	pending := controller.states["inst-pending"]
+	require.NotNil(t, pending)
+	assert.False(t, pending.standbyRequested)
+	assert.Len(t, pending.activeInbound, 1)
+	controller.mu.RUnlock()
+
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
+	assert.Equal(t, []string{"inst-busy"}, store.standbyCalls())
+}

--- a/lib/autostandby/metrics.go
+++ b/lib/autostandby/metrics.go
@@ -18,6 +18,7 @@ type Metrics struct {
 	trackedInstancesGauge  metric.Int64ObservableGauge
 	activeConnectionsGauge metric.Int64ObservableGauge
 	standbyInFlightGauge   metric.Int64ObservableGauge
+	standbyQueuedGauge     metric.Int64ObservableGauge
 	tracer                 trace.Tracer
 }
 
@@ -77,6 +78,13 @@ func newMetrics(meter metric.Meter, tracer trace.Tracer, controller *Controller)
 	if err != nil {
 		return &Metrics{tracer: tracer}
 	}
+	standbyQueuedGauge, err := meter.Int64ObservableGauge(
+		"hypeman_auto_standby_standby_queued",
+		metric.WithDescription("Standby attempts dispatched but waiting for an execution slot"),
+	)
+	if err != nil {
+		return &Metrics{tracer: tracer}
+	}
 
 	m := &Metrics{
 		conntrackEventsTotal:   conntrackEventsTotal,
@@ -86,6 +94,7 @@ func newMetrics(meter metric.Meter, tracer trace.Tracer, controller *Controller)
 		trackedInstancesGauge:  trackedInstancesGauge,
 		activeConnectionsGauge: activeConnectionsGauge,
 		standbyInFlightGauge:   standbyInFlightGauge,
+		standbyQueuedGauge:     standbyQueuedGauge,
 		tracer:                 tracer,
 	}
 
@@ -93,15 +102,16 @@ func newMetrics(meter metric.Meter, tracer trace.Tracer, controller *Controller)
 		if controller == nil {
 			return nil
 		}
-		active, countdown, ready, ineligible, totalConnections, inFlight := controller.metricSnapshot()
+		active, countdown, ready, ineligible, totalConnections, inFlight, queued := controller.metricSnapshot()
 		observer.ObserveInt64(m.trackedInstancesGauge, int64(active), metric.WithAttributes(attribute.String("phase", "active")))
 		observer.ObserveInt64(m.trackedInstancesGauge, int64(countdown), metric.WithAttributes(attribute.String("phase", "idle_countdown")))
 		observer.ObserveInt64(m.trackedInstancesGauge, int64(ready), metric.WithAttributes(attribute.String("phase", "ready_for_standby")))
 		observer.ObserveInt64(m.trackedInstancesGauge, int64(ineligible), metric.WithAttributes(attribute.String("phase", "ineligible")))
 		observer.ObserveInt64(m.activeConnectionsGauge, int64(totalConnections))
 		observer.ObserveInt64(m.standbyInFlightGauge, int64(inFlight))
+		observer.ObserveInt64(m.standbyQueuedGauge, int64(queued))
 		return nil
-	}, trackedInstancesGauge, activeConnectionsGauge, standbyInFlightGauge)
+	}, trackedInstancesGauge, activeConnectionsGauge, standbyInFlightGauge, standbyQueuedGauge)
 
 	return m
 }
@@ -147,7 +157,7 @@ func (c *Controller) recordObserverError(operation string) {
 	c.recordControllerError(operation)
 }
 
-func (c *Controller) metricSnapshot() (active, countdown, ready, ineligible, totalConnections, standbyInFlight int) {
+func (c *Controller) metricSnapshot() (active, countdown, ready, ineligible, totalConnections, standbyInFlight, standbyQueued int) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -159,6 +169,9 @@ func (c *Controller) metricSnapshot() (active, countdown, ready, ineligible, tot
 			continue
 		}
 		totalConnections += len(state.activeInbound)
+		if state.standbyRequested && !state.standbyExecuting {
+			standbyQueued++
+		}
 		switch {
 		case state.standbyRequested:
 			ready++

--- a/lib/autostandby/metrics.go
+++ b/lib/autostandby/metrics.go
@@ -17,6 +17,7 @@ type Metrics struct {
 	controllerErrorsTotal  metric.Int64Counter
 	trackedInstancesGauge  metric.Int64ObservableGauge
 	activeConnectionsGauge metric.Int64ObservableGauge
+	standbyInFlightGauge   metric.Int64ObservableGauge
 	tracer                 trace.Tracer
 }
 
@@ -69,6 +70,13 @@ func newMetrics(meter metric.Meter, tracer trace.Tracer, controller *Controller)
 	if err != nil {
 		return &Metrics{tracer: tracer}
 	}
+	standbyInFlightGauge, err := meter.Int64ObservableGauge(
+		"hypeman_auto_standby_standby_in_flight",
+		metric.WithDescription("Standby operations currently executing"),
+	)
+	if err != nil {
+		return &Metrics{tracer: tracer}
+	}
 
 	m := &Metrics{
 		conntrackEventsTotal:   conntrackEventsTotal,
@@ -77,6 +85,7 @@ func newMetrics(meter metric.Meter, tracer trace.Tracer, controller *Controller)
 		controllerErrorsTotal:  controllerErrorsTotal,
 		trackedInstancesGauge:  trackedInstancesGauge,
 		activeConnectionsGauge: activeConnectionsGauge,
+		standbyInFlightGauge:   standbyInFlightGauge,
 		tracer:                 tracer,
 	}
 
@@ -84,14 +93,15 @@ func newMetrics(meter metric.Meter, tracer trace.Tracer, controller *Controller)
 		if controller == nil {
 			return nil
 		}
-		active, countdown, ready, ineligible, totalConnections := controller.metricSnapshot()
+		active, countdown, ready, ineligible, totalConnections, inFlight := controller.metricSnapshot()
 		observer.ObserveInt64(m.trackedInstancesGauge, int64(active), metric.WithAttributes(attribute.String("phase", "active")))
 		observer.ObserveInt64(m.trackedInstancesGauge, int64(countdown), metric.WithAttributes(attribute.String("phase", "idle_countdown")))
 		observer.ObserveInt64(m.trackedInstancesGauge, int64(ready), metric.WithAttributes(attribute.String("phase", "ready_for_standby")))
 		observer.ObserveInt64(m.trackedInstancesGauge, int64(ineligible), metric.WithAttributes(attribute.String("phase", "ineligible")))
 		observer.ObserveInt64(m.activeConnectionsGauge, int64(totalConnections))
+		observer.ObserveInt64(m.standbyInFlightGauge, int64(inFlight))
 		return nil
-	}, trackedInstancesGauge, activeConnectionsGauge)
+	}, trackedInstancesGauge, activeConnectionsGauge, standbyInFlightGauge)
 
 	return m
 }
@@ -137,11 +147,12 @@ func (c *Controller) recordObserverError(operation string) {
 	c.recordControllerError(operation)
 }
 
-func (c *Controller) metricSnapshot() (active, countdown, ready, ineligible, totalConnections int) {
+func (c *Controller) metricSnapshot() (active, countdown, ready, ineligible, totalConnections, standbyInFlight int) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	now := c.now().UTC()
+	standbyInFlight = c.standbyInFlight
 	for _, state := range c.states {
 		if state.compiledPolicy == nil {
 			ineligible++

--- a/lib/providers/auto_standby_linux.go
+++ b/lib/providers/auto_standby_linux.go
@@ -4,8 +4,11 @@ package providers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 
+	"github.com/kernel/hypeman/cmd/api/config"
 	"github.com/kernel/hypeman/lib/autostandby"
 	"github.com/kernel/hypeman/lib/instances"
 	"go.opentelemetry.io/otel"
@@ -51,6 +54,9 @@ func (s autoStandbyInstanceStore) ListInstances(ctx context.Context) ([]autostan
 
 func (s autoStandbyInstanceStore) StandbyInstance(ctx context.Context, id string) error {
 	_, err := s.manager.StandbyInstance(ctx, id, instances.StandbyInstanceRequest{})
+	if errors.Is(err, instances.ErrNotFound) {
+		return fmt.Errorf("%w: %v", autostandby.ErrInstanceNotFound, err)
+	}
 	return err
 }
 
@@ -97,7 +103,7 @@ func toAutoStandbyInstance(inst *instances.Instance) *autostandby.Instance {
 }
 
 // ProvideAutoStandbyController provides the Linux auto-standby controller.
-func ProvideAutoStandbyController(instanceManager instances.Manager, log *slog.Logger) *autostandby.Controller {
+func ProvideAutoStandbyController(instanceManager instances.Manager, cfg *config.Config, log *slog.Logger) *autostandby.Controller {
 	if instanceManager == nil || log == nil {
 		return nil
 	}
@@ -111,9 +117,10 @@ func ProvideAutoStandbyController(instanceManager instances.Manager, log *slog.L
 		autoStandbyInstanceStore{manager: instanceManager, runtimeManager: runtimeManager},
 		autostandby.NewConntrackSource(),
 		autostandby.ControllerOptions{
-			Log:    log.With("controller", "auto_standby"),
-			Meter:  otel.GetMeterProvider().Meter("hypeman/autostandby"),
-			Tracer: otel.GetTracerProvider().Tracer("hypeman/autostandby"),
+			Log:                   log.With("controller", "auto_standby"),
+			Meter:                 otel.GetMeterProvider().Meter("hypeman/autostandby"),
+			Tracer:                otel.GetTracerProvider().Tracer("hypeman/autostandby"),
+			MaxConcurrentStandbys: cfg.AutoStandby.MaxConcurrent,
 		},
 	)
 }

--- a/lib/providers/auto_standby_unsupported.go
+++ b/lib/providers/auto_standby_unsupported.go
@@ -5,11 +5,12 @@ package providers
 import (
 	"log/slog"
 
+	"github.com/kernel/hypeman/cmd/api/config"
 	"github.com/kernel/hypeman/lib/autostandby"
 	"github.com/kernel/hypeman/lib/instances"
 )
 
 // ProvideAutoStandbyController is unavailable on non-Linux platforms.
-func ProvideAutoStandbyController(instances.Manager, *slog.Logger) *autostandby.Controller {
+func ProvideAutoStandbyController(instances.Manager, *config.Config, *slog.Logger) *autostandby.Controller {
 	return nil
 }


### PR DESCRIPTION
## Problem

The auto-standby controller executes standby operations synchronously inside its single `Run` event loop. A standby pauses the VM and writes its full memory snapshot to disk, which can take fractions of a second per standby.

- standby throughput is capped at one operation at a time per host
- while a standby is running, instance lifecycle events, conntrack events, and other timer fires all queue behind it — idle countdowns for unrelated instances start late
- when many instances go idle together, tail queue wait grows unboundedly, and callers waiting on a `Standby` state transition can time out on instances that are perfectly healthy

A secondary issue: a standby attempt that fails because the instance was deleted re-arms the idle timer and retries forever until the delete event drains through the (congested) loop.

## Change

- `handleStandbyTimer` now marks the instance standby-requested and hands the `StandbyInstance` call to a goroutine gated by a semaphore, so the event loop never blocks on snapshot IO. Follows the same shape as the existing `firecracker_max_concurrent_restores` cap on the restore side.
- New config `auto_standby.max_concurrent` (default 16) bounds concurrent standby operations per host. Demand above the cap queues; `max_concurrent: 1` reproduces the old serialized throughput while still keeping the loop unblocked.
- Inbound activity observed while an attempt is queued clears `standbyRequested`, and the worker re-validates state after acquiring a slot, cancelling the attempt. The same flag deduplicates repeat timer fires for one instance.
- The store adapter translates `instances.ErrNotFound` into `autostandby.ErrInstanceNotFound`; the controller drops tracking state for such instances instead of re-arming the timer.
- `Run` cancels and waits for in-flight workers on exit.
- New gauge `hypeman_auto_standby_standby_in_flight` for observing concurrency; startup log includes the configured cap.

## Testing

- `go test -race ./lib/autostandby/ ./lib/providers/ ./cmd/api/config/` passes. New tests cover: concurrency never exceeds the cap, queued attempts cancelled by inbound activity, duplicate timer fires deduplicate, and not-found errors drop state without re-arming.
- **End-to-end:** `TestAutoStandbyCloudHypervisorActiveInboundTCP` (the manual-only e2e that CI skips, `HYPEMAN_RUN_AUTO_STANDBY_E2E=1`) passes on this branch on a KVM-capable Linux host: a real VM stays `Running` while an inbound TCP connection is open, and reaches `Standby` via the new async worker path ~1.3s after the idle timer fires. Note it runs a single instance, so the semaphore is never contended — concurrency behavior is covered by the unit tests above.
- `go build ./...` passes; wire regenerated via `make generate-wire` (includes a cosmetic identifier rename from the current wire version).
- The `cmd/api/api` integration suite fails in my environment on an image-pull timeout; it fails identically on unmodified `main`, so it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core VM standby timing and concurrency on the control plane; behavior is well-tested but mis-tuned `max_concurrent` or race fixes could affect when instances enter Standby or how load spikes hit disk.
> 
> **Overview**
> **Auto-standby no longer blocks its event loop on memory snapshot IO.** When an idle timer fires, the controller marks the instance standby-requested and dispatches `StandbyInstance` to background workers gated by a semaphore (`standbySlots`), so conntrack, lifecycle events, and other timers keep processing.
> 
> **New server config `auto_standby.max_concurrent`** (default **16**, validated in config load) wires through `ProvideAutoStandbyController` into `ControllerOptions.MaxConcurrentStandbys`. Extra demand queues until a slot frees; startup logging and docs describe the tradeoff between snapshot IO pressure and standby latency.
> 
> **Standby lifecycle and races are tightened:** `standbyExecuting` prevents duplicate workers across resyncs; inbound traffic or reconcile while queued clears `standbyRequested` and workers no-op after acquiring a slot; failed standbys skip re-arming the idle timer when connections became active mid-flight. **`instances.ErrNotFound`** maps to **`autostandby.ErrInstanceNotFound`** so deleted instances drop tracking instead of retrying forever. **`Run`** cancels worker context on exit and waits on `standbyWG`; persist errors during idle refresh log warnings but still arm timers.
> 
> **Observability:** gauges `hypeman_auto_standby_standby_in_flight` and `hypeman_auto_standby_standby_queued` plus expanded unit tests for concurrency, queue cancel, shutdown, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e7cfd33015cbd8b2dc993e03f520caabc2d70d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->