### PR TITLE
Keep VMs awake while inbound connections are live

### DIFF
--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -766,6 +766,20 @@ func (c *Controller) executeStandby(ctx context.Context, id string, instanceName
 		c.recordControllerError("standby_preflight")
 		c.log.Warn("auto-standby could not classify inbound connections before standby", "instance_id", id, "instance_name", instanceName, "error", err)
 	}
+	// The table read runs without the lock, so fold in anything the event loop
+	// registered while it was in flight. Committing on the pre-read view would
+	// strand exactly the connection this check exists to protect.
+	c.mu.Lock()
+	if state := c.states[id]; state != nil {
+		for key := range state.activeInbound {
+			if live == nil {
+				live = make(map[ConnectionKey]struct{}, len(state.activeInbound))
+			}
+			live[key] = struct{}{}
+		}
+	}
+	c.mu.Unlock()
+
 	if len(live) > 0 {
 		c.recordStandbyAttempt("aborted_inbound_active")
 		c.log.Info("auto-standby aborted, inbound connection live at standby time", "instance_id", id, "instance_name", instanceName, "active_inbound_connections", len(live))

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -728,6 +728,54 @@ func (c *Controller) executeStandby(ctx context.Context, id string, instanceName
 		c.mu.Unlock()
 	}()
 
+	// activeInbound is built from conntrack events, and armReconcileLocked stops
+	// re-reading the host table once it drains, so nothing has compared that view
+	// against reality since the countdown started. Confirm before pausing:
+	// suspending a guest that still has a live inbound flow strands that flow,
+	// because wake-on-traffic does not exist.
+	conns, err := c.source.ListConnections(ctx)
+	if err != nil {
+		// A host table we cannot read is a transient failure, and suspending
+		// blind is what strands connections. Re-arm and try again next cycle.
+		recordSpanError(span, err)
+		c.recordStandbyAttempt("preflight_error")
+		c.recordControllerError("standby_preflight")
+		c.log.Warn("auto-standby could not read inbound connections before standby, deferring", "instance_id", id, "instance_name", instanceName, "error", err)
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if state := c.states[id]; state != nil {
+			state.standbyRequested = false
+			idleSince := c.now().UTC()
+			state.idleSince = &idleSince
+			c.armTimerLocked(id, state, idleSince)
+		}
+		return
+	}
+
+	live, err := c.matchingInboundConnections(id, conns)
+	if err != nil {
+		// Classification depends on the instance record, not on host state, so
+		// retrying cannot help and blocking standby forever would leak the VM.
+		c.recordControllerError("standby_preflight")
+		c.log.Warn("auto-standby could not classify inbound connections before standby", "instance_id", id, "instance_name", instanceName, "error", err)
+	}
+	if len(live) > 0 {
+		c.recordStandbyAttempt("aborted_inbound_active")
+		c.log.Info("auto-standby aborted, inbound connection live at standby time", "instance_id", id, "instance_name", instanceName, "active_inbound_connections", len(live))
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if state := c.states[id]; state != nil {
+			state.activeInbound = live
+			state.idleSince = nil
+			state.standbyRequested = false
+			c.cancelTimerLocked(state)
+			c.armReconcileLocked(id, state)
+		}
+		return
+	}
+
 	if err := c.store.StandbyInstance(ctx, id); err != nil {
 		recordSpanError(span, err)
 		c.recordStandbyAttempt("error")
@@ -775,6 +823,22 @@ func (c *Controller) executeStandby(ctx context.Context, id string, instanceName
 			c.log.Warn("auto-standby failed to clear runtime after standby", "instance_id", id, "error", err)
 		}
 	}
+}
+
+// matchingInboundConnections returns the flows from conns that match the
+// instance's policy.
+func (c *Controller) matchingInboundConnections(id string, conns []Connection) (map[ConnectionKey]struct{}, error) {
+	c.mu.Lock()
+	state := c.states[id]
+	if state == nil || state.compiledPolicy == nil {
+		c.mu.Unlock()
+		return nil, nil
+	}
+	inst := cloneInstance(state.instance)
+	policy := state.compiledPolicy
+	c.mu.Unlock()
+
+	return matchingConnections(inst, policy, conns)
 }
 
 func (c *Controller) handleActiveReconcile(ctx context.Context, id string) {

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -746,6 +746,12 @@ func (c *Controller) executeStandby(ctx context.Context, id string, instanceName
 		defer c.mu.Unlock()
 		if state := c.states[id]; state != nil {
 			state.standbyRequested = false
+			// The read happens without the lock, so inbound activity can land
+			// while it is in flight. That activity owns the state now; the
+			// reconcile/destroy flow restarts the countdown once it drains.
+			if len(state.activeInbound) > 0 {
+				return
+			}
 			idleSince := c.now().UTC()
 			state.idleSince = &idleSince
 			c.armTimerLocked(id, state, idleSince)

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -1175,3 +1175,48 @@ func TestStandbyDeferralKeepsActivityThatLandedDuringTheRead(t *testing.T) {
 	assert.Nil(t, state.timer)
 	assert.False(t, state.standbyRequested)
 }
+
+// Same unlocked window as the deferral case, but on the path that commits: the
+// table read can come back empty while the event loop registers a connection,
+// and suspending on the pre-read view strands it.
+func TestStandbySkippedWhenActivityLandsDuringTheRead(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-raced-commit", "192.168.100.124", idleSince),
+	})
+	source := &fakeConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	// The host table stays empty; the connection arrives only as an event.
+	source.setOnList(func() {
+		controller.handleConnectionEvent(context.Background(), ConnectionEvent{
+			Type: ConnectionEventNew,
+			Connection: Connection{
+				OriginalSourceIP:        mustAddr("1.2.3.4"),
+				OriginalSourcePort:      50014,
+				OriginalDestinationIP:   mustAddr("192.168.100.124"),
+				OriginalDestinationPort: 8080,
+				TCPState:                TCPStateEstablished,
+			},
+			ObservedAt: idleSince.Add(time.Minute),
+		})
+	})
+
+	controller.handleStandbyTimer(context.Background(), "inst-raced-commit")
+	controller.standbyWG.Wait()
+
+	assert.Empty(t, store.standbyCalls(), "a connection registered during the read must abort the attempt")
+	controller.mu.RLock()
+	defer controller.mu.RUnlock()
+	state := controller.states["inst-raced-commit"]
+	require.NotNil(t, state)
+	assert.Len(t, state.activeInbound, 1)
+	assert.Nil(t, state.idleSince)
+	assert.False(t, state.standbyRequested)
+}

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -90,15 +90,31 @@ type fakeConnectionSource struct {
 	connections []Connection
 	listErr     error
 	openErr     error
+	onList      func()
 }
 
 func (f *fakeConnectionSource) ListConnections(context.Context) ([]Connection, error) {
+	f.mu.Lock()
+	onList := f.onList
+	f.mu.Unlock()
+	// Runs while the caller holds no lock, so a test can land a conntrack event
+	// mid-read the way the controller's event loop would.
+	if onList != nil {
+		onList()
+	}
+
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
 	return append([]Connection(nil), f.connections...), nil
+}
+
+func (f *fakeConnectionSource) setOnList(fn func()) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.onList = fn
 }
 
 func (f *fakeConnectionSource) setConnections(conns ...Connection) {
@@ -1112,4 +1128,50 @@ func TestStandbyProceedsWhenHostTableAgreesInstanceIsIdle(t *testing.T) {
 	controller.standbyWG.Wait()
 
 	assert.Equal(t, []string{"inst-quiet"}, store.standbyCalls())
+}
+
+// The pre-suspend read happens without the controller lock, so a conntrack event
+// can register a connection while it is in flight. Deferring must not then
+// overwrite that fresh activity with a new idle countdown.
+func TestStandbyDeferralKeepsActivityThatLandedDuringTheRead(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-raced-read", "192.168.100.123", idleSince),
+	})
+	source := &fakeConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	source.setListErr(errors.New("conntrack permission denied"))
+	source.setOnList(func() {
+		controller.handleConnectionEvent(context.Background(), ConnectionEvent{
+			Type: ConnectionEventNew,
+			Connection: Connection{
+				OriginalSourceIP:        mustAddr("1.2.3.4"),
+				OriginalSourcePort:      50013,
+				OriginalDestinationIP:   mustAddr("192.168.100.123"),
+				OriginalDestinationPort: 8080,
+				TCPState:                TCPStateEstablished,
+			},
+			ObservedAt: idleSince.Add(time.Minute),
+		})
+	})
+
+	controller.handleStandbyTimer(context.Background(), "inst-raced-read")
+	controller.standbyWG.Wait()
+
+	assert.Empty(t, store.standbyCalls())
+	controller.mu.RLock()
+	defer controller.mu.RUnlock()
+	state := controller.states["inst-raced-read"]
+	require.NotNil(t, state)
+	assert.Len(t, state.activeInbound, 1, "activity that landed during the read must survive")
+	assert.Nil(t, state.idleSince, "deferring must not restart the countdown against a live connection")
+	assert.Nil(t, state.timer)
+	assert.False(t, state.standbyRequested)
 }

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -86,16 +86,31 @@ func (f *fakeInstanceStore) SubscribeInstanceEvents() (<-chan InstanceEvent, fun
 }
 
 type fakeConnectionSource struct {
+	mu          sync.Mutex
 	connections []Connection
 	listErr     error
 	openErr     error
 }
 
 func (f *fakeConnectionSource) ListConnections(context.Context) ([]Connection, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
 	return append([]Connection(nil), f.connections...), nil
+}
+
+func (f *fakeConnectionSource) setConnections(conns ...Connection) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.connections = append([]Connection(nil), conns...)
+}
+
+func (f *fakeConnectionSource) setListErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listErr = err
 }
 
 func (f *fakeConnectionSource) OpenStream(context.Context) (ConnectionStream, error) {
@@ -1006,4 +1021,95 @@ func TestRefreshPersistFailureStillArmsIdleTimer(t *testing.T) {
 	assert.NotNil(t, state.nextStandbyAt)
 	assert.NotNil(t, state.idleSince)
 	controller.mu.RUnlock()
+}
+
+// The tracked connection view is event-driven, and the reconcile that re-reads
+// the host table is cancelled once it drains, so a missed or misread conntrack
+// event leaves it empty while the client is still attached. Standby has to
+// confirm against the host table rather than trust that view.
+func TestStandbySkippedWhenConntrackStillShowsLiveInboundConnection(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-stale", "192.168.100.120", idleSince),
+	})
+	source := &fakeConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.mu.RLock()
+	require.Empty(t, controller.states["inst-stale"].activeInbound)
+	controller.mu.RUnlock()
+
+	source.setConnections(Connection{
+		OriginalSourceIP:        mustAddr("1.2.3.4"),
+		OriginalSourcePort:      50010,
+		OriginalDestinationIP:   mustAddr("192.168.100.120"),
+		OriginalDestinationPort: 8080,
+		TCPState:                TCPStateEstablished,
+	})
+
+	controller.handleStandbyTimer(context.Background(), "inst-stale")
+	controller.standbyWG.Wait()
+
+	assert.Empty(t, store.standbyCalls(), "a guest with a live inbound flow must not be suspended")
+	controller.mu.RLock()
+	defer controller.mu.RUnlock()
+	state := controller.states["inst-stale"]
+	require.NotNil(t, state)
+	assert.Len(t, state.activeInbound, 1)
+	assert.False(t, state.standbyRequested)
+	assert.Nil(t, state.idleSince)
+}
+
+func TestStandbyDeferredWhenConnectionListUnavailable(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-unreadable", "192.168.100.121", idleSince),
+	})
+	source := &fakeConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+	source.setListErr(errors.New("conntrack permission denied"))
+
+	controller.handleStandbyTimer(context.Background(), "inst-unreadable")
+	controller.standbyWG.Wait()
+
+	assert.Empty(t, store.standbyCalls(), "suspending blind is what strands connections")
+	controller.mu.RLock()
+	defer controller.mu.RUnlock()
+	state := controller.states["inst-unreadable"]
+	require.NotNil(t, state)
+	assert.False(t, state.standbyRequested)
+	// Re-armed rather than dropped, so the next cycle retries.
+	assert.NotNil(t, state.idleSince)
+	assert.NotNil(t, state.timer)
+}
+
+func TestStandbyProceedsWhenHostTableAgreesInstanceIsIdle(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	store := newFakeInstanceStore([]Instance{
+		idleTestInstance("inst-quiet", "192.168.100.122", idleSince),
+	})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), "inst-quiet")
+	controller.standbyWG.Wait()
+
+	assert.Equal(t, []string{"inst-quiet"}, store.standbyCalls())
 }

