### PR TITLE
Confirm conntrack state before auto-standby

### DIFF
--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -739,8 +739,9 @@ func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
 		c.mu.Unlock()
 		return
 	}
-	state.timer = nil
-	state.nextStandbyAt = nil
+	// Cancelled rather than dropped: the confirmation released the lock, so a
+	// failing standby worker may have armed a replacement timer in the meantime.
+	c.cancelTimerLocked(state)
 	state.standbyRequested = true
 	instanceName := state.instance.Name
 	c.mu.Unlock()

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -678,7 +678,9 @@ func (c *Controller) confirmIdleBeforeStandby(ctx context.Context, id string) bo
 	defer c.mu.Unlock()
 
 	state := c.states[id]
-	if state == nil || state.compiledPolicy == nil {
+	// Activity can land between the timer firing and this check, and it already
+	// owns idleSince and the reconcile loop; the paths below must not clobber it.
+	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 {
 		return false
 	}
 

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -784,6 +784,20 @@ func (c *Controller) confirmIdleBeforeStandby(ctx context.Context, id string) bo
 	return false
 }
 
+// standbyDeadlineElapsedLocked reports whether the armed standby deadline has
+// actually passed. A timer callback that fired before a re-arm (hold,
+// destroy-event restart) still delivers its id, so re-arm on the way out to
+// replace the spent timer, including when a backward clock step makes a
+// monotonic timer fire early by wall clock.
+func (c *Controller) standbyDeadlineElapsedLocked(id string, state *controllerState) bool {
+	now := c.now().UTC()
+	if state.nextStandbyAt == nil || now.Before(*state.nextStandbyAt) {
+		c.armTimerLocked(id, state, now)
+		return false
+	}
+	return true
+}
+
 // handleStandbyTimer marks the instance as standby-requested and hands the
 // standby call to a bounded worker so the event loop never blocks on snapshot
 // IO. Inbound activity observed while the work is queued clears
@@ -795,13 +809,7 @@ func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
 		c.mu.Unlock()
 		return
 	}
-	// A timer callback that fired before a re-arm (hold, destroy-event
-	// restart) still delivers its id; only act once the current deadline has
-	// actually elapsed. Re-arm on the way out so the spent timer is always
-	// replaced, including when a backward clock step makes a monotonic timer
-	// fire early by wall clock.
-	if state.nextStandbyAt == nil || c.now().UTC().Before(*state.nextStandbyAt) {
-		c.armTimerLocked(id, state, c.now().UTC())
+	if !c.standbyDeadlineElapsedLocked(id, state) {
 		c.mu.Unlock()
 		return
 	}
@@ -817,8 +825,14 @@ func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
 		c.mu.Unlock()
 		return
 	}
-	// Cancelled rather than dropped: the confirmation released the lock, so a
-	// failing standby worker may have armed a replacement timer in the meantime.
+	// Checked again because the confirmation released the lock: a hold placed
+	// while it ran pushes the deadline back out.
+	if !c.standbyDeadlineElapsedLocked(id, state) {
+		c.mu.Unlock()
+		return
+	}
+	// Cancelled rather than dropped: a failing standby worker may have armed a
+	// replacement timer during the confirmation.
 	c.cancelTimerLocked(state)
 	state.standbyRequested = true
 	instanceName := state.instance.Name

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -242,7 +242,6 @@ func (c *Controller) Run(ctx context.Context) error {
 				_ = stream.Close()
 			}
 			stream = replacement
-			c.setObserverConnected(true)
 			log.Info("auto-standby conntrack subscription restored")
 			// Events published during the outage are gone, so reseed from the
 			// conntrack table instead of waiting for the next snapshot sync.
@@ -250,6 +249,10 @@ func (c *Controller) Run(ctx context.Context) error {
 				c.recordControllerError("startup_resync")
 				log.Warn("auto-standby resync after subscription restore failed", "error", err)
 			}
+			// Marked connected after the reseed: a failed conntrack dump inside
+			// it reports an observer error, which would leave the restored
+			// subscription looking dead until the next reconnect.
+			c.setObserverConnected(true)
 		case err := <-streamErrors:
 			if err == nil {
 				continue
@@ -662,21 +665,21 @@ func (c *Controller) handleConnectionEvent(ctx context.Context, event Connection
 	}
 }
 
