### PR TITLE
Queue image rebuilds behind in-flight builds instead of dropping them

### DIFF
--- a/lib/images/credentials_test.go
+++ b/lib/images/credentials_test.go
@@ -113,9 +113,28 @@ func TestBorrowedCredentialsExpireWhileQueued(t *testing.T) {
 		return m.inflightPulls[digest].credentials == nil
 	}, time.Second, time.Millisecond)
 
-	credentials, _, expired := m.borrowedAuth(digest)
+	credentials, _, expired, stale := m.borrowedAuth(digest, inflight)
 	assert.True(t, expired)
+	assert.False(t, stale)
 	assert.Nil(t, credentials)
+}
+
+func TestBorrowedAuthRejectsReplacedInflightPull(t *testing.T) {
+	m := &manager{inflightPulls: make(map[string]*inflightImagePull)}
+	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	first := m.registerInflightPull(digest, &authn.AuthConfig{Username: "first"})
+	second := m.registerInflightPull(digest, &authn.AuthConfig{Username: "second"})
+	defer m.releaseInflightPull(digest, second)()
+
+	credentials, _, expired, stale := m.borrowedAuth(digest, first)
+	assert.Nil(t, credentials)
+	assert.False(t, expired)
+	assert.True(t, stale)
+
+	credentials, _, expired, stale = m.borrowedAuth(digest, second)
+	assert.Equal(t, "second", credentials.Username)
+	assert.False(t, expired)
+	assert.False(t, stale)
 }
 
 func TestRecoverInterruptedCredentialedConversionFromCache(t *testing.T) {

--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -377,7 +377,7 @@ func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest, 
 	// Keep borrowed credentials outside the queued closure so their lifetime is
 	// bounded even when this job waits behind another pull.
 	inflight := m.registerInflightPull(ref.Digest(), req.Credentials)
-	queuePos := m.queue.Enqueue(ref.Digest(), func() {
+	queuePos := m.queue.EnqueueSuccessor(ref.Digest(), func() {
 		credentials, deadline, expired := m.borrowedAuth(ref.Digest())
 		if expired {
 			m.updateStatusByDigest(ref, StatusFailed, ErrBorrowedCredentialsExpired)

--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -340,17 +340,20 @@ func (m *manager) releaseInflightPull(digest string, inflight *inflightImagePull
 	}
 }
 
-func (m *manager) borrowedAuth(digest string) (*authn.AuthConfig, time.Time, bool) {
+func (m *manager) borrowedAuth(digest string, expected *inflightImagePull) (*authn.AuthConfig, time.Time, bool, bool) {
 	m.createMu.Lock()
 	defer m.createMu.Unlock()
 	inflight := m.inflightPulls[digest]
+	if expected != nil && inflight != expected {
+		return nil, time.Time{}, false, true
+	}
 	if inflight == nil || inflight.credentialsExpireAt.IsZero() {
-		return nil, time.Time{}, false
+		return nil, time.Time{}, false, false
 	}
 	if inflight.credentials == nil || time.Now().After(inflight.credentialsExpireAt) {
-		return nil, inflight.credentialsExpireAt, true
+		return nil, inflight.credentialsExpireAt, true, false
 	}
-	return inflight.credentials, inflight.credentialsExpireAt, false
+	return inflight.credentials, inflight.credentialsExpireAt, false, false
 }
 
 func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest, requestedPlatform Platform) (*Image, error) {
@@ -386,7 +389,10 @@ func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest, 
 	inflight := m.registerInflightPull(ref.Digest(), req.Credentials)
 	buildID := meta.BuildID
 	queuePos := m.queue.EnqueueSuccessor(ref.Digest(), func() {
-		credentials, deadline, expired := m.borrowedAuth(ref.Digest())
+		credentials, deadline, expired, stale := m.borrowedAuth(ref.Digest(), inflight)
+		if stale {
+			return
+		}
 		if expired {
 			m.updateStatusByDigest(ref, StatusFailed, ErrBorrowedCredentialsExpired, buildID)
 			return

--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -300,6 +300,9 @@ func (m *manager) registerInflightPull(digest string, credentials *authn.AuthCon
 	if m.inflightPulls == nil {
 		m.inflightPulls = make(map[string]*inflightImagePull)
 	}
+	if previous := m.inflightPulls[digest]; previous != nil && previous.timer != nil {
+		previous.timer.Stop()
+	}
 	inflight := &inflightImagePull{
 		fingerprint: credentialFingerprint(credentials),
 		credentials: credentials,

--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -14,11 +14,14 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/uuid"
 	"github.com/kernel/hypeman/lib/paths"
 	"github.com/kernel/hypeman/lib/queue"
 	"github.com/kernel/hypeman/lib/tags"
 	"go.opentelemetry.io/otel/metric"
 )
+
+var errStaleBuild = errors.New("stale image build")
 
 const (
 	StatusPending    = "pending"
@@ -365,6 +368,7 @@ func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest, 
 		Status:       StatusPending,
 		Request:      &storedReq,
 		BorrowedAuth: req.Credentials != nil,
+		BuildID:      uuid.New().String(),
 		Tags:         tags.Clone(req.Tags),
 		CreatedAt:    time.Now(),
 	}
@@ -377,10 +381,11 @@ func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest, 
 	// Keep borrowed credentials outside the queued closure so their lifetime is
 	// bounded even when this job waits behind another pull.
 	inflight := m.registerInflightPull(ref.Digest(), req.Credentials)
+	buildID := meta.BuildID
 	queuePos := m.queue.EnqueueSuccessor(ref.Digest(), func() {
 		credentials, deadline, expired := m.borrowedAuth(ref.Digest())
 		if expired {
-			m.updateStatusByDigest(ref, StatusFailed, ErrBorrowedCredentialsExpired)
+			m.updateStatusByDigest(ref, StatusFailed, ErrBorrowedCredentialsExpired, buildID)
 			return
 		}
 		ctx := context.Background()
@@ -389,7 +394,7 @@ func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest, 
 			ctx, cancel = context.WithDeadline(ctx, deadline)
 			defer cancel()
 		}
-		m.buildImage(ctx, ref, credentials)
+		m.buildImage(ctx, ref, credentials, buildID)
 	}, m.releaseInflightPull(ref.Digest(), inflight))
 
 	img := meta.toImage()
@@ -399,7 +404,7 @@ func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest, 
 	return img, nil
 }
 
-func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef, credentials *authn.AuthConfig) {
+func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef, credentials *authn.AuthConfig, buildID string) {
 	buildStart := time.Now()
 	buildStatus := "failed"
 	buildDir := m.paths.SystemBuild(ref.String())
@@ -409,7 +414,7 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef, credentials 
 	}()
 
 	if err := os.MkdirAll(buildDir, 0755); err != nil {
-		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("create build dir: %w", err))
+		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("create build dir: %w", err), buildID)
 		return
 	}
 
@@ -420,7 +425,7 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef, credentials 
 		m.recordImageBuildPhase(ctx, ref.Digest(), "cleanup", time.Since(start), phaseStatus(err), "not_applicable")
 	}()
 
-	m.updateStatusByDigest(ref, StatusPulling, nil)
+	m.updateStatusByDigest(ref, StatusPulling, nil, buildID)
 
 	// Pull by the digest-pinned reference, not the tag: a digest ref fetches the
 	// exact manifest regardless of the platform passed downstream, so a
@@ -431,7 +436,7 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef, credentials 
 	result, err := m.ociClient.pullAndExportWithAuth(ctx, pullRef, ref.Digest(), tempDir, credentials)
 	m.recordPullResultMetrics(ctx, ref.Digest(), result)
 	if err != nil {
-		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("pull and export: %w", err))
+		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("pull and export: %w", err), buildID)
 		m.recordPullMetrics(ctx, "failed")
 		return
 	}
@@ -449,7 +454,7 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef, credentials 
 		}
 	}
 
