### PR TITLE
Require QEMU for vGPU instances

### DIFF
--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -88,9 +88,10 @@ func (m *manager) createInstance(
 		log.ErrorContext(ctx, "invalid create request", "error", err)
 		return nil, err
 	}
-	hvType := req.Hypervisor
-	if hvType == "" {
-		hvType = m.defaultHypervisor
+	hvType, err := resolveCreateHypervisor(req, m.defaultHypervisor)
+	if err != nil {
+		log.ErrorContext(ctx, "invalid create request", "error", err)
+		return nil, err
 	}
 
 	// 2. Validate image exists and is ready; auto-pull if not found

--- a/lib/instances/start.go
+++ b/lib/instances/start.go
@@ -48,6 +48,10 @@ func (m *manager) startInstance(
 		log.ErrorContext(ctx, "invalid state for start", "instance_id", id, "state", inst.State)
 		return nil, fmt.Errorf("%w: cannot start from state %s, must be Stopped", ErrInvalidState, inst.State)
 	}
+	if err := validateVGPUHypervisor(stored.GPUProfile, stored.HypervisorType); err != nil {
+		log.ErrorContext(ctx, "invalid vGPU hypervisor", "instance_id", id, "error", err)
+		return nil, err
+	}
 
 	// 2a. Clear stale exit info from previous run and apply command overrides
 	stored.ExitCode = nil

--- a/lib/instances/vgpu_hypervisor.go
+++ b/lib/instances/vgpu_hypervisor.go
@@ -1,0 +1,30 @@
+package instances
+
+import (
+	"fmt"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+)
+
+func resolveCreateHypervisor(req CreateInstanceRequest, defaultHypervisor hypervisor.Type) (hypervisor.Type, error) {
+	hvType := req.Hypervisor
+	if hvType == "" {
+		hvType = defaultHypervisor
+	}
+
+	profile := ""
+	if req.GPU != nil {
+		profile = req.GPU.Profile
+	}
+	if err := validateVGPUHypervisor(profile, hvType); err != nil {
+		return "", err
+	}
+	return hvType, nil
+}
+
+func validateVGPUHypervisor(profile string, hvType hypervisor.Type) error {
+	if profile != "" && hvType != hypervisor.TypeQEMU {
+		return fmt.Errorf("%w: vGPU requires qemu, got %s", ErrInvalidRequest, hvType)
+	}
+	return nil
+}

--- a/lib/instances/vgpu_hypervisor_test.go
+++ b/lib/instances/vgpu_hypervisor_test.go
@@ -1,0 +1,92 @@
+package instances
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+)
+
+func TestResolveCreateHypervisorForVGPU(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		request           CreateInstanceRequest
+		defaultHypervisor hypervisor.Type
+		want              hypervisor.Type
+		wantErr           bool
+	}{
+		{
+			name: "explicit qemu",
+			request: CreateInstanceRequest{
+				Hypervisor: hypervisor.TypeQEMU,
+				GPU:        &GPUConfig{Profile: "NVIDIA L40S-2Q"},
+			},
+			defaultHypervisor: hypervisor.TypeCloudHypervisor,
+			want:              hypervisor.TypeQEMU,
+		},
+		{
+			name: "qemu default",
+			request: CreateInstanceRequest{
+				GPU: &GPUConfig{Profile: "NVIDIA L40S-2Q"},
+			},
+			defaultHypervisor: hypervisor.TypeQEMU,
+			want:              hypervisor.TypeQEMU,
+		},
+		{
+			name: "explicit cloud hypervisor",
+			request: CreateInstanceRequest{
+				Hypervisor: hypervisor.TypeCloudHypervisor,
+				GPU:        &GPUConfig{Profile: "NVIDIA L40S-2Q"},
+			},
+			defaultHypervisor: hypervisor.TypeQEMU,
+			wantErr:           true,
+		},
+		{
+			name: "cloud hypervisor default",
+			request: CreateInstanceRequest{
+				GPU: &GPUConfig{Profile: "NVIDIA L40S-2Q"},
+			},
+			defaultHypervisor: hypervisor.TypeCloudHypervisor,
+			wantErr:           true,
+		},
+		{
+			name: "firecracker",
+			request: CreateInstanceRequest{
+				Hypervisor: hypervisor.TypeFirecracker,
+				GPU:        &GPUConfig{Profile: "NVIDIA L40S-2Q"},
+			},
+			defaultHypervisor: hypervisor.TypeQEMU,
+			wantErr:           true,
+		},
+		{
+			name: "non-GPU cloud hypervisor",
+			request: CreateInstanceRequest{
+				Hypervisor: hypervisor.TypeCloudHypervisor,
+			},
+			defaultHypervisor: hypervisor.TypeQEMU,
+			want:              hypervisor.TypeCloudHypervisor,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveCreateHypervisor(tt.request, tt.defaultHypervisor)
+			if tt.wantErr {
+				if !errors.Is(err, ErrInvalidRequest) {
+					t.Fatalf("expected ErrInvalidRequest, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## summary

- reject vGPU creates that select, or default to, a non-QEMU hypervisor
- enforce the same invariant when restarting stopped vGPU instances
- cover explicit and default hypervisor selection with parallel pure tests

## why

QEMU is the supported vGPU path. Rejecting unsupported hypervisors before image resolution or device allocation prevents an invalid VM configuration from reaching the host.

## tests

- `go test -race ./lib/instances -run '^TestResolveCreateHypervisorForVGPU$' -count=1`
- `go test ./lib/instances -run '^$' -count=1`
- `go vet ./lib/instances`
- CI Linux and Darwin test suites

The full local VM integration suite requires `mkfs.erofs` and privileged networking; the equivalent CI suite passed.
