### PR TITLE
Harden vGPU release ordering in the instance lifecycle

### DIFF
--- a/lib/devices/GPU.md
+++ b/lib/devices/GPU.md
@@ -235,6 +235,20 @@ To upgrade the NVIDIA driver version:
    - Run GPU passthrough E2E tests
    - Verify with real CUDA workloads (e.g., ollama inference)
 
+## Rolling Back vGPU Changes
+
+Before downgrading Hypeman or the host to a version that does not support the active vGPU framework:
+
+1. Stop or delete all vGPU instances while the current Hypeman version can release their assignments.
+2. Confirm `/resources` reports `used_slots: 0`.
+3. Confirm no mdev assignments remain:
+   ```bash
+   test -z "$(find /sys/bus/mdev/devices -mindepth 1 -maxdepth 1 2>/dev/null)"
+   ```
+4. Downgrade only after both checks are clean.
+
+If assignment cleanup fails, Hypeman retains the instance metadata so a compatible version can retry it. Do not remove that metadata manually while the assignment remains active.
+
 ## Troubleshooting
 
 ### No GPU shown in /resources

--- a/lib/devices/GPU.md
+++ b/lib/devices/GPU.md
@@ -235,20 +235,6 @@ To upgrade the NVIDIA driver version:
    - Run GPU passthrough E2E tests
    - Verify with real CUDA workloads (e.g., ollama inference)
 
-## Rolling Back vGPU Changes
-
-Before downgrading Hypeman or the host to a version that does not support the active vGPU framework:
-
-1. Stop or delete all vGPU instances while the current Hypeman version can release their assignments.
-2. Confirm `/resources` reports `used_slots: 0`.
-3. Confirm no mdev assignments remain:
-   ```bash
-   test -z "$(find /sys/bus/mdev/devices -mindepth 1 -maxdepth 1 2>/dev/null)"
-   ```
-4. Downgrade only after both checks are clean.
-
-If assignment cleanup fails, Hypeman retains the instance metadata so a compatible version can retry it. Do not remove that metadata manually while the assignment remains active.
-
 ## Troubleshooting
 
 ### No GPU shown in /resources