--- a/lib/autostandby/types.go
+++ b/lib/autostandby/types.go
@@ -62,17 +62,24 @@ const (
 	TCPStateRetrans     TCPState = 11
 )
 
-// Active reports whether the TCP state should keep a VM awake. SYN_SENT
-// counts: a client mid-handshake is inbound demand, and a freshly restored
-// guest can take several seconds to answer the SYN it was woken for — going
-// back to standby in that window orphans the connection, since wake-on-traffic
-// does not exist.
+// Active reports whether the TCP state should keep a VM awake. Only states that
+// mean the flow is finished stop counting; everything else is treated as inbound
+// demand, including transient states conntrack reports on a live flow and any
+// state this enum does not name.
+//
+// The asymmetry is deliberate. Wake-on-traffic does not exist, so a flow
+// misjudged as finished is stranded until the client gives up, while a flow
+// misjudged as live only costs idle VM time until the next DESTROY event or
+// reconcile drops it. Enumerating live states instead kept missing them one at a
+// time: SYN_SENT (a client mid-handshake) had to be added separately, and
+// SYN_SENT2 — value 9, named TCPStateListen here — is a simultaneous open that
+// was still classified as finished.
 func (s TCPState) Active() bool {
 	switch s {
-	case TCPStateSynSent, TCPStateSynRecv, TCPStateEstablished, TCPStateFinWait, TCPStateCloseWait, TCPStateLastAck:
-		return true
-	default:
+	case TCPStateNone, TCPStateTimeWait, TCPStateClose:
 		return false
+	default:
+		return true
 	}
 }
 

