### PR TITLE
Treat TCP states as active unless the flow is finished

### DIFF
--- a/lib/autostandby/types.go
+++ b/lib/autostandby/types.go
@@ -62,17 +62,24 @@ const (
 	TCPStateRetrans     TCPState = 11
 )
 
-// Active reports whether the TCP state should keep a VM awake. SYN_SENT
-// counts: a client mid-handshake is inbound demand, and a freshly restored
-// guest can take several seconds to answer the SYN it was woken for — going
-// back to standby in that window orphans the connection, since wake-on-traffic
-// does not exist.
+// Active reports whether the TCP state should keep a VM awake. Only states that
+// mean the flow is finished stop counting; everything else is treated as inbound
+// demand, including transient states conntrack reports on a live flow and any
+// state this enum does not name.
+//
+// The asymmetry is deliberate. Wake-on-traffic does not exist, so a flow
+// misjudged as finished is stranded until the client gives up, while a flow
+// misjudged as live only costs idle VM time until the next DESTROY event or
+// reconcile drops it. Enumerating live states instead kept missing them one at a
+// time: SYN_SENT (a client mid-handshake) had to be added separately, and
+// SYN_SENT2 — value 9, named TCPStateListen here — is a simultaneous open that
+// was still classified as finished.
 func (s TCPState) Active() bool {
 	switch s {
-	case TCPStateSynSent, TCPStateSynRecv, TCPStateEstablished, TCPStateFinWait, TCPStateCloseWait, TCPStateLastAck:
-		return true
-	default:
+	case TCPStateNone, TCPStateTimeWait, TCPStateClose:
 		return false
+	default:
+		return true
 	}
 }
 

--- a/lib/autostandby/types_test.go
+++ b/lib/autostandby/types_test.go
@@ -12,3 +12,35 @@ func TestTCPStateConstantsMatchExpectedKernelValues(t *testing.T) {
 	assert.Equal(t, TCPState(10), TCPStateIgnore)
 	assert.Equal(t, TCPState(11), TCPStateRetrans)
 }
+
+func TestActiveOnlyTreatsFinishedFlowsAsIdle(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		state TCPState
+		want  bool
+	}{
+		{"none", TCPStateNone, false},
+		{"time_wait", TCPStateTimeWait, false},
+		{"close", TCPStateClose, false},
+		{"syn_sent", TCPStateSynSent, true},
+		{"syn_recv", TCPStateSynRecv, true},
+		{"established", TCPStateEstablished, true},
+		{"fin_wait", TCPStateFinWait, true},
+		{"close_wait", TCPStateCloseWait, true},
+		{"last_ack", TCPStateLastAck, true},
+		// SYN_SENT2: a simultaneous open is still a client waiting on the guest.
+		{"syn_sent2", TCPStateListen, true},
+		{"ignore", TCPStateIgnore, true},
+		{"retrans", TCPStateRetrans, true},
+		// Anything this enum does not name has to count, or the next state the
+		// kernel reports on a live flow strands it again.
+		{"unnamed", TCPState(12), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.state.Active())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`Active()` enumerated the TCP states that keep a VM awake, so any state it did not list read as idle. That default is the wrong way round for this decision.

Wake-on-traffic does not exist: a standby guest is only restored by a **new** inbound connection. So a live flow misjudged as finished is not slowed down, it is stranded — the guest is suspended underneath it and the client waits until it gives up. A flow misjudged as live only costs idle VM time until the next `DESTROY` event or reconcile drops it. The failure modes are not symmetric, and the default should fall on the survivable side.

Enumerating live states also kept missing them one at a time:

- `SYN_SENT` — a client mid-handshake — had to be added separately in #312.
- `SYN_SENT2` (value 9, named `TCPStateListen` here) is a simultaneous open, still a client waiting on the guest, and was classified as finished.
- Every value the enum does not name fell through to `false`.

## Change

Invert it: only `NONE`, `TIME_WAIT` and `CLOSE` stop counting. Everything else, named or not, counts as inbound demand.

Nothing that previously kept a VM awake stops doing so — the change is one-directional. `TIME_WAIT` stays on the idle side deliberately: counting it would hold VMs awake for the full linger after every connection closes, which is a real cost regression.

## Testing

`go test -race ./lib/autostandby/...` passes. New table test covers every named state plus an unnamed one; it fails against the current allowlist on `syn_sent2`, `ignore`, `retrans` and `unnamed`.

## Note for the reviewer

`TCPStateIgnore = 10` and `TCPStateRetrans = 11` look off by one against the kernel's `tcp_conntrack` enum, where `TCP_CONNTRACK_MAX` occupies 10 and `IGNORE`/`RETRANS`/`UNACK` are 11/12/13. This change makes the misnumbering harmless for live flows — every one of those values now returns `true` either way — but the constants deserve their own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