--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -92,6 +92,13 @@ func (m *manager) deleteInstanceWithOptions(
 	if err := m.markRestartManualStopLocked(ctx, id); err != nil {
 		return fmt.Errorf("block restart policy before delete: %w", err)
 	}
+	// markRestartManualStopLocked persists through a separate metadata load.
+	// Reload it so later saves in this delete do not overwrite the block.
+	meta, err = m.loadMetadata(id)
+	if err != nil {
+		return fmt.Errorf("reload metadata after blocking restart policy: %w", err)
+	}
+	stored = &meta.StoredMetadata
 
 	// 4. If active, try graceful guest shutdown before force kill.
 	gracefulShutdown := false

--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -86,9 +86,9 @@ func (m *manager) deleteInstanceWithOptions(
 	}
 
 	// 3b. Block the restart policy before any teardown. If the delete fails
-	// partway (e.g. a failed vGPU release) the metadata is retained with the
-	// VMM already stopped, and without this marker the restart policy
-	// controller would start the instance again.
+	// partway (e.g. the hypervisor cannot be confirmed dead) the metadata is
+	// retained with the VMM already stopped, and without this marker the
+	// restart policy controller would start the instance again.
 	if err := m.markRestartManualStopLocked(ctx, id); err != nil {
 		return fmt.Errorf("block restart policy before delete: %w", err)
 	}
@@ -141,18 +141,21 @@ func (m *manager) deleteInstanceWithOptions(
 	m.closeFirecrackerUFFDSession(ctx, stored)
 
 	// 5b. Release the vGPU assignment if present, before any network, device,
-	// or volume teardown. A failed release retains the instance metadata; the
-	// VMM has already been stopped, but its attachments are intact and the
-	// restart policy is blocked, so a retried delete is safe.
+	// or volume teardown. Release failure is logged and the delete continues,
+	// matching the pre-refactor contract: the VMM is already confirmed dead,
+	// the guards inside the release never destroy a device they cannot prove
+	// is unowned, and a skipped release is recovered by startup
+	// reconciliation.
 	hadVGPUAssignment := storedVGPUDevicePath(stored) != ""
-	if err := releaseStoredVGPU(ctx, stored); err != nil {
-		log.ErrorContext(ctx, "failed to destroy vGPU; retaining instance metadata", "instance_id", id, "error", err)
-		return fmt.Errorf("destroy vGPU: %w", err)
-	}
 	if hadVGPUAssignment {
+		log.InfoContext(ctx, "destroying vGPU", "instance_id", id, "uuid", stored.GPUMdevUUID)
+	}
+	if err := releaseStoredVGPU(ctx, stored); err != nil {
+		// Log error but continue with cleanup.
+		log.WarnContext(ctx, "failed to destroy vGPU, continuing with cleanup", "instance_id", id, "uuid", stored.GPUMdevUUID, "error", err)
+	} else if hadVGPUAssignment {
 		if err := m.saveMetadata(meta); err != nil {
-			log.ErrorContext(ctx, "failed to save metadata after vGPU release", "instance_id", id, "error", err)
-			return fmt.Errorf("save metadata after vGPU release: %w", err)
+			log.WarnContext(ctx, "failed to save metadata after vGPU release", "instance_id", id, "error", err)
 		}
 	}
 

--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -174,8 +174,8 @@ func (m *manager) deleteInstanceWithOptions(
 	if path := storedVGPUDevicePath(stored); path != "" {
 		log.InfoContext(ctx, "destroying vGPU", "instance_id", id, "device_path", path)
 		if err := releaseStoredVGPU(ctx, stored); err != nil {
-			// Log error but continue with cleanup
-			log.WarnContext(ctx, "failed to destroy vGPU, continuing with cleanup", "instance_id", id, "device_path", path, "error", err)
+			log.ErrorContext(ctx, "failed to destroy vGPU; retaining instance metadata", "instance_id", id, "device_path", path, "error", err)
+			return fmt.Errorf("destroy vGPU: %w", err)
 		}
 	}
 

--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -85,6 +85,14 @@ func (m *manager) deleteInstanceWithOptions(
 		guest.CloseConn(dialer.Key())
 	}
 
+	// 3b. Block the restart policy before any teardown. If the delete fails
+	// partway (e.g. a failed vGPU release) the metadata is retained with the
+	// VMM already stopped, and without this marker the restart policy
+	// controller would start the instance again.
+	if err := m.markRestartManualStopLocked(ctx, id); err != nil {
+		return fmt.Errorf("block restart policy before delete: %w", err)
+	}
+
 	// 4. If active, try graceful guest shutdown before force kill.
 	gracefulShutdown := false
 	if !options.skipGracefulShutdown && (inst.State == StateRunning || inst.State == StateInitializing) {
@@ -126,9 +134,9 @@ func (m *manager) deleteInstanceWithOptions(
 	m.closeFirecrackerUFFDSession(ctx, stored)
 
 	// 5b. Release the vGPU assignment if present, before any network, device,
-	// or volume teardown. A failed release retains the instance metadata, and
-	// nothing destructive has happened to its attachments yet, so a retried
-	// delete is safe.
+	// or volume teardown. A failed release retains the instance metadata; the
+	// VMM has already been stopped, but its attachments are intact and the
+	// restart policy is blocked, so a retried delete is safe.
 	if err := releaseStoredVGPU(ctx, stored); err != nil {
 		log.ErrorContext(ctx, "failed to destroy vGPU; retaining instance metadata", "instance_id", id, "error", err)
 		return fmt.Errorf("destroy vGPU: %w", err)

--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -137,9 +137,16 @@ func (m *manager) deleteInstanceWithOptions(
 	// or volume teardown. A failed release retains the instance metadata; the
 	// VMM has already been stopped, but its attachments are intact and the
 	// restart policy is blocked, so a retried delete is safe.
+	hadVGPUAssignment := storedVGPUDevicePath(stored) != ""
 	if err := releaseStoredVGPU(ctx, stored); err != nil {
 		log.ErrorContext(ctx, "failed to destroy vGPU; retaining instance metadata", "instance_id", id, "error", err)
 		return fmt.Errorf("destroy vGPU: %w", err)
+	}
+	if hadVGPUAssignment {
+		if err := m.saveMetadata(meta); err != nil {
+			log.ErrorContext(ctx, "failed to save metadata after vGPU release", "instance_id", id, "error", err)
+			return fmt.Errorf("save metadata after vGPU release: %w", err)
+		}
 	}
 
 	// 6. Release network allocation

--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -125,6 +125,15 @@ func (m *manager) deleteInstanceWithOptions(
 	}
 	m.closeFirecrackerUFFDSession(ctx, stored)
 
+	// 5b. Release the vGPU assignment if present, before any network, device,
+	// or volume teardown. A failed release retains the instance metadata, and
+	// nothing destructive has happened to its attachments yet, so a retried
+	// delete is safe.
+	if err := releaseStoredVGPU(ctx, stored); err != nil {
+		log.ErrorContext(ctx, "failed to destroy vGPU; retaining instance metadata", "instance_id", id, "error", err)
+		return fmt.Errorf("destroy vGPU: %w", err)
+	}
+
 	// 6. Release network allocation
 	if inst.NetworkEnabled {
 		m.unregisterEgressProxyInstance(ctx, id)
@@ -167,15 +176,6 @@ func (m *manager) deleteInstanceWithOptions(
 				// Log error but continue with cleanup
 				log.WarnContext(ctx, "failed to detach volume, continuing with cleanup", "instance_id", id, "volume_id", volAttach.VolumeID, "error", err)
 			}
-		}
-	}
-
-	// 7c. Release the vGPU assignment if present.
-	if path := storedVGPUDevicePath(stored); path != "" {
-		log.InfoContext(ctx, "destroying vGPU", "instance_id", id, "device_path", path)
-		if err := releaseStoredVGPU(ctx, stored); err != nil {
-			log.ErrorContext(ctx, "failed to destroy vGPU; retaining instance metadata", "instance_id", id, "device_path", path, "error", err)
-			return fmt.Errorf("destroy vGPU: %w", err)
 		}
 	}
 

--- a/lib/instances/fork.go
+++ b/lib/instances/fork.go
@@ -299,6 +299,11 @@ func (m *manager) forkInstanceFromStoppedOrStandby(ctx context.Context, id strin
 	// phase (Standby for snapshot forks, Stopped for stopped forks) will be
 	// recorded by the appropriate operation when the fork is acted on.
 	forkMeta.Phases.Reset()
+	// A vGPU assignment is never shared with a fork: normally stop already
+	// released it, and an assignment retained by a failed release must stay
+	// with the source so only one instance retries it. The fork acquires its
+	// own vGPU on start from GPUProfile.
+	clearStoredVGPUDevice(&forkMeta)
 	switch source.State {
 	case StateStandby:
 		forkMeta.Phases.Record(phasetracking.PhaseStandby, now)

--- a/lib/instances/fork_test.go
+++ b/lib/instances/fork_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/kernel/hypeman/lib/autostandby"
+	"github.com/kernel/hypeman/lib/devices"
 	"github.com/kernel/hypeman/lib/guest"
 	"github.com/kernel/hypeman/lib/healthcheck"
 	"github.com/kernel/hypeman/lib/hypervisor"
@@ -28,6 +29,39 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestForkInstanceClearsVGPUAssignment(t *testing.T) {
+	manager, _ := setupTestManager(t)
+	ctx := context.Background()
+	hvType := hypervisor.Type("fork-vgpu-test")
+	hypervisor.RegisterCapabilities(hvType, hypervisor.Capabilities{SupportsConcurrentForkPrepare: true})
+	manager.vmStarters[hvType] = concurrentForkPrepareTestStarter{}
+
+	sourceID := "fork-vgpu-source"
+	createStoppedSnapshotSourceFixture(t, manager, sourceID, sourceID, hvType)
+
+	// A retained assignment (release failed during stop) must stay with the
+	// source; the fork keeps only the profile and acquires its own vGPU on
+	// start.
+	meta, err := manager.loadMetadata(sourceID)
+	require.NoError(t, err)
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUFramework = devices.VGPUFramework("future-framework")
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	meta.GPUMdevUUID = "retained-uuid"
+	require.NoError(t, manager.saveMetadata(meta))
+
+	forked, err := manager.ForkInstance(ctx, sourceID, ForkInstanceRequest{Name: "fork-vgpu-copy"})
+	require.NoError(t, err)
+	assert.Equal(t, "NVIDIA L40S-2Q", forked.GPUProfile)
+	assert.Equal(t, devices.VGPUFrameworkNone, forked.GPUFramework)
+	assert.Empty(t, forked.GPUDevicePath)
+	assert.Empty(t, forked.GPUMdevUUID)
+
+	source, err := manager.loadMetadata(sourceID)
+	require.NoError(t, err)
+	assert.Equal(t, "/sys/bus/pci/devices/0000:82:00.4", source.GPUDevicePath)
+}
 
 func TestForkInstance_VZStoppedSourceSupported(t *testing.T) {
 	t.Parallel()

--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -186,6 +186,32 @@ func TestDeleteBlocksRestartPolicyWhenVGPUReleaseFails(t *testing.T) {
 		"a failed delete must not leave the instance restartable")
 }
 
+func TestDeletePersistsVGPUReleaseBeforeTeardown(t *testing.T) {
+	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
+	var persisted *metadata
+	deviceManager := &recordingDeviceManager{
+		onMarkDetached: func() {
+			var err error
+			persisted, err = m.loadMetadata(id)
+			require.NoError(t, err)
+		},
+	}
+	m.deviceManager = deviceManager
+	meta, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUDevicePath = "/sys/bus/mdev/devices/test-mdev"
+	meta.GPUMdevUUID = "test-mdev"
+	meta.Devices = []string{"dev-1"}
+	require.NoError(t, m.saveMetadata(meta))
+
+	require.NoError(t, m.DeleteInstance(context.Background(), id))
+	require.NotNil(t, persisted)
+	assert.Empty(t, persisted.GPUDevicePath)
+	assert.Empty(t, persisted.GPUMdevUUID)
+	assert.Equal(t, "NVIDIA L40S-2Q", persisted.GPUProfile)
+}
+
 func TestDeleteReleasesVGPUBeforeTeardown(t *testing.T) {
 	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
 	deviceManager := &recordingDeviceManager{}
@@ -275,12 +301,16 @@ func TestStopStoppedInstanceVGPUReleaseFailureRemainsNoop(t *testing.T) {
 // teardown calls. Only the methods delete exercises are implemented.
 type recordingDeviceManager struct {
 	devices.Manager
-	detached []string
-	unbound  []string
+	detached       []string
+	unbound        []string
+	onMarkDetached func()
 }
 
 func (m *recordingDeviceManager) MarkDetached(ctx context.Context, deviceID string) error {
 	m.detached = append(m.detached, deviceID)
+	if m.onMarkDetached != nil {
+		m.onMarkDetached()
+	}
 	return nil
 }
 

--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -149,7 +149,7 @@ func TestLifecycleNoopStandbyWithOptionsStillRejectsStandbyInstance(t *testing.T
 	assertNoLifecycleEvent(t, events)
 }
 
-func TestDeleteRetainsMetadataWhenVGPUReleaseFails(t *testing.T) {
+func TestDeleteContinuesWhenVGPUReleaseFails(t *testing.T) {
 	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
 	meta, err := m.loadMetadata(id)
 	require.NoError(t, err)
@@ -158,32 +158,13 @@ func TestDeleteRetainsMetadataWhenVGPUReleaseFails(t *testing.T) {
 	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
 	require.NoError(t, m.saveMetadata(meta))
 
-	err = m.DeleteInstance(context.Background(), id)
-	require.Error(t, err)
+	// A failed release is logged and the delete continues, matching the
+	// pre-refactor contract; the leaked assignment is recovered by startup
+	// reconciliation.
+	require.NoError(t, m.DeleteInstance(context.Background(), id))
 
-	stored, err := m.loadMetadata(id)
-	require.NoError(t, err)
-	assert.Equal(t, devices.VGPUFramework("future-framework"), stored.GPUFramework)
-	assert.Equal(t, "/sys/bus/pci/devices/0000:82:00.4", stored.GPUDevicePath)
-}
-
-func TestDeleteBlocksRestartPolicyWhenVGPUReleaseFails(t *testing.T) {
-	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
-	meta, err := m.loadMetadata(id)
-	require.NoError(t, err)
-	meta.RestartPolicy = &restartpolicy.Policy{Policy: restartpolicy.PolicyAlways}
-	meta.GPUProfile = "NVIDIA L40S-2Q"
-	meta.GPUFramework = devices.VGPUFramework("future-framework")
-	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
-	require.NoError(t, m.saveMetadata(meta))
-
-	err = m.DeleteInstance(context.Background(), id)
-	require.Error(t, err)
-
-	stored, err := m.loadMetadata(id)
-	require.NoError(t, err)
-	assert.Equal(t, restartpolicy.BlockedReasonManualStop, stored.RestartStatus.BlockedReason,
-		"a failed delete must not leave the instance restartable")
+	_, err = m.loadMetadata(id)
+	require.Error(t, err, "instance data must be deleted despite the failed release")
 }
 
 func TestDeletePersistsVGPUReleaseBeforeTeardown(t *testing.T) {
@@ -214,7 +195,7 @@ func TestDeletePersistsVGPUReleaseBeforeTeardown(t *testing.T) {
 	assert.Equal(t, restartpolicy.BlockedReasonManualStop, persisted.RestartStatus.BlockedReason)
 }
 
-func TestDeleteReleasesVGPUBeforeTeardown(t *testing.T) {
+func TestDeleteContinuesTeardownAfterFailedVGPURelease(t *testing.T) {
 	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
 	deviceManager := &recordingDeviceManager{}
 	m.deviceManager = deviceManager
@@ -226,15 +207,13 @@ func TestDeleteReleasesVGPUBeforeTeardown(t *testing.T) {
 	meta.Devices = []string{"dev-1"}
 	require.NoError(t, m.saveMetadata(meta))
 
-	err = m.DeleteInstance(context.Background(), id)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "destroy vGPU")
-	assert.Empty(t, deviceManager.detached)
-	assert.Empty(t, deviceManager.unbound)
+	// The failed release must not block the rest of the teardown: devices
+	// are detached and the instance is fully deleted.
+	require.NoError(t, m.DeleteInstance(context.Background(), id))
+	assert.Equal(t, []string{"dev-1"}, deviceManager.detached)
 
-	stored, err := m.loadMetadata(id)
-	require.NoError(t, err)
-	assert.Equal(t, devices.VGPUFramework("future-framework"), stored.GPUFramework)
+	_, err = m.loadMetadata(id)
+	require.Error(t, err, "instance data must be deleted despite the failed release")
 }
 
 // A stale release during start must be persisted immediately: if start fails

--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -166,6 +166,85 @@ func TestDeleteRetainsMetadataWhenVGPUReleaseFails(t *testing.T) {
 	assert.Equal(t, "/sys/bus/pci/devices/0000:82:00.4", stored.GPUDevicePath)
 }
 
+func TestDeleteReleasesVGPUBeforeTeardown(t *testing.T) {
+	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
+	deviceManager := &recordingDeviceManager{}
+	m.deviceManager = deviceManager
+	meta, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUFramework = devices.VGPUFramework("future-framework")
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	meta.Devices = []string{"dev-1"}
+	require.NoError(t, m.saveMetadata(meta))
+
+	err = m.DeleteInstance(context.Background(), id)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "destroy vGPU")
+	assert.Empty(t, deviceManager.detached)
+	assert.Empty(t, deviceManager.unbound)
+
+	stored, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	assert.Equal(t, devices.VGPUFramework("future-framework"), stored.GPUFramework)
+}
+
+func TestStopStoppedInstanceReleasesRetainedVGPU(t *testing.T) {
+	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
+	meta, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUFramework = devices.VGPUFrameworkNone
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	require.NoError(t, m.saveMetadata(meta))
+
+	inst, err := m.StopInstance(context.Background(), id)
+	require.NoError(t, err)
+	require.NotNil(t, inst)
+	assert.Equal(t, StateStopped, inst.State)
+
+	stored, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	assert.Empty(t, stored.GPUDevicePath)
+}
+
+func TestStopStoppedInstanceVGPUReleaseFailureReturnsError(t *testing.T) {
+	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
+	meta, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUFramework = devices.VGPUFramework("future-framework")
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	require.NoError(t, m.saveMetadata(meta))
+
+	_, err = m.StopInstance(context.Background(), id)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "destroy vGPU")
+
+	stored, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	assert.Equal(t, devices.VGPUFramework("future-framework"), stored.GPUFramework)
+	assert.Equal(t, "/sys/bus/pci/devices/0000:82:00.4", stored.GPUDevicePath)
+}
+
+// recordingDeviceManager is a devices.Manager stub that records passthrough
+// teardown calls. Only the methods delete exercises are implemented.
+type recordingDeviceManager struct {
+	devices.Manager
+	detached []string
+	unbound  []string
+}
+
+func (m *recordingDeviceManager) MarkDetached(ctx context.Context, deviceID string) error {
+	m.detached = append(m.detached, deviceID)
+	return nil
+}
+
+func (m *recordingDeviceManager) UnbindFromVFIO(ctx context.Context, id string) error {
+	m.unbound = append(m.unbound, id)
+	return nil
+}
+
 func newLifecycleNoopManagerWithInstance(t *testing.T, state State, now time.Time) (*manager, string) {
 	t.Helper()
 

--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -199,6 +199,7 @@ func TestDeletePersistsVGPUReleaseBeforeTeardown(t *testing.T) {
 	m.deviceManager = deviceManager
 	meta, err := m.loadMetadata(id)
 	require.NoError(t, err)
+	meta.RestartPolicy = &restartpolicy.Policy{Policy: restartpolicy.PolicyAlways}
 	meta.GPUProfile = "NVIDIA L40S-2Q"
 	meta.GPUDevicePath = "/sys/bus/mdev/devices/test-mdev"
 	meta.GPUMdevUUID = "test-mdev"
@@ -210,6 +211,7 @@ func TestDeletePersistsVGPUReleaseBeforeTeardown(t *testing.T) {
 	assert.Empty(t, persisted.GPUDevicePath)
 	assert.Empty(t, persisted.GPUMdevUUID)
 	assert.Equal(t, "NVIDIA L40S-2Q", persisted.GPUProfile)
+	assert.Equal(t, restartpolicy.BlockedReasonManualStop, persisted.RestartStatus.BlockedReason)
 }
 
 func TestDeleteReleasesVGPUBeforeTeardown(t *testing.T) {

--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kernel/hypeman/lib/devices"
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/paths"
 	"github.com/stretchr/testify/assert"
@@ -145,6 +146,24 @@ func TestLifecycleNoopStandbyWithOptionsStillRejectsStandbyInstance(t *testing.T
 	_, err := m.StandbyInstance(context.Background(), id, StandbyInstanceRequest{CompressionDelay: &delay})
 	require.ErrorIs(t, err, ErrInvalidState)
 	assertNoLifecycleEvent(t, events)
+}
+
+func TestDeleteRetainsMetadataWhenVGPUReleaseFails(t *testing.T) {
+	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
+	meta, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUFramework = devices.VGPUFramework("future-framework")
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	require.NoError(t, m.saveMetadata(meta))
+
+	err = m.DeleteInstance(context.Background(), id)
+	require.Error(t, err)
+
+	stored, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	assert.Equal(t, devices.VGPUFramework("future-framework"), stored.GPUFramework)
+	assert.Equal(t, "/sys/bus/pci/devices/0000:82:00.4", stored.GPUDevicePath)
 }
 
 func newLifecycleNoopManagerWithInstance(t *testing.T, state State, now time.Time) (*manager, string) {

--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -208,7 +208,7 @@ func TestStopStoppedInstanceReleasesRetainedVGPU(t *testing.T) {
 	assert.Empty(t, stored.GPUDevicePath)
 }
 
-func TestStopStoppedInstanceVGPUReleaseFailureReturnsError(t *testing.T) {
+func TestStopStoppedInstanceVGPUReleaseFailureRemainsNoop(t *testing.T) {
 	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
 	meta, err := m.loadMetadata(id)
 	require.NoError(t, err)
@@ -217,9 +217,10 @@ func TestStopStoppedInstanceVGPUReleaseFailureReturnsError(t *testing.T) {
 	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
 	require.NoError(t, m.saveMetadata(meta))
 
-	_, err = m.StopInstance(context.Background(), id)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "destroy vGPU")
+	inst, err := m.StopInstance(context.Background(), id)
+	require.NoError(t, err)
+	require.NotNil(t, inst)
+	assert.Equal(t, StateStopped, inst.State)
 
 	stored, err := m.loadMetadata(id)
 	require.NoError(t, err)

--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -218,6 +218,7 @@ func TestStartPersistsStaleVGPUReleaseImmediately(t *testing.T) {
 	meta, err := m.loadMetadata(id)
 	require.NoError(t, err)
 	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.HypervisorType = hypervisor.TypeQEMU
 	meta.GPUFramework = devices.VGPUFrameworkNone
 	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
 	require.NoError(t, m.saveMetadata(meta))

--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kernel/hypeman/lib/devices"
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/paths"
+	restartpolicy "github.com/kernel/hypeman/lib/restart-policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -164,6 +165,25 @@ func TestDeleteRetainsMetadataWhenVGPUReleaseFails(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, devices.VGPUFramework("future-framework"), stored.GPUFramework)
 	assert.Equal(t, "/sys/bus/pci/devices/0000:82:00.4", stored.GPUDevicePath)
+}
+
+func TestDeleteBlocksRestartPolicyWhenVGPUReleaseFails(t *testing.T) {
+	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
+	meta, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	meta.RestartPolicy = &restartpolicy.Policy{Policy: restartpolicy.PolicyAlways}
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUFramework = devices.VGPUFramework("future-framework")
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	require.NoError(t, m.saveMetadata(meta))
+
+	err = m.DeleteInstance(context.Background(), id)
+	require.Error(t, err)
+
+	stored, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	assert.Equal(t, restartpolicy.BlockedReasonManualStop, stored.RestartStatus.BlockedReason,
+		"a failed delete must not leave the instance restartable")
 }
 
 func TestDeleteReleasesVGPUBeforeTeardown(t *testing.T) {

--- a/lib/instances/lifecycle_noop_test.go
+++ b/lib/instances/lifecycle_noop_test.go
@@ -189,6 +189,28 @@ func TestDeleteReleasesVGPUBeforeTeardown(t *testing.T) {
 	assert.Equal(t, devices.VGPUFramework("future-framework"), stored.GPUFramework)
 }
 
+// A stale release during start must be persisted immediately: if start fails
+// later (here at vGPU recreation on a host without VFs), the on-disk metadata
+// must no longer point at the already-released device.
+func TestStartPersistsStaleVGPUReleaseImmediately(t *testing.T) {
+	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
+	m.imageManager = readyFixtureImageManager{name: "test-image"}
+	meta, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUFramework = devices.VGPUFrameworkNone
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	require.NoError(t, m.saveMetadata(meta))
+
+	_, err = m.StartInstance(context.Background(), id, StartInstanceRequest{})
+	require.Error(t, err)
+
+	stored, err := m.loadMetadata(id)
+	require.NoError(t, err)
+	assert.Empty(t, stored.GPUDevicePath, "released assignment should be persisted despite the failed start")
+	assert.Equal(t, "NVIDIA L40S-2Q", stored.GPUProfile, "profile is kept for the next start")
+}
+
 func TestStopStoppedInstanceReleasesRetainedVGPU(t *testing.T) {
 	m, id := newLifecycleNoopManagerWithInstance(t, StateStopped, time.Now().UTC())
 	meta, err := m.loadMetadata(id)

--- a/lib/instances/manager.go
+++ b/lib/instances/manager.go
@@ -637,10 +637,10 @@ func (m *manager) StopInstance(ctx context.Context, id string) (*Instance, error
 		}
 		// A stopped instance can retain a vGPU assignment when the release
 		// failed during the original stop. Retry it here so the vGPU slot is
-		// not held until the next start, delete, or hypeman restart.
-		if err := m.releaseRetainedVGPULocked(ctx, id); err != nil {
-			return nil, err
-		}
+		// not held until the next start, delete, or hypeman restart. A failed
+		// retry only logs, keeping stop's no-op contract for already-stopped
+		// instances.
+		m.releaseRetainedVGPULocked(ctx, id)
 		updated, err := m.currentInstanceWithoutHydration(ctx, id)
 		if err != nil {
 			return nil, err

--- a/lib/instances/manager.go
+++ b/lib/instances/manager.go
@@ -635,6 +635,12 @@ func (m *manager) StopInstance(ctx context.Context, id string) (*Instance, error
 		if err := m.markRestartManualStopLocked(ctx, id); err != nil {
 			return nil, err
 		}
+		// A stopped instance can retain a vGPU assignment when the release
+		// failed during the original stop. Retry it here so the vGPU slot is
+		// not held until the next start, delete, or hypeman restart.
+		if err := m.releaseRetainedVGPULocked(ctx, id); err != nil {
+			return nil, err
+		}
 		updated, err := m.currentInstanceWithoutHydration(ctx, id)
 		if err != nil {
 			return nil, err

--- a/lib/instances/snapshot.go
+++ b/lib/instances/snapshot.go
@@ -306,6 +306,12 @@ func (m *manager) restoreSnapshot(ctx context.Context, id string, snapshotID str
 	restored.StoppedAt = nil
 	restored.ExitCode = nil
 	restored.ExitMessage = ""
+	// vGPU assignments are live host state, not snapshot payload: keep the
+	// instance's current assignment (possibly retained from a failed release)
+	// instead of resurrecting the one embedded in the snapshot.
+	restored.GPUFramework = sourceMeta.GPUFramework
+	restored.GPUDevicePath = sourceMeta.GPUDevicePath
+	restored.GPUMdevUUID = sourceMeta.GPUMdevUUID
 	restored.HypervisorType = targetHypervisor
 	restored.HypervisorVersion = targetHypervisorVersion
 	restored.SocketPath = m.paths.InstanceSocket(id, starter.SocketName())

--- a/lib/instances/snapshot.go
+++ b/lib/instances/snapshot.go
@@ -435,6 +435,7 @@ func (m *manager) forkSnapshot(ctx context.Context, snapshotID string, req ForkS
 	forkMeta.ExitCode = nil
 	forkMeta.ExitMessage = ""
 	forkMeta.RestartStatus = restartpolicy.Status{}
+	clearStoredVGPUDevice(&forkMeta)
 	forkMeta.FirecrackerUFFDSessionID = ""
 	forkMeta.FirecrackerUFFDPagerVersion = ""
 	forkMeta.FirecrackerUseUFFDOnNextRestore = useFirecrackerUFFDOnNextRestore(targetHypervisor, rec.Snapshot.Kind == SnapshotKindStandby, targetState)

--- a/lib/instances/snapshot_test.go
+++ b/lib/instances/snapshot_test.go
@@ -8,12 +8,49 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kernel/hypeman/lib/devices"
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/images"
 	snapshotstore "github.com/kernel/hypeman/lib/snapshot"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestForkSnapshotClearsVGPUAssignment(t *testing.T) {
+	mgr, _ := setupTestManager(t)
+	ctx := context.Background()
+
+	sourceID := "snapshot-vgpu-source"
+	createStoppedSnapshotSourceFixture(t, mgr, sourceID, sourceID, mgr.defaultHypervisor)
+
+	meta, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUFramework = devices.VGPUFramework("future-framework")
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	meta.GPUMdevUUID = "retained-uuid"
+	require.NoError(t, mgr.saveMetadata(meta))
+
+	snapshot, err := mgr.CreateSnapshot(ctx, sourceID, CreateSnapshotRequest{
+		Kind: SnapshotKindStopped,
+		Name: "snapshot-vgpu",
+	})
+	require.NoError(t, err)
+
+	forked, err := mgr.ForkSnapshot(ctx, snapshot.Id, ForkSnapshotRequest{
+		Name:        "snapshot-vgpu-fork",
+		TargetState: StateStopped,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "NVIDIA L40S-2Q", forked.GPUProfile)
+	assert.Equal(t, devices.VGPUFrameworkNone, forked.GPUFramework)
+	assert.Empty(t, forked.GPUDevicePath)
+	assert.Empty(t, forked.GPUMdevUUID)
+
+	source, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	assert.Equal(t, "/sys/bus/pci/devices/0000:82:00.4", source.GPUDevicePath)
+}
 
 func TestStoppedSnapshotLifecycleAndForkAfterSourceDeletion(t *testing.T) {
 	t.Parallel()

--- a/lib/instances/snapshot_test.go
+++ b/lib/instances/snapshot_test.go
@@ -52,6 +52,82 @@ func TestForkSnapshotClearsVGPUAssignment(t *testing.T) {
 	assert.Equal(t, "/sys/bus/pci/devices/0000:82:00.4", source.GPUDevicePath)
 }
 
+func TestRestoreSnapshotDoesNotResurrectStaleVGPUAssignment(t *testing.T) {
+	mgr, _ := setupTestManager(t)
+	ctx := context.Background()
+
+	sourceID := "snapshot-vgpu-restore-stale"
+	createStoppedSnapshotSourceFixture(t, mgr, sourceID, sourceID, mgr.defaultHypervisor)
+
+	meta, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	meta.GPUProfile = "NVIDIA L40S-2Q"
+	meta.GPUFramework = devices.VGPUFramework("future-framework")
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	meta.GPUMdevUUID = "retained-uuid"
+	require.NoError(t, mgr.saveMetadata(meta))
+
+	snapshot, err := mgr.CreateSnapshot(ctx, sourceID, CreateSnapshotRequest{
+		Kind: SnapshotKindStopped,
+		Name: "snapshot-vgpu-restore-stale",
+	})
+	require.NoError(t, err)
+
+	// The retained assignment is released successfully after the snapshot
+	// was taken; a restore must not resurrect the snapshot's embedded copy.
+	meta, err = mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	clearStoredVGPUDevice(&meta.StoredMetadata)
+	require.NoError(t, mgr.saveMetadata(meta))
+
+	_, err = mgr.RestoreSnapshot(ctx, sourceID, snapshot.Id, RestoreSnapshotRequest{
+		TargetState:      StateStopped,
+		TargetHypervisor: mgr.defaultHypervisor,
+	})
+	require.NoError(t, err)
+
+	restored, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	assert.Equal(t, devices.VGPUFrameworkNone, restored.GPUFramework)
+	assert.Empty(t, restored.GPUDevicePath)
+	assert.Empty(t, restored.GPUMdevUUID)
+}
+
+func TestRestoreSnapshotKeepsCurrentVGPUAssignment(t *testing.T) {
+	mgr, _ := setupTestManager(t)
+	ctx := context.Background()
+
+	sourceID := "snapshot-vgpu-restore-retained"
+	createStoppedSnapshotSourceFixture(t, mgr, sourceID, sourceID, mgr.defaultHypervisor)
+
+	snapshot, err := mgr.CreateSnapshot(ctx, sourceID, CreateSnapshotRequest{
+		Kind: SnapshotKindStopped,
+		Name: "snapshot-vgpu-restore-retained",
+	})
+	require.NoError(t, err)
+
+	// An assignment retained after the snapshot was taken (e.g. from a
+	// failed release on stop) must survive the restore for the next retry.
+	meta, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	meta.GPUFramework = devices.VGPUFramework("future-framework")
+	meta.GPUDevicePath = "/sys/bus/pci/devices/0000:82:00.4"
+	meta.GPUMdevUUID = "retained-uuid"
+	require.NoError(t, mgr.saveMetadata(meta))
+
+	_, err = mgr.RestoreSnapshot(ctx, sourceID, snapshot.Id, RestoreSnapshotRequest{
+		TargetState:      StateStopped,
+		TargetHypervisor: mgr.defaultHypervisor,
+	})
+	require.NoError(t, err)
+
+	restored, err := mgr.loadMetadata(sourceID)
+	require.NoError(t, err)
+	assert.Equal(t, devices.VGPUFramework("future-framework"), restored.GPUFramework)
+	assert.Equal(t, "/sys/bus/pci/devices/0000:82:00.4", restored.GPUDevicePath)
+	assert.Equal(t, "retained-uuid", restored.GPUMdevUUID)
+}
+
 func TestStoppedSnapshotLifecycleAndForkAfterSourceDeletion(t *testing.T) {
 	t.Parallel()
 	mgr, _ := setupTestManager(t)

--- a/lib/instances/start.go
+++ b/lib/instances/start.go
@@ -48,6 +48,10 @@ func (m *manager) startInstance(
 		log.ErrorContext(ctx, "invalid state for start", "instance_id", id, "state", inst.State)
 		return nil, fmt.Errorf("%w: cannot start from state %s, must be Stopped", ErrInvalidState, inst.State)
 	}
+	if err := releaseStoredVGPU(ctx, stored); err != nil {
+		log.ErrorContext(ctx, "failed to release stale vGPU before start", "instance_id", id, "error", err)
+		return nil, fmt.Errorf("release stale vGPU before start: %w", err)
+	}
 
 	// 2a. Clear stale exit info from previous run and apply command overrides
 	stored.ExitCode = nil

--- a/lib/instances/start.go
+++ b/lib/instances/start.go
@@ -48,6 +48,7 @@ func (m *manager) startInstance(
 		log.ErrorContext(ctx, "invalid state for start", "instance_id", id, "state", inst.State)
 		return nil, fmt.Errorf("%w: cannot start from state %s, must be Stopped", ErrInvalidState, inst.State)
 	}
+
 	// Release any assignment retained by an earlier failed release and
 	// persist the cleared fields immediately, so a failure later in start
 	// cannot leave on-disk metadata pointing at a device that is already

--- a/lib/instances/start.go
+++ b/lib/instances/start.go
@@ -48,9 +48,19 @@ func (m *manager) startInstance(
 		log.ErrorContext(ctx, "invalid state for start", "instance_id", id, "state", inst.State)
 		return nil, fmt.Errorf("%w: cannot start from state %s, must be Stopped", ErrInvalidState, inst.State)
 	}
-	if err := releaseStoredVGPU(ctx, stored); err != nil {
-		log.ErrorContext(ctx, "failed to release stale vGPU before start", "instance_id", id, "error", err)
-		return nil, fmt.Errorf("release stale vGPU before start: %w", err)
+	// Release any assignment retained by an earlier failed release and
+	// persist the cleared fields immediately, so a failure later in start
+	// cannot leave on-disk metadata pointing at a device that is already
+	// gone (matching releaseRetainedVGPULocked).
+	if storedVGPUDevicePath(stored) != "" {
+		if err := releaseStoredVGPU(ctx, stored); err != nil {
+			log.ErrorContext(ctx, "failed to release stale vGPU before start", "instance_id", id, "error", err)
+			return nil, fmt.Errorf("release stale vGPU before start: %w", err)
+		}
+		if err := m.saveMetadata(meta); err != nil {
+			log.ErrorContext(ctx, "failed to save metadata after stale vGPU release", "instance_id", id, "error", err)
+			return nil, fmt.Errorf("save metadata after stale vGPU release: %w", err)
+		}
 	}
 
 	// 2a. Clear stale exit info from previous run and apply command overrides

--- a/lib/instances/stop.go
+++ b/lib/instances/stop.go
@@ -266,9 +266,7 @@ func (m *manager) stopInstance(
 	if path := storedVGPUDevicePath(stored); path != "" {
 		log.InfoContext(ctx, "destroying vGPU on stop", "instance_id", id, "device_path", path)
 		if err := releaseStoredVGPU(ctx, stored); err != nil {
-			// Log error but continue - vGPU cleanup is best-effort
-			log.WarnContext(ctx, "failed to destroy vGPU on stop", "instance_id", id, "device_path", path, "error", err)
-			clearStoredVGPUDevice(stored)
+			log.WarnContext(ctx, "failed to destroy vGPU on stop; retaining assignment metadata", "instance_id", id, "device_path", path, "error", err)
 		}
 	}
 

--- a/lib/instances/vgpu.go
+++ b/lib/instances/vgpu.go
@@ -2,9 +2,11 @@ package instances
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/kernel/hypeman/lib/devices"
+	"github.com/kernel/hypeman/lib/logger"
 )
 
 func setStoredVGPUDevice(stored *StoredMetadata, device *devices.VGPUDevice) {
@@ -33,6 +35,25 @@ func releaseStoredVGPU(ctx context.Context, stored *StoredMetadata) error {
 	}
 	clearStoredVGPUDevice(stored)
 	return nil
+}
+
+// releaseRetainedVGPULocked releases a vGPU assignment retained on a stopped
+// instance after a failed release during the original stop. It is a no-op
+// when no assignment is retained. The caller must hold the instance lock.
+func (m *manager) releaseRetainedVGPULocked(ctx context.Context, id string) error {
+	meta, err := m.loadMetadata(id)
+	if err != nil {
+		return err
+	}
+	stored := &meta.StoredMetadata
+	if storedVGPUDevicePath(stored) == "" {
+		return nil
+	}
+	if err := releaseStoredVGPU(ctx, stored); err != nil {
+		logger.FromContext(ctx).ErrorContext(ctx, "failed to destroy retained vGPU; retaining assignment metadata", "instance_id", id, "error", err)
+		return fmt.Errorf("destroy vGPU: %w", err)
+	}
+	return m.saveMetadata(meta)
 }
 
 func storedVGPUDevicePath(stored *StoredMetadata) string {

--- a/lib/instances/vgpu.go
+++ b/lib/instances/vgpu.go
@@ -2,7 +2,6 @@ package instances
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"github.com/kernel/hypeman/lib/devices"
@@ -39,21 +38,26 @@ func releaseStoredVGPU(ctx context.Context, stored *StoredMetadata) error {
 
 // releaseRetainedVGPULocked releases a vGPU assignment retained on a stopped
 // instance after a failed release during the original stop. It is a no-op
-// when no assignment is retained. The caller must hold the instance lock.
-func (m *manager) releaseRetainedVGPULocked(ctx context.Context, id string) error {
+// when no assignment is retained, and a failed retry only logs so the
+// metadata stays for the next retry. The caller must hold the instance lock.
+func (m *manager) releaseRetainedVGPULocked(ctx context.Context, id string) {
+	log := logger.FromContext(ctx)
 	meta, err := m.loadMetadata(id)
 	if err != nil {
-		return err
+		log.WarnContext(ctx, "failed to load metadata for retained vGPU release", "instance_id", id, "error", err)
+		return
 	}
 	stored := &meta.StoredMetadata
 	if storedVGPUDevicePath(stored) == "" {
-		return nil
+		return
 	}
 	if err := releaseStoredVGPU(ctx, stored); err != nil {
-		logger.FromContext(ctx).ErrorContext(ctx, "failed to destroy retained vGPU; retaining assignment metadata", "instance_id", id, "error", err)
-		return fmt.Errorf("destroy vGPU: %w", err)
+		log.WarnContext(ctx, "failed to destroy retained vGPU; retaining assignment metadata", "instance_id", id, "error", err)
+		return
 	}
-	return m.saveMetadata(meta)
+	if err := m.saveMetadata(meta); err != nil {
+		log.WarnContext(ctx, "failed to save metadata after retained vGPU release", "instance_id", id, "error", err)
+	}
 }
 
 func storedVGPUDevicePath(stored *StoredMetadata) string {

--- a/lib/instances/vgpu.go
+++ b/lib/instances/vgpu.go
@@ -2,6 +2,7 @@ package instances
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/kernel/hypeman/lib/devices"

--- a/lib/instances/vgpu.go
+++ b/lib/instances/vgpu.go
@@ -2,7 +2,6 @@ package instances
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"github.com/kernel/hypeman/lib/devices"


### PR DESCRIPTION
## Summary

Layer 2 of the vendor VFIO vGPU stack (#366 ← **this** ← #363 ← #364 ← #321). Where #366 is a behavior-preserving refactor, this layer changes lifecycle semantics — release ordering and retention — still on mdev-era machinery, before the vendor VFIO backend lands above:

- **Delete releases the vGPU before other teardown** — a successful release persists the cleared assignment before later teardown. A failed release keeps the pre-refactor contract: it is logged and the delete continues, since the release guards never destroy a device they cannot prove is unowned and a skipped release is recovered by startup reconciliation. Stopped instances retry a previously failed release.
- **Stop keeps its no-op contract** — a failed retained-release on stop logs and retains the assignment metadata instead of failing the stop; assignments are passed to `DestroyVGPU` as a struct.
- **Forks don't inherit retained assignments** — a retained (failed-release) vGPU assignment is stripped from fork metadata so a fork can't release its parent's device.
- **Start persists a stale release immediately** — releasing a stale assignment before start writes the cleared metadata at once, so a later start failure can't leave metadata pointing at a device that's already gone.

## Testing

- `go build ./...`, `go vet` clean
- `go test -race` targeted `lib/instances` lifecycle suites pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes instance lifecycle semantics for GPU teardown, restart-policy blocking on delete, and snapshot restore metadata—incorrect ordering could leak vGPU slots or double-release, though failures remain best-effort with reconciliation.
> 
> **Overview**
> **Hardens vGPU assignment handling** across delete, stop, start, fork, and snapshot restore so host GPU state and on-disk metadata stay consistent when release fails or clones are created.
> 
> **Delete** now blocks restart policy before teardown (with a metadata reload so the block is not overwritten), and **releases vGPU immediately after the VMM is gone**—before network, devices, or volumes. A successful release is persisted; failures are logged and teardown still continues.
> 
> **Stop** no longer clears assignment metadata when `DestroyVGPU` fails; the assignment is **retained for retry**. Stopping an already-stopped instance retries release via `releaseRetainedVGPULocked` without breaking the no-op contract.
> 
> **Start** releases any stale retained assignment up front and **saves cleared metadata before** allocating a new vGPU, so a later start failure cannot leave metadata pointing at an already-destroyed device.
> 
> **Forks** (instance and snapshot) strip device path/UUID from fork metadata while keeping `GPUProfile`; **restore** keeps the instance’s current vGPU fields instead of resurrecting values embedded in the snapshot.
> 
> Lifecycle tests cover ordering, fork isolation, restore behavior, and best-effort delete on release failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fccdc8417374475c1538b5c31e1f853011611ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