-	m.updateStatusByDigest(ref, StatusConverting, nil)
+	m.updateStatusByDigest(ref, StatusConverting, nil, buildID)
 
 	diskPath := digestPath(m.paths, ref.Repository(), ref.DigestHex())
 	// Use default image format (erofs on Linux, ext4 on Darwin)
@@ -457,30 +462,32 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef, credentials 
 	diskSize, err := ExportRootfs(tempDir, diskPath, DefaultImageFormat)
 	m.recordImageBuildPhase(ctx, ref.Digest(), "filesystem_export", time.Since(convertStart), phaseStatus(err), "not_applicable")
 	if err != nil {
-		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("convert to %s: %w", DefaultImageFormat, err))
+		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("convert to %s: %w", DefaultImageFormat, err), buildID)
 		return
 	}
 
 	finalizeStart := time.Now()
-	err = m.finalizeImage(ref, result, diskSize)
+	err = m.finalizeImage(ref, result, diskSize, buildID)
 	m.recordImageBuildPhase(ctx, ref.Digest(), "finalize", time.Since(finalizeStart), phaseStatus(err), "not_applicable")
 	if err != nil {
-		m.updateStatusByDigest(ref, StatusFailed, err)
+		if errors.Is(err, errStaleBuild) {
+			return
+		}
+		m.updateStatusByDigest(ref, StatusFailed, err, buildID)
 		return
 	}
 
 	buildStatus = "success"
 }
 
