### PR TITLE
Stop in-flight forks from making the source name ambiguous

### DIFF
--- a/lib/instances/query.go
+++ b/lib/instances/query.go
@@ -936,6 +936,12 @@ func (m *manager) findInstanceMetadataByNameOrIDPrefix(idOrName string, minPrefi
 		if err != nil {
 			continue
 		}
+		// A fork clones the source directory before writing its own metadata,
+		// so a directory can briefly hold the source's id and name. Ignore it
+		// until it describes itself, or the source resolves as ambiguous.
+		if meta.Id != id {
+			continue
+		}
 
 		if meta.Name == idOrName {
 			nameMatches++

--- a/lib/instances/resolve_test.go
+++ b/lib/instances/resolve_test.go
@@ -1,0 +1,54 @@
+package instances
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/stretchr/testify/require"
+)
+
+// A fork clones the source directory before writing its own metadata, so a
+// half-built fork directory can hold a copy of the source's metadata. Looking
+// up the source by name must not see that copy as a second instance.
+func TestFindInstanceMetadata_IgnoresDirectoryHoldingAnotherInstancesMetadata(t *testing.T) {
+	t.Parallel()
+	p := paths.New(t.TempDir())
+	mgr := &manager{paths: p}
+
+	source := StoredMetadata{
+		Id:             "source-id",
+		Name:           "browser-seed",
+		Image:          "nginx:latest",
+		CreatedAt:      time.Now(),
+		HypervisorType: hypervisor.TypeFirecracker,
+		DataDir:        p.InstanceDir("source-id"),
+	}
+	write := func(dirID string, stored StoredMetadata) {
+		require.NoError(t, mgr.ensureDirectories(dirID))
+		data, err := json.MarshalIndent(&metadata{StoredMetadata: stored}, "", "  ")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(p.InstanceDir(dirID), instanceMetadataRelPath), data, 0644))
+	}
+
+	write("source-id", source)
+	write("fork-id", source) // fork dir, source's metadata not yet overwritten
+
+	meta, err := mgr.findInstanceMetadataByNameOrIDPrefix("browser-seed", 1)
+	require.NoError(t, err)
+	require.Equal(t, "source-id", meta.Id)
+
+	// The fork's own id still resolves once it describes itself.
+	fork := source
+	fork.Id = "fork-id"
+	fork.Name = "browser-fork"
+	write("fork-id", fork)
+
+	meta, err = mgr.findInstanceMetadataByNameOrIDPrefix("browser-fork", 1)
+	require.NoError(t, err)
+	require.Equal(t, "fork-id", meta.Id)
+}

--- a/lib/instances/snapshot_alias_lock.go
+++ b/lib/instances/snapshot_alias_lock.go
@@ -140,9 +140,13 @@ func (m *manager) cloneGuestDirectoryForFork(ctx context.Context, srcDir, dstDir
 		}
 	}
 
-	copyOptions := forkvm.CopyOptions{}
+	// The caller writes the fork's own metadata right after this, so copying
+	// the source's is both pointless and briefly duplicates its name.
+	copyOptions := forkvm.CopyOptions{
+		SkipRelativePaths: map[string]struct{}{instanceMetadataRelPath: {}},
+	}
 	if shareMemFile {
-		copyOptions.SkipRelativePaths = map[string]struct{}{firecrackerSnapshotMemoryRelPath: {}}
+		copyOptions.SkipRelativePaths[firecrackerSnapshotMemoryRelPath] = struct{}{}
 	}
 	if err := forkvm.CopyGuestDirectoryWithOptions(srcDir, dstDir, copyOptions); err != nil {
 		return err

--- a/lib/instances/storage.go
+++ b/lib/instances/storage.go
@@ -36,6 +36,9 @@ const (
 //       config.json
 //       memory-ranges
 
+// instanceMetadataRelPath is metadata.json relative to an instance directory.
+const instanceMetadataRelPath = "metadata.json"
+
 // metadata wraps StoredMetadata for JSON serialization
 type metadata struct {
 	StoredMetadata


### PR DESCRIPTION
## Problem

Forking by source **name** fails under concurrency. Reproduced with 25 concurrent forks of one standby source: **19 of 50 fork calls returned `409 {"code":"ambiguous","message":"multiple resources match, use full ID"}`**. The same run with the source addressed by ID succeeded 50/50.

## Mechanism

`fork` clones the source's instance directory (`copyForkSourceGuestDirectory` → `cloneGuestDirectoryForFork`) and only afterwards writes the fork's own metadata (`forkMeta.Id` / `forkMeta.Name`). In between, the fork's directory holds a verbatim copy of the source's `metadata.json`, including the source's `Id` and `Name`.

`findInstanceMetadataByNameOrIDPrefix` walks every metadata file and counts name matches, so during that window it sees two instances named `<source>` and returns `ErrAmbiguousName`. Every concurrent fork widens the window, so the wider you fan out, the more lookups of the source fail.

## Fix

- `query.go`: ignore metadata whose `Id` doesn't match the directory it was loaded from. A directory that describes another instance isn't that instance, and this also covers any other path that clones a guest directory.
- `snapshot_alias_lock.go`: skip `metadata.json` in the fork clone. The fork's metadata is written from `forkMeta` moments later, so copying the source's was both the cause of the window and wasted I/O.

+11 non-test lines. No API change, and no behavior change for callers that address instances by ID.

## Tests

- New `lib/instances/resolve_test.go`: a directory holding another instance's metadata must not make that instance's name ambiguous, and the fork's own name still resolves once its metadata is written. Passes.
- `go vet` and `gofmt` clean; the resolver / list / admission / delete unit tests in `lib/instances` pass.
- The fork integration tests (`TestForkCloudHypervisorFromRunning*`) fail in my environment with "Image should be ready after 60 seconds" — they need the root/KVM test environment. I verified they fail identically on a clean checkout, so this change isn't responsible; CI should be the judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)