--- a/lib/autostandby/types_test.go
+++ b/lib/autostandby/types_test.go
@@ -12,3 +12,35 @@ func TestTCPStateConstantsMatchExpectedKernelValues(t *testing.T) {
 	assert.Equal(t, TCPState(10), TCPStateIgnore)
 	assert.Equal(t, TCPState(11), TCPStateRetrans)
 }
+
+func TestActiveOnlyTreatsFinishedFlowsAsIdle(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		state TCPState
+		want  bool
+	}{
+		{"none", TCPStateNone, false},
+		{"time_wait", TCPStateTimeWait, false},
+		{"close", TCPStateClose, false},
+		{"syn_sent", TCPStateSynSent, true},
+		{"syn_recv", TCPStateSynRecv, true},
+		{"established", TCPStateEstablished, true},
+		{"fin_wait", TCPStateFinWait, true},
+		{"close_wait", TCPStateCloseWait, true},
+		{"last_ack", TCPStateLastAck, true},
+		// SYN_SENT2: a simultaneous open is still a client waiting on the guest.
+		{"syn_sent2", TCPStateListen, true},
+		{"ignore", TCPStateIgnore, true},
+		{"retrans", TCPStateRetrans, true},
+		// Anything this enum does not name has to count, or the next state the
+		// kernel reports on a live flow strands it again.
+		{"unnamed", TCPState(12), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.state.Active())
+		})
+	}
+}