-func (m *manager) finalizeImage(ref *ResolvedRef, result *pullResult, diskSize int64) error {
-	// Read current metadata to preserve request info.
+func (m *manager) finalizeImage(ref *ResolvedRef, result *pullResult, diskSize int64, buildID string) error {
+	m.createMu.Lock()
+	defer m.createMu.Unlock()
+
+	// Read current metadata to preserve request info and reject stale builds.
 	meta, err := readMetadata(m.paths, ref.Repository(), ref.DigestHex())
-	if err != nil {
-		meta = &imageMetadata{
-			Name:      ref.String(),
-			Digest:    ref.Digest(),
-			CreatedAt: time.Now(),
-		}
+	if err != nil || meta.BuildID != buildID {
+		return errStaleBuild
 	}
 
 	// The pulled image config is the source of truth for the platform.
@@ -557,19 +564,15 @@ func (m *manager) recordImageBuildPhase(ctx context.Context, digest, phase strin
 	)
 }
 
-func (m *manager) updateStatusByDigest(ref *ResolvedRef, status string, err error) {
+func (m *manager) updateStatusByDigest(ref *ResolvedRef, status string, err error, buildID string) {
+	m.createMu.Lock()
+	defer m.createMu.Unlock()
+
 	meta, readErr := readMetadata(m.paths, ref.Repository(), ref.DigestHex())
-	if readErr != nil {
-		// Create new metadata if it doesn't exist
-		meta = &imageMetadata{
-			Name:      ref.String(),
-			Digest:    ref.Digest(),
-			Status:    status,
-			CreatedAt: time.Now(),
-		}
-	} else {
-		meta.Status = status
+	if readErr != nil || meta.BuildID != buildID {
+		return
 	}
+	meta.Status = status
 
 	if err != nil {
 		errorMsg := err.Error()
@@ -578,7 +581,8 @@ func (m *manager) updateStatusByDigest(ref *ResolvedRef, status string, err erro
 
 	writeMetadata(m.paths, ref.Repository(), ref.DigestHex(), meta)
 
-	// Notify subscribers of terminal status
+	// Notify while holding createMu so a delete/recreate cannot race the
+	// metadata write and receive a terminal event for the old build.
 	if status == StatusReady || status == StatusFailed {
 		m.notifyReady(ref.DigestHex(), status, err)
 	}
@@ -608,11 +612,12 @@ func (m *manager) RecoverInterruptedBuilds() {
 		}
 		ref := NewResolvedRef(normalized, meta.Digest)
 		if meta.BorrowedAuth && (meta.Status != StatusConverting || !m.ociClient.existsInLayout(digestToLayoutTag(meta.Digest))) {
-			m.updateStatusByDigest(ref, StatusFailed, ErrBorrowedCredentialsExpired)
+			m.updateStatusByDigest(ref, StatusFailed, ErrBorrowedCredentialsExpired, meta.BuildID)
 			continue
 		}
+		buildID := meta.BuildID
 		m.queue.Enqueue(meta.Digest, func() {
-			m.buildImage(context.Background(), ref, nil)
+			m.buildImage(context.Background(), ref, nil, buildID)
 		}, nil)
 	}
 }

--- a/lib/images/manager_test.go
+++ b/lib/images/manager_test.go
@@ -670,6 +670,17 @@ func TestDeleteAndRecreateDuringBuildTail(t *testing.T) {
 	currentMeta, err := readMetadata(p, repo, digestHex)
 	require.NoError(t, err)
 	require.NotEqual(t, firstMeta.BuildID, currentMeta.BuildID)
+	require.NoError(t, m.DeleteImage(ctx, repo+"@"+digestStr))
+	recreatedAgain, err := m.ImportLocalImage(ctx, repo, tag, digestStr)
+	require.NoError(t, err)
+	require.Equal(t, StatusPending, recreatedAgain.Status)
+	require.NotNil(t, recreatedAgain.QueuePosition)
+	require.Equal(t, 1, *recreatedAgain.QueuePosition)
+	latestMeta, err := readMetadata(p, repo, digestHex)
+	require.NoError(t, err)
+	require.NotEqual(t, currentMeta.BuildID, latestMeta.BuildID)
+	currentMeta = latestMeta
+
 	waitCtx, cancelWait := context.WithCancel(ctx)
 	defer cancelWait()
 	waitResult := make(chan error, 1)

--- a/lib/images/manager_test.go
+++ b/lib/images/manager_test.go
@@ -642,6 +642,9 @@ func TestDeleteAndRecreateDuringBuildTail(t *testing.T) {
 	case <-time.After(30 * time.Second):
 		t.Fatal("first build did not become ready")
 	}
+	firstMeta, err := readMetadata(p, repo, digestHex)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstMeta.BuildID)
 
 	slotHeld := make(chan struct{})
 	releaseSlot := make(chan struct{})
@@ -664,6 +667,32 @@ func TestDeleteAndRecreateDuringBuildTail(t *testing.T) {
 	require.NotNil(t, recreated.QueuePosition)
 	require.Equal(t, 1, *recreated.QueuePosition)
 
+	currentMeta, err := readMetadata(p, repo, digestHex)
+	require.NoError(t, err)
+	require.NotEqual(t, firstMeta.BuildID, currentMeta.BuildID)
+	waitCtx, cancelWait := context.WithCancel(ctx)
+	defer cancelWait()
+	waitResult := make(chan error, 1)
+	go func() {
+		waitResult <- m.WaitForReady(waitCtx, repo+"@"+digestStr)
+	}()
+	select {
+	case err := <-waitResult:
+		t.Fatalf("recreated image completed before successor ran: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	normalized, err := ParseNormalizedRef(repo + "@" + digestStr)
+	require.NoError(t, err)
+	staleRef := NewResolvedRef(normalized, digestStr)
+	m.updateStatusByDigest(staleRef, StatusFailed, errors.New("stale build"), firstMeta.BuildID)
+	staleResult, _, _, err := m.ociClient.extractOCIImageDetails(digestHex)
+	require.NoError(t, err)
+	require.ErrorIs(t, m.finalizeImage(staleRef, &pullResult{Metadata: staleResult}, 1, firstMeta.BuildID), errStaleBuild)
+	currentMeta, err = readMetadata(p, repo, digestHex)
+	require.NoError(t, err)
+	require.Equal(t, StatusPending, currentMeta.Status)
+	require.Nil(t, currentMeta.Error)
+
 	close(releaseSlot)
 	select {
 	case event := <-events:
@@ -671,7 +700,12 @@ func TestDeleteAndRecreateDuringBuildTail(t *testing.T) {
 	case <-time.After(30 * time.Second):
 		t.Fatal("recreated image did not become ready")
 	}
-	waitForReady(t, m, ctx, repo+":"+tag)
+	select {
+	case err := <-waitResult:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("WaitForReady did not observe the successor build")
+	}
 }
 
 // waitForReady waits for an image build to complete

--- a/lib/images/manager_test.go
+++ b/lib/images/manager_test.go
@@ -602,6 +602,78 @@ func TestImportLocalImageFromOCICache(t *testing.T) {
 	t.Logf("Disk path verified: %s (%d bytes)", diskPath, diskStat.Size())
 }
 
+func TestDeleteAndRecreateDuringBuildTail(t *testing.T) {
+	origFormat := DefaultImageFormat
+	DefaultImageFormat = FormatCpio
+	defer func() { DefaultImageFormat = origFormat }()
+
+	dataDir := t.TempDir()
+	p := paths.New(dataDir)
+	mgr, err := NewManager(p, 1, nil)
+	require.NoError(t, err)
+	m := mgr.(*manager)
+
+	ctx := context.Background()
+	const repo = "kernel.local/test/recreate-race"
+	const tag = "v1"
+
+	testImg := createTestDockerImage(t)
+	imgDigest, err := testImg.Digest()
+	require.NoError(t, err)
+	digestStr := imgDigest.String()
+
+	cacheDir := p.SystemOCICache()
+	layoutPath, err := layout.Write(cacheDir, empty.Index)
+	require.NoError(t, err)
+	require.NoError(t, layoutPath.AppendImage(testImg, layout.WithAnnotations(map[string]string{
+		"org.opencontainers.image.ref.name": digestToLayoutTag(digestStr),
+	})))
+
+	digestHex := digestToLayoutTag(digestStr)
+	events := make(chan StatusEvent, 2)
+	m.subscribeToReady(digestHex, events)
+	defer m.unsubscribeFromReady(digestHex, events)
+
+	_, err = m.ImportLocalImage(ctx, repo, tag, digestStr)
+	require.NoError(t, err)
+	select {
+	case event := <-events:
+		require.Equal(t, StatusReady, event.Status)
+	case <-time.After(30 * time.Second):
+		t.Fatal("first build did not become ready")
+	}
+
+	slotHeld := make(chan struct{})
+	releaseSlot := make(chan struct{})
+	m.queue.EnqueueSuccessor(digestStr, func() {
+		close(slotHeld)
+		<-releaseSlot
+	}, nil)
+	select {
+	case <-slotHeld:
+	case <-time.After(5 * time.Second):
+		t.Fatal("queue slot was not held")
+	}
+
+	// Delete by digest so the test does not depend on the tag symlink being
+	// created after the ready notification.
+	require.NoError(t, m.DeleteImage(ctx, repo+"@"+digestStr))
+	recreated, err := m.ImportLocalImage(ctx, repo, tag, digestStr)
+	require.NoError(t, err)
+	require.Equal(t, StatusPending, recreated.Status)
+	require.NotNil(t, recreated.QueuePosition)
+	require.Equal(t, 1, *recreated.QueuePosition)
+
+	close(releaseSlot)
+	select {
+	case event := <-events:
+		require.Equal(t, StatusReady, event.Status)
+	case <-time.After(30 * time.Second):
+		t.Fatal("recreated image did not become ready")
+	}
+	waitForReady(t, m, ctx, repo+":"+tag)
+}
+
 // waitForReady waits for an image build to complete
 func waitForReady(t *testing.T, mgr Manager, ctx context.Context, imageName string) {
 	for i := 0; i < 600; i++ {

--- a/lib/images/storage.go
+++ b/lib/images/storage.go
@@ -29,6 +29,7 @@ type imageMetadata struct {
 	WorkingDir   string              `json:"working_dir,omitempty"`
 	CreatedAt    time.Time           `json:"created_at"`
 	BorrowedAuth bool                `json:"borrowed_auth,omitempty"`
+	BuildID      string              `json:"build_id,omitempty"`
 }
 
 func (m *imageMetadata) toImage() *Image {

--- a/lib/queue/queue.go
+++ b/lib/queue/queue.go
@@ -39,28 +39,23 @@ func New(maxConcurrent int) *Queue {
 // is torn down only once the queue is done with it), but only when this call
 // actually started the job — a dedup'd enqueue does not run it.
 func (q *Queue) Enqueue(key string, startFn func(), done func()) int {
-	return q.enqueue(key, startFn, done, false)
+	return q.enqueue(key, startFn, done, false, false)
 }
 
 // EnqueueSuccessor queues a new job behind an active job with the same key.
-// Pending jobs with the same key are still deduplicated. This is useful when
-// the caller has replaced the persisted work for a key while the previous job
-// is finishing.
+// If a successor is already pending, it is replaced by the new job. This is
+// useful when the caller has replaced the persisted work for a key while the
+// previous job is finishing.
 func (q *Queue) EnqueueSuccessor(key string, startFn func(), done func()) int {
-	return q.enqueue(key, startFn, done, true)
+	return q.enqueue(key, startFn, done, true, true)
 }
 
-func (q *Queue) enqueue(key string, startFn func(), done func(), allowActive bool) int {
+func (q *Queue) enqueue(key string, startFn func(), done func(), allowActive, replacePending bool) int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
 	if q.active[key] && !allowActive {
 		return 0
-	}
-	for i, j := range q.pending {
-		if j.key == key {
-			return i + 1
-		}
 	}
 
 	wrappedFn := func() {
@@ -71,6 +66,15 @@ func (q *Queue) enqueue(key string, startFn func(), done func(), allowActive boo
 		}
 		defer q.complete(key)
 		startFn()
+	}
+
+	for i, j := range q.pending {
+		if j.key == key {
+			if replacePending {
+				q.pending[i] = job{key: key, startFn: wrappedFn}
+			}
+			return i + 1
+		}
 	}
 
 	if len(q.active) < q.maxConcurrent && !q.active[key] {

--- a/lib/queue/queue.go
+++ b/lib/queue/queue.go
@@ -39,10 +39,22 @@ func New(maxConcurrent int) *Queue {
 // is torn down only once the queue is done with it), but only when this call
 // actually started the job — a dedup'd enqueue does not run it.
 func (q *Queue) Enqueue(key string, startFn func(), done func()) int {
+	return q.enqueue(key, startFn, done, false)
+}
+
+// EnqueueSuccessor queues a new job behind an active job with the same key.
+// Pending jobs with the same key are still deduplicated. This is useful when
+// the caller has replaced the persisted work for a key while the previous job
+// is finishing.
+func (q *Queue) EnqueueSuccessor(key string, startFn func(), done func()) int {
+	return q.enqueue(key, startFn, done, true)
+}
+
+func (q *Queue) enqueue(key string, startFn func(), done func(), allowActive bool) int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	if q.active[key] {
+	if q.active[key] && !allowActive {
 		return 0
 	}
 	for i, j := range q.pending {
@@ -61,7 +73,7 @@ func (q *Queue) Enqueue(key string, startFn func(), done func()) int {
 		startFn()
 	}
 
-	if len(q.active) < q.maxConcurrent {
+	if len(q.active) < q.maxConcurrent && !q.active[key] {
 		q.active[key] = true
 		// The key enters the active set before the goroutine launches, both
 		// under the lock, so a concurrent Enqueue always observes the slot and
@@ -77,17 +89,23 @@ func (q *Queue) Enqueue(key string, startFn func(), done func()) int {
 }
 
 // complete removes the key from the active set and starts the next pending
-// job if there is capacity.
+// job if there is capacity. Pending successors for an active key are skipped
+// until that key completes.
 func (q *Queue) complete(key string) {
 	q.mu.Lock()
 	delete(q.active, key)
 
 	var next *job
-	if len(q.pending) > 0 && len(q.active) < q.maxConcurrent {
-		nextJob := q.pending[0]
-		q.pending = q.pending[1:]
-		q.active[nextJob.key] = true
-		next = &nextJob
+	if len(q.active) < q.maxConcurrent {
+		for i, pending := range q.pending {
+			if q.active[pending.key] {
+				continue
+			}
+			q.pending = append(q.pending[:i], q.pending[i+1:]...)
+			q.active[pending.key] = true
+			next = &pending
+			break
+		}
 	}
 	q.mu.Unlock()
 
@@ -96,15 +114,12 @@ func (q *Queue) complete(key string) {
 	}
 }
 
-// GetPosition returns nil if the key is active or unknown, otherwise its
-// 1-based position in the pending queue.
+// GetPosition returns nil if the key is unknown or active without a
+// successor, otherwise its 1-based position in the pending queue.
 func (q *Queue) GetPosition(key string) *int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	if q.active[key] {
-		return nil
-	}
 	for i, j := range q.pending {
 		if j.key == key {
 			pos := i + 1

--- a/lib/queue/queue_test.go
+++ b/lib/queue/queue_test.go
@@ -109,7 +109,7 @@ func TestEnqueueSuccessor(t *testing.T) {
 	q := New(1)
 	release := make(chan struct{})
 	started := make(chan struct{}, 1)
-	successorDone := make(chan struct{})
+	replacementDone := make(chan struct{})
 
 	q.Enqueue("same", func() {
 		started <- struct{}{}
@@ -117,9 +117,7 @@ func TestEnqueueSuccessor(t *testing.T) {
 	}, nil)
 	<-started
 
-	pos := q.EnqueueSuccessor("same", func() {}, func() {
-		close(successorDone)
-	})
+	pos := q.EnqueueSuccessor("same", func() {}, nil)
 	if pos != 1 {
 		t.Fatalf("successor position = %d, want 1", pos)
 	}
@@ -127,16 +125,18 @@ func TestEnqueueSuccessor(t *testing.T) {
 		t.Fatalf("GetPosition(same) = %v, want 1", pos)
 	}
 
-	duplicatePos := q.EnqueueSuccessor("same", func() {}, nil)
+	duplicatePos := q.EnqueueSuccessor("same", func() {}, func() {
+		close(replacementDone)
+	})
 	if duplicatePos != 1 {
 		t.Fatalf("duplicate successor position = %d, want 1", duplicatePos)
 	}
 
 	close(release)
 	select {
-	case <-successorDone:
+	case <-replacementDone:
 	case <-time.After(5 * time.Second):
-		t.Fatal("successor did not run after active job completed")
+		t.Fatal("replacement successor did not run after active job completed")
 	}
 }
 

--- a/lib/queue/queue_test.go
+++ b/lib/queue/queue_test.go
@@ -109,7 +109,7 @@ func TestEnqueueSuccessor(t *testing.T) {
 	q := New(1)
 	release := make(chan struct{})
 	started := make(chan struct{}, 1)
-	var ran int64
+	successorDone := make(chan struct{})
 
 	q.Enqueue("same", func() {
 		started <- struct{}{}
@@ -117,9 +117,9 @@ func TestEnqueueSuccessor(t *testing.T) {
 	}, nil)
 	<-started
 
-	pos := q.EnqueueSuccessor("same", func() {
-		atomic.AddInt64(&ran, 1)
-	}, nil)
+	pos := q.EnqueueSuccessor("same", func() {}, func() {
+		close(successorDone)
+	})
 	if pos != 1 {
 		t.Fatalf("successor position = %d, want 1", pos)
 	}
@@ -127,20 +127,16 @@ func TestEnqueueSuccessor(t *testing.T) {
 		t.Fatalf("GetPosition(same) = %v, want 1", pos)
 	}
 
-	duplicatePos := q.EnqueueSuccessor("same", func() {
-		atomic.AddInt64(&ran, 1)
-	}, nil)
+	duplicatePos := q.EnqueueSuccessor("same", func() {}, nil)
 	if duplicatePos != 1 {
 		t.Fatalf("duplicate successor position = %d, want 1", duplicatePos)
 	}
 
 	close(release)
-	deadline := time.Now().Add(5 * time.Second)
-	for atomic.LoadInt64(&ran) != 1 || q.QueueLength() != 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("successor did not run after active job completed")
-		}
-		time.Sleep(time.Millisecond)
+	select {
+	case <-successorDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("successor did not run after active job completed")
 	}
 }
 
@@ -148,6 +144,7 @@ func TestEnqueueSuccessorSkipsActiveKey(t *testing.T) {
 	q := New(2)
 	releaseA := make(chan struct{})
 	releaseB := make(chan struct{})
+	successorDone := make(chan struct{})
 	startedA := make(chan struct{}, 1)
 	startedB := make(chan struct{}, 1)
 	startedC := make(chan struct{}, 1)
@@ -157,15 +154,20 @@ func TestEnqueueSuccessorSkipsActiveKey(t *testing.T) {
 		<-releaseA
 	}, nil)
 	<-startedA
-	q.EnqueueSuccessor("a", func() {}, nil)
+	q.EnqueueSuccessor("a", func() {}, func() {
+		close(successorDone)
+	})
 	q.Enqueue("b", func() {
 		startedB <- struct{}{}
 		<-releaseB
 	}, nil)
 	<-startedB
+	cDone := make(chan struct{})
 	q.Enqueue("c", func() {
 		startedC <- struct{}{}
-	}, nil)
+	}, func() {
+		close(cDone)
+	})
 
 	close(releaseB)
 	select {
@@ -173,14 +175,16 @@ func TestEnqueueSuccessorSkipsActiveKey(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("unblocked pending job did not start")
 	}
+	select {
+	case <-cDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("unblocked pending job did not complete")
+	}
 	close(releaseA)
-
-	deadline := time.Now().Add(5 * time.Second)
-	for q.QueueLength() != 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("successor did not run after its active job completed")
-		}
-		time.Sleep(time.Millisecond)
+	select {
+	case <-successorDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("successor did not run after its active job completed")
 	}
 }
 

--- a/lib/queue/queue_test.go
+++ b/lib/queue/queue_test.go
@@ -109,6 +109,7 @@ func TestEnqueueSuccessor(t *testing.T) {
 	q := New(1)
 	release := make(chan struct{})
 	started := make(chan struct{}, 1)
+	successorStarted := make(chan struct{})
 	replacementDone := make(chan struct{})
 
 	q.Enqueue("same", func() {
@@ -117,7 +118,9 @@ func TestEnqueueSuccessor(t *testing.T) {
 	}, nil)
 	<-started
 
-	pos := q.EnqueueSuccessor("same", func() {}, nil)
+	pos := q.EnqueueSuccessor("same", func() {
+		close(successorStarted)
+	}, nil)
 	if pos != 1 {
 		t.Fatalf("successor position = %d, want 1", pos)
 	}
@@ -125,11 +128,19 @@ func TestEnqueueSuccessor(t *testing.T) {
 		t.Fatalf("GetPosition(same) = %v, want 1", pos)
 	}
 
-	duplicatePos := q.EnqueueSuccessor("same", func() {}, func() {
+	duplicatePos := q.EnqueueSuccessor("same", func() {
+		close(successorStarted)
+	}, func() {
 		close(replacementDone)
 	})
 	if duplicatePos != 1 {
 		t.Fatalf("duplicate successor position = %d, want 1", duplicatePos)
+	}
+
+	select {
+	case <-successorStarted:
+		t.Fatal("successor started before its predecessor was released")
+	default:
 	}
 
 	close(release)
@@ -137,6 +148,11 @@ func TestEnqueueSuccessor(t *testing.T) {
 	case <-replacementDone:
 	case <-time.After(5 * time.Second):
 		t.Fatal("replacement successor did not run after active job completed")
+	}
+	select {
+	case <-successorStarted:
+	default:
+		t.Fatal("replacement successor did not start")
 	}
 }
 

--- a/lib/queue/queue_test.go
+++ b/lib/queue/queue_test.go
@@ -103,6 +103,87 @@ func TestDedupesByKey(t *testing.T) {
 	}
 }
 
+// TestEnqueueSuccessor queues a replacement behind an active job without
+// changing the normal active-key deduplication behavior.
+func TestEnqueueSuccessor(t *testing.T) {
+	q := New(1)
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	var ran int64
+
+	q.Enqueue("same", func() {
+		started <- struct{}{}
+		<-release
+	}, nil)
+	<-started
+
+	pos := q.EnqueueSuccessor("same", func() {
+		atomic.AddInt64(&ran, 1)
+	}, nil)
+	if pos != 1 {
+		t.Fatalf("successor position = %d, want 1", pos)
+	}
+	if pos := q.GetPosition("same"); pos == nil || *pos != 1 {
+		t.Fatalf("GetPosition(same) = %v, want 1", pos)
+	}
+
+	duplicatePos := q.EnqueueSuccessor("same", func() {
+		atomic.AddInt64(&ran, 1)
+	}, nil)
+	if duplicatePos != 1 {
+		t.Fatalf("duplicate successor position = %d, want 1", duplicatePos)
+	}
+
+	close(release)
+	deadline := time.Now().Add(5 * time.Second)
+	for atomic.LoadInt64(&ran) != 1 || q.QueueLength() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("successor did not run after active job completed")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestEnqueueSuccessorSkipsActiveKey(t *testing.T) {
+	q := New(2)
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	startedA := make(chan struct{}, 1)
+	startedB := make(chan struct{}, 1)
+	startedC := make(chan struct{}, 1)
+
+	q.Enqueue("a", func() {
+		startedA <- struct{}{}
+		<-releaseA
+	}, nil)
+	<-startedA
+	q.EnqueueSuccessor("a", func() {}, nil)
+	q.Enqueue("b", func() {
+		startedB <- struct{}{}
+		<-releaseB
+	}, nil)
+	<-startedB
+	q.Enqueue("c", func() {
+		startedC <- struct{}{}
+	}, nil)
+
+	close(releaseB)
+	select {
+	case <-startedC:
+	case <-time.After(5 * time.Second):
+		t.Fatal("unblocked pending job did not start")
+	}
+	close(releaseA)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for q.QueueLength() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("successor did not run after its active job completed")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 // TestDoneRunsAfterKeyReleased guards the completion-hook ordering: done must
 // fire only after the key has left the active set, otherwise a caller's
 // "job finished" bookkeeping would race a concurrent re-enqueue of the key.


### PR DESCRIPTION
## Summary

Fixes an image rebuild race where deleting and recreating an image after its ready notification but before its queue slot is released left the recreated image pending forever.

## Root cause

Image builds notify readiness before the queue wrapper releases the active key. A delete/recreate in that window writes fresh pending metadata, then the shared queue deduplicates the new request against the still-active digest and drops it. The original build completes with no successor to start.

A related stale-result race allowed an older build to write terminal metadata or notify readiness after a newer build had replaced its metadata for the same digest.

## Fix

- Add `Queue.EnqueueSuccessor` for callers that intentionally replace work while the previous job is still active.
- Replace an already-pending successor with the newest build closure so repeated recreates cannot retain stale work.
- Keep normal active-key deduplication unchanged for image pushes and other queue users.
- Skip pending successors whose key is still active when promoting queued work.
- Report a pending position when a key has both an active job and a successor.
- Attach a unique build ID to image metadata and reject stale status/finalization writes and notifications.
- Use successor enqueueing for image creation and retry paths.

## Tests

- Queue successor execution and pending successor replacement.
- Promotion skips a successor whose active predecessor has not completed.
- End-to-end local OCI image delete/recreate during the build tail.
- Stale build updates cannot change replacement metadata or unblock `WaitForReady`.
- Repeated delete/recreate requests run the latest pending successor.

Verification:

- `go test -race ./lib/queue`
- `go test -race -run '^TestDeleteAndRecreateDuringBuildTail$' ./lib/images`
- `go test -race ./lib/images` remains for CI; the local environment lacks `mkfs.erofs`, and the development-host rerun was unavailable during this update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core image build scheduling, metadata writes, and readiness notifications; behavior is constrained by BuildID checks and new queue paths, with broad test coverage for the race scenarios.
> 
> **Overview**
> Fixes a race where **delete + recreate** during the window after an image reports ready but before its digest leaves the active queue slot left the new image **pending forever**, because the queue deduped the recreate against the still-active digest.
> 
> **Queue:** Adds `EnqueueSuccessor` so a replacement job can sit behind an active job with the same key; a pending successor is **replaced** on repeat recreates, promotion **skips** successors whose key is still active, and `GetPosition` reports queue depth when a successor is waiting.
> 
> **Image manager:** Persists a per-build **`BuildID`** and routes new creates through `EnqueueSuccessor`. `updateStatusByDigest` and `finalizeImage` no-op when metadata’s `BuildID` no longer matches, so an older goroutine cannot mark failed/ready or notify `WaitForReady` after a newer build took over. Borrowed-auth lookup takes the expected inflight handle and returns **stale** when credentials were re-registered for a superseded pull.
> 
> **Tests** cover successor queue behavior, end-to-end delete/recreate during the build tail, and stale-build rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d0b1946e8c8c3193be83ee82aec750426de900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->