### PR TITLE
Make an auto-standby hold replace the previous deadline

### DIFF
--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -428,9 +428,10 @@ func (c *Controller) Describe(inst Instance) StatusSnapshot {
 
 // HoldStandby guarantees the controller will not put the instance into
 // standby before now + the policy idle timeout, and cancels any queued
-// standby attempt. The idle countdown itself is untouched; a hold only ever
-// extends the current one. It fails with ErrStandbyInProgress once a standby
-// operation is executing, and is a no-op for instances that cannot
+// standby attempt. The idle countdown itself is untouched. Each hold replaces
+// the instance's previous one, so a hold placed under a shorter idle timeout
+// moves an earlier, longer deadline in. It fails with ErrStandbyInProgress once
+// a standby operation is executing, and is a no-op for instances that cannot
 // auto-standby at all (unconfigured, disabled, or ineligible).
 func (c *Controller) HoldStandby(_ context.Context, inst Instance) (StatusSnapshot, error) {
 	now := c.now().UTC()
@@ -462,10 +463,12 @@ func (c *Controller) HoldStandby(_ context.Context, inst Instance) (StatusSnapsh
 		return c.Describe(inst), nil
 	}
 
+	// The newest hold wins. A caller holding under a shorter idle timeout is
+	// asking for a shorter deadline, and there is no release endpoint, so
+	// keeping the earlier longer one would pin the instance awake until it
+	// lapsed on its own.
 	holdUntil := now.Add(idleTimeout)
-	if holdUntil.After(state.holdUntil) {
-		state.holdUntil = holdUntil
-	}
+	state.holdUntil = holdUntil
 	state.standbyRequested = false
 	if state.compiledPolicy != nil {
 		c.armTimerLocked(inst.ID, state, now)

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -1384,6 +1384,51 @@ func TestHoldStandbyExtendsArmedCountdown(t *testing.T) {
 	controller.mu.RUnlock()
 }
 
+func TestHoldStandbyReplacesLongerHold(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	longPolicy := Instance{
+		ID:             "inst-reset-hold",
+		Name:           "inst-reset-hold",
+		State:          StateRunning,
+		NetworkEnabled: true,
+		IP:             "192.168.100.110",
+		AutoStandby:    &Policy{Enabled: true, IdleTimeout: "10m"},
+		Runtime:        &Runtime{IdleSince: &idleSince},
+	}
+	store := newFakeInstanceStore([]Instance{longPolicy})
+	now := idleSince
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	snapshot, err := controller.HoldStandby(context.Background(), longPolicy)
+	require.NoError(t, err)
+	require.NotNil(t, snapshot.HoldUntil)
+	assert.Equal(t, idleSince.Add(10*time.Minute), *snapshot.HoldUntil)
+
+	// Shortening the idle timeout a minute later, then holding again, must move
+	// hold_until in rather than leaving the ten minute deadline pinned.
+	now = idleSince.Add(time.Minute)
+	shortPolicy := longPolicy
+	shortPolicy.AutoStandby = &Policy{Enabled: true, IdleTimeout: "1m"}
+	require.NoError(t, controller.handleInstanceEvent(context.Background(), InstanceEvent{
+		Action:     InstanceEventUpdate,
+		InstanceID: shortPolicy.ID,
+		Instance:   &shortPolicy,
+	}))
+
+	snapshot, err = controller.HoldStandby(context.Background(), shortPolicy)
+	require.NoError(t, err)
+	require.NotNil(t, snapshot.HoldUntil)
+	assert.Equal(t, now.Add(time.Minute), *snapshot.HoldUntil)
+	require.NotNil(t, snapshot.NextStandbyAt)
+	assert.Equal(t, now.Add(time.Minute), *snapshot.NextStandbyAt)
+}
+
 func TestHoldStandbyCancelsQueuedStandby(t *testing.T) {
 	t.Parallel()
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3366,6 +3366,10 @@ paths:
         instance into standby before `hold_until`, and cancels any queued
         auto-standby attempt.
 
+        Each hold replaces the instance's previous hold, so `hold_until` always
+        reflects the most recent call. Holding again after the policy's
+        `idle_timeout` is shortened moves `hold_until` earlier.
+
         Callers may use this before opening a connection to a candidate-idle instance:
         a 200 means it is safe to connect until `hold_until`; a 409 means the
         instance is in standby (or irrevocably entering it) and must be restored


### PR DESCRIPTION
## Summary

`HoldStandby` only ever moved `hold_until` later:

```go
holdUntil := now.Add(idleTimeout)
if holdUntil.After(state.holdUntil) {
    state.holdUntil = holdUntil
}
```

So a hold placed while the policy's `idle_timeout` was long kept the instance awake for that full window, and a later hold under a shorter timeout was discarded. With no release endpoint, a caller had no way to walk a long hold back — the only path to standby sooner was `POST /instances/{id}/standby`.

Holds are now per-instance last-write-wins: each call sets `hold_until` to `now + the current policy idle timeout` outright. Hold at a 30s timeout, shorten the policy, hold again at 3s → `hold_until` moves in to `now+3s`.

Nothing else changes. `armTimerLocked` already takes `max(idleSince+idleTimeout, holdUntil)`, so a shortened hold re-arms the timer at the plain idle countdown rather than firing early, and the extension case is unaffected because `now + idleTimeout` on a stable policy always lands later than a prior hold's deadline.

## Notes

- The endpoint takes no duration, so concurrent holders on the same instance all compute the same deadline. Replacement only changes behavior when the policy's `idle_timeout` changed between calls.
- Holds stay in-memory only; the persisted countdown is still untouched.

## Testing

`go test ./lib/autostandby/` passes, including the existing hold tests. Added `TestHoldStandbyReplacesLongerHold`, which holds under a 10m timeout, shortens the policy to 1m, holds again, and asserts both `hold_until` and `next_standby_at` move in.

A full `go build ./...` fails on this checkout for unrelated reasons — three `go:embed` patterns (cloud-hypervisor, guest-agent, caddy binaries) need `make` to fetch their artifacts first. That is pre-existing and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in in-memory auto-standby hold logic; extends existing hold tests and OpenAPI docs only.
> 
> **Overview**
> **Auto-standby holds are now last-write-wins.** Each `HoldStandby` call sets `hold_until` to `now +` the current policy `idle_timeout` instead of only moving the deadline later, so a hold after shortening `idle_timeout` can pull `hold_until` and `next_standby_at` earlier.
> 
> Docs on `HoldStandby` and `POST /instances/{id}/auto-standby/hold` describe replacement behavior. **`TestHoldStandbyReplacesLongerHold`** covers hold under 10m, policy shortened to 1m, then hold again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2430a2ded86f25b976fe3af59883d5b6f9a83cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->