### PR DESCRIPTION
## What breaks

Standby pauses a VM, snapshots it, and deletes the VMM (`instances.StandbyInstance`: "pause, snapshot, delete VMM"). A standby guest is only restored by a **new** inbound connection, so a connection that is already open when this happens is not slowed down — it is left attached to nothing, with no response, no `close` and no `error`, until the client gives up.

Production trace, customer session on `prod-yul-hypeman-4`:

```
07:29:12.688  restoring instance from standby        ← handoff
07:29:13.529  inbound activity observed (1 conn)     ← their connection registers
07:29:13.569  idle countdown started                 ← evicted 38ms later
   ...6.8s, client sending ~7 CDP commands, zero activity events...
07:29:20.353  standby timer fired
07:29:20.353  putting instance in standby
07:29:21.077  their Target.getTargets hangs          ← 724ms into the pause
```

The connection registers, is dropped from the tracked set 38ms later, and nothing re-registers it: `handleConnectionEvent` only ever *adds* on a conntrack `NEW`, and an established connection that has been evicted produces no further `NEW`. The 6s timer runs unopposed.

## Changes

**1. `Active()` becomes a denylist** (`types.go`). It enumerated the states that keep a VM awake, so anything unlisted read as idle — the wrong default, since a flow misjudged as finished is stranded while one misjudged as live only costs idle VM time until the next `DESTROY` or reconcile drops it. It also kept missing states one at a time: `SYN_SENT` needed #312, and `SYN_SENT2` (value 9, named `TCPStateListen`) is a simultaneous open still classified as finished. Now only `NONE`, `TIME_WAIT` and `CLOSE` stop counting. Nothing that previously kept a VM awake stops doing so; `TIME_WAIT` stays idle deliberately, or VMs would linger awake after every close.