-// handleStandbyTimer marks the instance as standby-requested and hands the
-// standby call to a bounded worker so the event loop never blocks on snapshot
-// IO. Inbound activity observed while the work is queued clears
-// standbyRequested and cancels the attempt.
-func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
-	// activeInbound is built from the conntrack event stream, so a dropped NEW
-	// event leaves it empty while the guest still holds a live connection. The
-	// table is authoritative, so confirm against it before taking the VM away.
+// confirmIdleBeforeStandby re-reads the conntrack table and reports whether the
+// instance is still idle. activeInbound is built from the event stream, so a
+// dropped NEW event leaves it empty while the guest holds a live connection; the
+// table is authoritative. When the instance turns out to be busy the reconcile
+// loop takes the state back over, and when the table cannot be read the instance
+// is treated as busy so an unconfirmed guest is never taken away.
+func (c *Controller) confirmIdleBeforeStandby(ctx context.Context, id string) bool {
 	conns, listErr := c.source.ListConnections(ctx)
 
 	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	state := c.states[id]
-	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || state.standbyRequested || state.standbyExecuting {
-		c.mu.Unlock()
-		return
+	if state == nil || state.compiledPolicy == nil {
+		return false
 	}
 
 	var activeSet map[ConnectionKey]struct{}
@@ -685,26 +688,55 @@ func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
 		activeSet, err = matchingConnections(state.instance, state.compiledPolicy, conns)
 	}
 	if err != nil {
-		// An unconfirmed instance is treated as busy: restart the countdown
-		// rather than risk standby while a connection is open.
 		idleSince := c.now().UTC()
 		state.idleSince = &idleSince
 		c.armTimerLocked(id, state, idleSince)
-		c.mu.Unlock()
+		if persistErr := c.persistRuntime(ctx, id, &Runtime{
+			IdleSince:             cloneTimePtr(state.idleSince),
+			LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
+		}); persistErr != nil {
+			c.recordControllerError("persist_runtime")
+			c.log.Warn("auto-standby failed to persist runtime after unconfirmed standby", "instance_id", id, "error", persistErr)
+		}
 		c.recordControllerError("standby_confirm")
 		c.log.Warn("auto-standby could not confirm idle before standby", "instance_id", id, "error", err)
-		return
+		return false
 	}
-	if len(activeSet) > 0 {
-		state.activeInbound = activeSet
-		state.idleSince = nil
-		c.cancelTimerLocked(state)
-		c.armReconcileLocked(id, state)
-		c.mu.Unlock()
-		c.log.Info("auto-standby skipped standby, conntrack still reports inbound connections", "instance_id", id, "active_inbound_connections", len(activeSet))
+	if len(activeSet) == 0 {
+		return true
+	}
+
+	now := c.now().UTC()
+	state.activeInbound = activeSet
+	state.idleSince = nil
+	state.lastInboundAt = &now
+	c.cancelTimerLocked(state)
+	c.armReconcileLocked(id, state)
+	if err := c.persistRuntime(ctx, id, &Runtime{
+		LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
+	}); err != nil {
+		c.recordControllerError("persist_runtime")
+		c.log.Warn("auto-standby failed to persist runtime after standby confirmation found connections", "instance_id", id, "error", err)
+	}
+	c.log.Info("auto-standby skipped standby, conntrack still reports inbound connections", "instance_id", id, "active_inbound_connections", len(activeSet))
+	return false
+}
+
+// handleStandbyTimer marks the instance as standby-requested and hands the
+// standby call to a bounded worker so the event loop never blocks on snapshot
+// IO. Inbound activity observed while the work is queued clears
+// standbyRequested and cancels the attempt.
+func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
+	if !c.confirmIdleBeforeStandby(ctx, id) {
 		return
 	}
 
+	c.mu.Lock()
+	state := c.states[id]
+	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || state.standbyRequested || state.standbyExecuting {
+		c.mu.Unlock()
+		return
+	}
 	state.timer = nil
 	state.nextStandbyAt = nil
 	state.standbyRequested = true

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -244,6 +244,12 @@ func (c *Controller) Run(ctx context.Context) error {
 			stream = replacement
 			c.setObserverConnected(true)
 			log.Info("auto-standby conntrack subscription restored")
+			// Events published during the outage are gone, so reseed from the
+			// conntrack table instead of waiting for the next snapshot sync.
+			if err := c.startupResync(ctx); err != nil {
+				c.recordControllerError("startup_resync")
+				log.Warn("auto-standby resync after subscription restore failed", "error", err)
+			}
 		case err := <-streamErrors:
 			if err == nil {
 				continue
@@ -661,12 +667,44 @@ func (c *Controller) handleConnectionEvent(ctx context.Context, event Connection
 // IO. Inbound activity observed while the work is queued clears
 // standbyRequested and cancels the attempt.
 func (c *Controller) handleStandbyTimer(ctx context.Context, id string) {
+	// activeInbound is built from the conntrack event stream, so a dropped NEW
+	// event leaves it empty while the guest still holds a live connection. The
+	// table is authoritative, so confirm against it before taking the VM away.
+	conns, listErr := c.source.ListConnections(ctx)
+
 	c.mu.Lock()
 	state := c.states[id]
 	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 || state.standbyRequested || state.standbyExecuting {
 		c.mu.Unlock()
 		return
 	}
+
+	var activeSet map[ConnectionKey]struct{}
+	err := listErr
+	if err == nil {
+		activeSet, err = matchingConnections(state.instance, state.compiledPolicy, conns)
+	}
+	if err != nil {
+		// An unconfirmed instance is treated as busy: restart the countdown
+		// rather than risk standby while a connection is open.
+		idleSince := c.now().UTC()
+		state.idleSince = &idleSince
+		c.armTimerLocked(id, state, idleSince)
+		c.mu.Unlock()
+		c.recordControllerError("standby_confirm")
+		c.log.Warn("auto-standby could not confirm idle before standby", "instance_id", id, "error", err)
+		return
+	}
+	if len(activeSet) > 0 {
+		state.activeInbound = activeSet
+		state.idleSince = nil
+		c.cancelTimerLocked(state)
+		c.armReconcileLocked(id, state)
+		c.mu.Unlock()
+		c.log.Info("auto-standby skipped standby, conntrack still reports inbound connections", "instance_id", id, "active_inbound_connections", len(activeSet))
+		return
+	}
+
 	state.timer = nil
 	state.nextStandbyAt = nil
 	state.standbyRequested = true

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -655,6 +655,8 @@ func TestHandleStandbyTimerSkipsStandbyWhenConntrackReportsConnection(t *testing
 	controller.standbyWG.Wait()
 
 	assert.Empty(t, store.standbyCalls())
+	require.NotNil(t, store.persistedRuntime["inst-missed-event"])
+	assert.Nil(t, store.persistedRuntime["inst-missed-event"].IdleSince)
 
 	controller.mu.RLock()
 	state := controller.states["inst-missed-event"]
@@ -687,6 +689,9 @@ func TestHandleStandbyTimerRearmsCountdownWhenConfirmationFails(t *testing.T) {
 	controller.standbyWG.Wait()
 
 	assert.Empty(t, store.standbyCalls())
+	require.NotNil(t, store.persistedRuntime["inst-confirm-fail"])
+	require.NotNil(t, store.persistedRuntime["inst-confirm-fail"].IdleSince)
+	assert.Equal(t, now, *store.persistedRuntime["inst-confirm-fail"].IdleSince)
 
 	controller.mu.RLock()
 	state := controller.states["inst-confirm-fail"]
@@ -743,6 +748,44 @@ func TestStreamRestoreResyncsFromConntrackTable(t *testing.T) {
 	require.NoError(t, <-done)
 }
 
+func TestStreamRestoreKeepsObserverConnectedWhenResyncFails(t *testing.T) {
+	t.Parallel()
+
+	inst := Instance{
+		ID:             "inst-restore-degraded",
+		Name:           "inst-restore-degraded",
+		State:          StateRunning,
+		NetworkEnabled: true,
+		IP:             "192.168.100.66",
+		AutoStandby:    &Policy{Enabled: true, IdleTimeout: "1m"},
+	}
+	store := newFakeInstanceStore([]Instance{inst})
+	source := &restoreConnectionSource{streams: make(chan *fakeConnectionStream, 4)}
+	controller := NewController(store, source, ControllerOptions{
+		ReconnectDelay: time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- controller.Run(ctx) }()
+
+	stream := <-source.streams
+	listsBeforeRestore := source.listCalls()
+
+	source.setListErr(errors.New("conntrack dump failed"))
+	stream.errs <- errors.New("recv conntrack events: no buffer space available")
+
+	// The reseed after the restore fails, but the subscription itself is live,
+	// so the instance must not be left reporting an observer error.
+	require.Eventually(t, func() bool {
+		return source.listCalls() > listsBeforeRestore && controller.Describe(inst).Status != StatusError
+	}, time.Second, 5*time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
 func mustAddr(raw string) netip.Addr {
 	return netip.MustParseAddr(raw)
 }
@@ -752,12 +795,18 @@ func mustAddr(raw string) netip.Addr {
 type restoreConnectionSource struct {
 	mu          sync.Mutex
 	connections []Connection
+	listErr     error
+	lists       int
 	streams     chan *fakeConnectionStream
 }
 
 func (s *restoreConnectionSource) ListConnections(context.Context) ([]Connection, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.lists++
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
 	return append([]Connection(nil), s.connections...), nil
 }
 
@@ -765,6 +814,18 @@ func (s *restoreConnectionSource) setConnections(conns []Connection) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.connections = conns
+}
+
+func (s *restoreConnectionSource) setListErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listErr = err
+}
+
+func (s *restoreConnectionSource) listCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lists
 }
 
 func (s *restoreConnectionSource) OpenStream(context.Context) (ConnectionStream, error) {

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -748,7 +748,7 @@ func TestHandleStandbyTimerKeepsActiveStateWhenConfirmationFails(t *testing.T) {
 	controller.mu.RUnlock()
 }
 
-func TestHandleStandbyTimerStopsTimerArmedDuringConfirmation(t *testing.T) {
+func TestHandleStandbyTimerAbortsWhenTimerRearmedDuringConfirmation(t *testing.T) {
 	t.Parallel()
 
 	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
@@ -762,7 +762,7 @@ func TestHandleStandbyTimerStopsTimerArmedDuringConfirmation(t *testing.T) {
 
 	require.NoError(t, controller.startupResync(context.Background()))
 
-	// A standby worker failing mid-confirmation re-arms the idle timer, the same
+	// A standby worker failing mid-confirmation restarts the countdown, the same
 	// way executeStandby's failure path does.
 	var rearmed *time.Timer
 	source.hook = func() {
@@ -777,9 +777,46 @@ func TestHandleStandbyTimerStopsTimerArmedDuringConfirmation(t *testing.T) {
 	controller.handleStandbyTimer(context.Background(), "inst-confirm-rearm")
 	controller.standbyWG.Wait()
 
-	require.Equal(t, []string{"inst-confirm-rearm"}, store.standbyCalls())
+	assert.Empty(t, store.standbyCalls())
 	require.NotNil(t, rearmed)
-	assert.False(t, rearmed.Stop(), "timer armed during confirmation should have been stopped, not orphaned")
+	assert.False(t, rearmed.Stop(), "the timer armed during confirmation should have been replaced, not left running")
+
+	status := controller.Describe(inst)
+	require.NotNil(t, status.NextStandbyAt)
+	assert.Equal(t, now.Add(time.Minute), *status.NextStandbyAt)
+}
+
+func TestHandleStandbyTimerAbortsWhenHoldPlacedDuringConfirmation(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	now := idleSince.Add(time.Minute)
+	inst := idleTestInstance("inst-hold-race", "192.168.100.69", idleSince)
+	store := newFakeInstanceStore([]Instance{inst})
+	source := &hookedConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	// The hold lands while the confirmation dump is in flight, after the timer
+	// delivery already passed the deadline check.
+	source.hook = func() {
+		_, err := controller.HoldStandby(context.Background(), inst)
+		require.NoError(t, err)
+	}
+
+	controller.handleStandbyTimer(context.Background(), "inst-hold-race")
+	controller.standbyWG.Wait()
+
+	assert.Empty(t, store.standbyCalls())
+
+	status := controller.Describe(inst)
+	require.NotNil(t, status.HoldUntil)
+	assert.Equal(t, now.Add(time.Minute), *status.HoldUntil)
+	require.NotNil(t, status.NextStandbyAt)
+	assert.Equal(t, now.Add(time.Minute), *status.NextStandbyAt)
 }
 
 func TestStreamRestoreResyncsFromConntrackTable(t *testing.T) {

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -748,6 +748,40 @@ func TestHandleStandbyTimerKeepsActiveStateWhenConfirmationFails(t *testing.T) {
 	controller.mu.RUnlock()
 }
 
+func TestHandleStandbyTimerStopsTimerArmedDuringConfirmation(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	now := idleSince.Add(time.Minute)
+	inst := idleTestInstance("inst-confirm-rearm", "192.168.100.68", idleSince)
+	store := newFakeInstanceStore([]Instance{inst})
+	source := &hookedConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	// A standby worker failing mid-confirmation re-arms the idle timer, the same
+	// way executeStandby's failure path does.
+	var rearmed *time.Timer
+	source.hook = func() {
+		controller.mu.Lock()
+		defer controller.mu.Unlock()
+		state := controller.states["inst-confirm-rearm"]
+		state.idleSince = &now
+		controller.armTimerLocked("inst-confirm-rearm", state, now)
+		rearmed = state.timer
+	}
+
+	controller.handleStandbyTimer(context.Background(), "inst-confirm-rearm")
+	controller.standbyWG.Wait()
+
+	require.Equal(t, []string{"inst-confirm-rearm"}, store.standbyCalls())
+	require.NotNil(t, rearmed)
+	assert.False(t, rearmed.Stop(), "timer armed during confirmation should have been stopped, not orphaned")
+}
+
 func TestStreamRestoreResyncsFromConntrackTable(t *testing.T) {
 	t.Parallel()
 
@@ -832,6 +866,26 @@ func TestStreamRestoreKeepsObserverConnectedWhenResyncFails(t *testing.T) {
 
 func mustAddr(raw string) netip.Addr {
 	return netip.MustParseAddr(raw)
+}
+
+// hookedConnectionSource runs a callback inside ListConnections so a test can
+// mutate controller state while a conntrack dump is in flight.
+type hookedConnectionSource struct {
+	hook func()
+}
+
+func (s *hookedConnectionSource) ListConnections(context.Context) ([]Connection, error) {
+	if s.hook != nil {
+		s.hook()
+	}
+	return nil, nil
+}
+
+func (s *hookedConnectionSource) OpenStream(context.Context) (ConnectionStream, error) {
+	return &fakeConnectionStream{
+		events: make(chan ConnectionEvent),
+		errs:   make(chan error),
+	}, nil
 }
 
 // restoreConnectionSource hands out the streams it creates so a test can fail

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -628,8 +628,152 @@ func TestHandleStandbyTimerFailureRearmsIdleCountdown(t *testing.T) {
 	controller.mu.RUnlock()
 }
 
+func TestHandleStandbyTimerSkipsStandbyWhenConntrackReportsConnection(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	inst := idleTestInstance("inst-missed-event", "192.168.100.63", idleSince)
+	store := newFakeInstanceStore([]Instance{inst})
+	source := &fakeConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now: func() time.Time { return idleSince.Add(time.Minute) },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	// The NEW event for this connection never reached the controller, so only
+	// the conntrack table knows the instance is busy.
+	source.connections = []Connection{{
+		OriginalSourceIP:        mustAddr("1.2.3.4"),
+		OriginalSourcePort:      50100,
+		OriginalDestinationIP:   mustAddr("192.168.100.63"),
+		OriginalDestinationPort: 8080,
+		TCPState:                TCPStateEstablished,
+	}}
+
+	controller.handleStandbyTimer(context.Background(), "inst-missed-event")
+	controller.standbyWG.Wait()
+
+	assert.Empty(t, store.standbyCalls())
+
+	controller.mu.RLock()
+	state := controller.states["inst-missed-event"]
+	require.NotNil(t, state)
+	assert.Len(t, state.activeInbound, 1)
+	assert.Nil(t, state.idleSince)
+	assert.Nil(t, state.timer)
+	assert.NotNil(t, state.reconcileTimer)
+	assert.False(t, state.standbyRequested)
+	controller.mu.RUnlock()
+}
+
+func TestHandleStandbyTimerRearmsCountdownWhenConfirmationFails(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	now := idleSince.Add(time.Minute)
+	inst := idleTestInstance("inst-confirm-fail", "192.168.100.64", idleSince)
+	store := newFakeInstanceStore([]Instance{inst})
+	source := &fakeConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	source.listErr = errors.New("conntrack dump failed")
+
+	controller.handleStandbyTimer(context.Background(), "inst-confirm-fail")
+	controller.standbyWG.Wait()
+
+	assert.Empty(t, store.standbyCalls())
+
+	controller.mu.RLock()
+	state := controller.states["inst-confirm-fail"]
+	require.NotNil(t, state)
+	assert.False(t, state.standbyRequested)
+	require.NotNil(t, state.idleSince)
+	assert.Equal(t, now, *state.idleSince)
+	require.NotNil(t, state.nextStandbyAt)
+	assert.Equal(t, now.Add(time.Minute), *state.nextStandbyAt)
+	controller.mu.RUnlock()
+}
+
+func TestStreamRestoreResyncsFromConntrackTable(t *testing.T) {
+	t.Parallel()
+
+	inst := Instance{
+		ID:             "inst-restore",
+		Name:           "inst-restore",
+		State:          StateRunning,
+		NetworkEnabled: true,
+		IP:             "192.168.100.65",
+		AutoStandby:    &Policy{Enabled: true, IdleTimeout: "1m"},
+	}
+	store := newFakeInstanceStore([]Instance{inst})
+	source := &restoreConnectionSource{streams: make(chan *fakeConnectionStream, 4)}
+	controller := NewController(store, source, ControllerOptions{
+		ReconnectDelay: time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- controller.Run(ctx) }()
+
+	stream := <-source.streams
+	require.Equal(t, StatusIdleCountdown, controller.Describe(inst).Status)
+
+	// The connection opens while the subscription is down, so its NEW event is
+	// never delivered.
+	source.setConnections([]Connection{{
+		OriginalSourceIP:        mustAddr("1.2.3.4"),
+		OriginalSourcePort:      50200,
+		OriginalDestinationIP:   mustAddr("192.168.100.65"),
+		OriginalDestinationPort: 8080,
+		TCPState:                TCPStateEstablished,
+	}})
+	stream.errs <- errors.New("recv conntrack events: no buffer space available")
+
+	require.Eventually(t, func() bool {
+		return controller.Describe(inst).Status == StatusActive
+	}, time.Second, 5*time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
 func mustAddr(raw string) netip.Addr {
 	return netip.MustParseAddr(raw)
+}
+
+// restoreConnectionSource hands out the streams it creates so a test can fail
+// one, and serializes connection access for controllers running in Run mode.
+type restoreConnectionSource struct {
+	mu          sync.Mutex
+	connections []Connection
+	streams     chan *fakeConnectionStream
+}
+
+func (s *restoreConnectionSource) ListConnections(context.Context) ([]Connection, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Connection(nil), s.connections...), nil
+}
+
+func (s *restoreConnectionSource) setConnections(conns []Connection) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.connections = conns
+}
+
+func (s *restoreConnectionSource) OpenStream(context.Context) (ConnectionStream, error) {
+	stream := &fakeConnectionStream{
+		events: make(chan ConnectionEvent),
+		errs:   make(chan error, 1),
+	}
+	s.streams <- stream
+	return stream, nil
 }
 
 func idleTestInstance(id, ip string, idleSince time.Time) Instance {

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -704,6 +704,50 @@ func TestHandleStandbyTimerRearmsCountdownWhenConfirmationFails(t *testing.T) {
 	controller.mu.RUnlock()
 }
 
+func TestHandleStandbyTimerKeepsActiveStateWhenConfirmationFails(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	now := idleSince.Add(time.Minute)
+	inst := idleTestInstance("inst-confirm-active", "192.168.100.67", idleSince)
+	store := newFakeInstanceStore([]Instance{inst})
+	source := &fakeConnectionSource{}
+	controller := NewController(store, source, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	// Inbound activity arrives after the standby timer was already queued.
+	controller.handleConnectionEvent(context.Background(), ConnectionEvent{
+		Type: ConnectionEventNew,
+		Connection: Connection{
+			OriginalSourceIP:        mustAddr("1.2.3.4"),
+			OriginalSourcePort:      50300,
+			OriginalDestinationIP:   mustAddr("192.168.100.67"),
+			OriginalDestinationPort: 8080,
+			TCPState:                TCPStateEstablished,
+		},
+		ObservedAt: now,
+	})
+	source.listErr = errors.New("conntrack dump failed")
+
+	controller.handleStandbyTimer(context.Background(), "inst-confirm-active")
+	controller.standbyWG.Wait()
+
+	assert.Empty(t, store.standbyCalls())
+	require.NotNil(t, store.persistedRuntime["inst-confirm-active"])
+	assert.Nil(t, store.persistedRuntime["inst-confirm-active"].IdleSince)
+
+	controller.mu.RLock()
+	state := controller.states["inst-confirm-active"]
+	require.NotNil(t, state)
+	assert.Len(t, state.activeInbound, 1)
+	assert.Nil(t, state.idleSince)
+	assert.Nil(t, state.timer)
+	controller.mu.RUnlock()
+}
+
 func TestStreamRestoreResyncsFromConntrackTable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The auto-standby idle countdown is driven entirely by the conntrack event stream. `state.activeInbound` is built from NEW/DESTROY events, and once it drains the countdown timer arms — after that nothing re-reads the conntrack table before the timer fires. So a single dropped NEW event (receive buffer overrun, or the reconnect gap after a stream error, where the restored subscription previously did no resync) is enough to standby an instance that still has a live connection. The only correction was `periodicSnapshotSync` at 5 minutes, which never runs in time for a shorter `idle_timeout`.

Two changes, both in `lib/autostandby/controller.go`:

- `handleStandbyTimer` now dumps the conntrack table and classifies it with the instance's policy before committing to standby. If matching inbound connections are still present, it repopulates `activeInbound`, clears `idleSince`, arms the reconcile timer, and skips the attempt. If the dump or classification fails, the instance is treated as busy and the countdown restarts rather than risking standby on an unverified instance. One dump per standby attempt, on the same event-loop goroutine that already dumps every 2s via `handleActiveReconcile`.
- The `streamReady` case in `Run` calls `startupResync` after a subscription is restored, so state is rebuilt from the table immediately instead of staying stale for up to a full snapshot interval.

## Tests

`go test ./lib/autostandby/ -race` passes, including three new cases: standby skipped when conntrack reports a connection the event stream missed, countdown re-armed when the confirmation dump fails, and a `Run`-level test that fails the stream and asserts the instance flips back to active after the reconnect resync.

`./lib/instances` and `./cmd/api/api` do not build in this checkout (missing embedded `cloud-hypervisor` / `caddy` / `guest-agent` binaries, unrelated to this change), so their auto-standby tests were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when VMs enter standby (snapshot IO) based on authoritative conntrack reads; behavior is conservative on errors but affects production instance lifecycle timing.
> 
> **Overview**
> Fixes a case where **auto-standby could snapshot a VM that still had live inbound traffic** when conntrack **NEW** events were missed (stream gaps or buffer overruns) and idle state was driven only by the event stream.
> 
> **Before standby**, `handleStandbyTimer` now runs **`confirmIdleBeforeStandby`**: a conntrack table dump and policy match. If connections remain, it restores active state and skips standby; if the dump fails, it **restarts the idle countdown** instead of standing by on unverified idle. Deadline checks are factored into **`standbyDeadlineElapsedLocked`**, with a second pass after confirmation for holds/re-arms that happen while the lock was released.
> 
> On **conntrack subscription restore**, `Run` calls **`startupResync`** before marking the observer connected, so state is reseeded from the table immediately rather than staying stale until periodic sync; observer “connected” is set **after** resync so a failed dump does not look like a dead subscription.
> 
> Tests cover missed events, failed confirmation, races (hold/re-arm during confirmation), and `Run`-level stream restore behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571b961ef1d26ccd3e11c83b1bbb02f98a42004d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->