### PR TITLE
Use the resolved instance in the auto-standby hold handler

### DIFF
--- a/cmd/api/api/auto_standby_hold.go
+++ b/cmd/api/api/auto_standby_hold.go
@@ -7,24 +7,18 @@ import (
 	"github.com/kernel/hypeman/lib/autostandby"
 	"github.com/kernel/hypeman/lib/instances"
 	"github.com/kernel/hypeman/lib/logger"
+	mw "github.com/kernel/hypeman/lib/middleware"
 	"github.com/kernel/hypeman/lib/oapi"
 )
 
 func (s *ApiService) HoldAutoStandby(ctx context.Context, request oapi.HoldAutoStandbyRequestObject) (oapi.HoldAutoStandbyResponseObject, error) {
 	log := logger.FromContext(ctx)
 
-	inst, err := s.InstanceManager.GetInstance(ctx, request.Id)
-	if err != nil {
-		if err == instances.ErrNotFound || err == instances.ErrAmbiguousName {
-			return oapi.HoldAutoStandby404JSONResponse{
-				Code:    "not_found",
-				Message: "instance not found",
-			}, nil
-		}
-		log.ErrorContext(ctx, "failed to resolve instance for auto-standby hold", "instance_id", request.Id, "error", err)
+	inst := mw.GetResolvedInstance[instances.Instance](ctx)
+	if inst == nil {
 		return oapi.HoldAutoStandby500JSONResponse{
 			Code:    "internal_error",
-			Message: "failed to load instance",
+			Message: "resource not resolved",
 		}, nil
 	}
 
@@ -39,6 +33,7 @@ func (s *ApiService) HoldAutoStandby(ctx context.Context, request oapi.HoldAutoS
 			Reason:       autostandby.ReasonUnsupportedPlatform,
 		}
 	} else {
+		var err error
 		snapshot, err = s.AutoStandbyController.HoldStandby(ctx, instanceToAutoStandby(*inst))
 		if err != nil {
 			if errors.Is(err, autostandby.ErrStandbyInProgress) {
@@ -54,10 +49,10 @@ func (s *ApiService) HoldAutoStandby(ctx context.Context, request oapi.HoldAutoS
 			}, nil
 		}
 
-		// The instance can complete a standby between the load above and the
-		// hold taking effect; re-check so a 200 never describes a standby
-		// instance.
-		inst, err = s.InstanceManager.GetInstance(ctx, request.Id)
+		// The instance can complete a standby between resolution and the hold
+		// taking effect; re-check so a 200 never describes a standby instance.
+		// Reloading by resolved ID skips the name/prefix resolution path.
+		inst, err = s.InstanceManager.GetInstance(ctx, inst.Id)
 		if err != nil {
 			if err == instances.ErrNotFound || err == instances.ErrAmbiguousName {
 				return oapi.HoldAutoStandby404JSONResponse{

--- a/cmd/api/api/auto_standby_hold_test.go
+++ b/cmd/api/api/auto_standby_hold_test.go
@@ -49,7 +49,7 @@ func TestHoldAutoStandbyExtendsCountdown(t *testing.T) {
 	base.InstanceManager = &captureStatusManager{Manager: base.InstanceManager, instance: inst}
 	base.AutoStandbyController = controller
 
-	resp, err := base.HoldAutoStandby(ctx(), oapi.HoldAutoStandbyRequestObject{Id: "inst-hold"})
+	resp, err := base.HoldAutoStandby(ctxWithInstance(base, "inst-hold"), oapi.HoldAutoStandbyRequestObject{Id: "inst-hold"})
 	require.NoError(t, err)
 
 	holdResp, ok := resp.(oapi.HoldAutoStandby200JSONResponse)
@@ -76,7 +76,7 @@ func TestHoldAutoStandbyConflictWhenInstanceInStandby(t *testing.T) {
 		},
 	}
 
-	resp, err := base.HoldAutoStandby(ctx(), oapi.HoldAutoStandbyRequestObject{Id: "inst-standby"})
+	resp, err := base.HoldAutoStandby(ctxWithInstance(base, "inst-standby"), oapi.HoldAutoStandbyRequestObject{Id: "inst-standby"})
 	require.NoError(t, err)
 
 	conflictResp, ok := resp.(oapi.HoldAutoStandby409JSONResponse)
@@ -122,7 +122,7 @@ func TestHoldAutoStandbyConflictWhenStandbyCompletesDuringHold(t *testing.T) {
 	base.InstanceManager = &sequenceManager{Manager: base.InstanceManager, sequence: []*instances.Instance{running, standby}}
 	base.AutoStandbyController = controller
 
-	resp, err := base.HoldAutoStandby(ctx(), oapi.HoldAutoStandbyRequestObject{Id: "inst-race"})
+	resp, err := base.HoldAutoStandby(ctxWithInstance(base, "inst-race"), oapi.HoldAutoStandbyRequestObject{Id: "inst-race"})
 	require.NoError(t, err)
 
 	conflictResp, ok := resp.(oapi.HoldAutoStandby409JSONResponse)
@@ -148,7 +148,7 @@ func TestHoldAutoStandbyUnsupportedWithoutController(t *testing.T) {
 		},
 	}
 
-	resp, err := base.HoldAutoStandby(ctx(), oapi.HoldAutoStandbyRequestObject{Id: "inst-nosupport"})
+	resp, err := base.HoldAutoStandby(ctxWithInstance(base, "inst-nosupport"), oapi.HoldAutoStandbyRequestObject{Id: "inst-nosupport"})
 	require.NoError(t, err)
 
 	holdResp, ok := resp.(oapi.HoldAutoStandby200JSONResponse)


### PR DESCRIPTION
`HoldAutoStandby` re-resolved the instance that `ResolveResource` middleware had already loaded, so a hold cost three full instance loads where the comparable `restore` fast path costs one. Each load reads and unmarshals instance metadata from disk, which dominates the request.

Measured on a live running browser VM on a staging host, warm connection, n=20, all 200s:

| call | p50 |
| --- | --- |
| `POST /instances/{id}/auto-standby/hold` | 25.9ms |
| `POST /instances/{id}/restore` (already running) | 10.2ms |
| `GET /instances/{id}` | 9.4ms |

Server-side spans agree (23.4 vs 8.9ms). The three `instances.derive_state` children total 53µs, so hydration is not the cost — the surrounding metadata loads are. Callers hold on the connection-setup path, so this is paid per connection.

## Change

- Take the instance from context via `mw.GetResolvedInstance`, as `RestoreInstance` and the other instance handlers do. Removes one of three loads, ~8ms on the host above (not yet measured post-change; needs a deploy).
- Reload by resolved ID in the post-hold re-check, skipping name/prefix resolution.
- The handler's 404 branch went with it — already unreachable, since `ResolveResource` responds before the handler runs.

The re-check stays: it is what keeps a 200 from describing an instance that completed standby mid-request.

## Tests

`go test -run AutoStandby ./cmd/api/api/` and `./lib/autostandby/` pass; `go vet` clean. The hold tests now build context with the existing `ctxWithInstance` helper so they exercise the resolver path instead of bypassing it; the standby-completes-during-hold race is still covered.

Three tests in the full package (`TestCpToAndFromInstance`, `TestInstanceLifecycle_StopStart`, `TestRegistryDockerV2ManifestConversion`) fail locally — they need root network capabilities and registry pulls, and fail identically on `main`.

## Follow-ups, not here

- The remaining re-check load can go: it only reads `State`, and the race it guards exists on one path inside `HoldStandby`. Having `HoldStandby` report which path it took would reach parity with `restore`.
- `GetAutoStandbyStatus` has the same redundancy; left alone as it is not on the connect path.
- ~8ms for a small read plus unmarshal is itself suspect — likely contention on the global snapshot-source alias lock in `loadMetadata`, or disk. Every endpoint pays it.
- `HoldStandby` emits no span, which is why most of a hold request is unattributed in tracing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)