**2. Confirm against conntrack before pausing** (`controller.go`). `executeStandby` trusted `state.activeInbound`, which is fed only by conntrack events — and `armReconcileLocked` cancels the reconcile that re-reads the host table once that view drains, leaving the 5-minute periodic sync against a 6-second timeout. Nothing checked reality between the countdown starting and the snapshot. It now lists connections and aborts if any inbound flow still matches. Read failure defers and re-arms (suspending blind is the outcome being avoided); classification failure logs and proceeds (it depends on the instance record, so retrying cannot help and blocking forever would leak the VM). Reported as `aborted_inbound_active` / `preflight_error`. Cost: one `ListConnections` per standby attempt.

Change 1 fixes the known eviction path. Change 2 does not depend on knowing the path — which matters, because #314 cut conntrack overflows 96% and the customer's next load test still failed at 1 in 657 with zero overflows in the window.

## Conflicts with `hypeship/auto-standby-reset`

That branch adds `POST /instances/{id}/auto-standby/reset` for an atomic reserve-then-connect. It solves the connection-*setup* race from the caller's side; this covers a connection already established and in use, where nobody called reset recently — the trace above had been driving for 7s, so a single reset at connect would not have saved it. Both touch `executeStandby` and `controller_test.go`. Merge order needs a decision.

## Testing

`go test -race ./lib/autostandby/...` passes; builds for linux and darwin. Four new tests:

- `Active()` per TCP state incl. an unnamed one — fails on `syn_sent2`, `ignore`, `retrans`, `unnamed` against the old allowlist
- standby skipped when conntrack still shows a live flow the tracked view lost
- standby deferred and re-armed when the connection list is unreadable
- a genuinely idle instance still reaches standby (regression guard)

All but the last fail with their change removed.

## For the reviewer

`TCPStateIgnore = 10` / `TCPStateRetrans = 11` look off by one against the kernel's `tcp_conntrack` enum, where `TCP_CONNTRACK_MAX` takes 10 and `IGNORE`/`RETRANS`/`UNACK` are 11/12/13. Change 1 makes that harmless for live flows — those values return `true` either way — but the constants want their own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when VMs enter standby (guest lifecycle and connection correctness); behavior is conservative when uncertain (defer/abort rather than suspend), with broad new test coverage.
> 
> **Overview**
> Prevents auto-standby from pausing VMs while clients still have **live inbound TCP flows**, which would strand open connections because standby only restores on *new* traffic.
> 
> **`TCPState.Active()`** is flipped from an allowlist to a **denylist**: only `NONE`, `TIME_WAIT`, and `CLOSE` stop counting as activity. States like simultaneous-open (`TCPStateListen` / SYN_SENT2), `IGNORE`, `RETRANS`, and unknown kernel values now keep the guest awake so misclassified “finished” flows cannot trigger standby.
> 
> **`executeStandby`** adds a **conntrack preflight** before `StandbyInstance`: it lists host connections, classifies inbound matches, and **merges** any `activeInbound` keys registered while the read runs unlocked. Live flows **abort** standby (`aborted_inbound_active`), re-arm reconcile, and clear the idle countdown; **list failures defer** and re-arm the timer (`preflight_error`) instead of suspending blind; classification errors log and proceed so VMs do not leak.
> 
> Tests cover stale tracked state vs host table, unreadable lists, idle regression, and races during the preflight read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1a73406008722e648b14c805ab5361763cbe391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->