### PR TITLE
Parse creatable_vgpu_types in the format the driver emits

### DIFF
--- a/lib/devices/vendor_vfio_linux.go
+++ b/lib/devices/vendor_vfio_linux.go
@@ -331,21 +331,28 @@ func (s vendorVFIOSysfs) vfioDeviceInUse(vfAddress string) (bool, error) {
 	return false, nil
 }
 
+// parseCreatableVGPUTypes reads the driver's creatable_vgpu_types listing:
+//
+//	ID    : vGPU Name
+//	1147  : NVIDIA L40S-1Q
 func parseCreatableVGPUTypes(value string) ([]profileMetadata, error) {
 	profiles := make([]profileMetadata, 0)
 	for lineNumber, line := range strings.Split(value, "\n") {
-		fields := strings.Fields(line)
-		if len(fields) == 0 {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		if len(fields) < 2 {
+		typeID, name, found := strings.Cut(line, ":")
+		typeID = strings.TrimSpace(typeID)
+		name = strings.TrimSpace(name)
+		if !found || name == "" {
 			return nil, fmt.Errorf("parse creatable vGPU types line %d: %q", lineNumber+1, line)
 		}
-		typeID := fields[len(fields)-1]
+		if typeID == "ID" {
+			continue
+		}
 		if _, err := strconv.Atoi(typeID); err != nil {
 			return nil, fmt.Errorf("parse vGPU type ID %q: %w", typeID, err)
 		}
-		name := strings.Join(fields[:len(fields)-1], " ")
 		profiles = append(profiles, profileMetadata{
 			TypeName:      typeID,
 			Name:          name,

--- a/lib/devices/vendor_vfio_linux_test.go
+++ b/lib/devices/vendor_vfio_linux_test.go
@@ -12,9 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testCreatableTypes = `NVIDIA L40S-1Q           1147
-NVIDIA L40S-2Q           1148
-NVIDIA L40S-48Q          1159
+const testCreatableTypes = `ID    : vGPU Name
+1147  : NVIDIA L40S-1Q
+1148  : NVIDIA L40S-2Q
+1159  : NVIDIA L40S-48Q
 `
 
 func TestParseCreatableVGPUTypes(t *testing.T) {
@@ -101,10 +102,22 @@ func TestVendorVFIOReconcilePreservesLegacyGroupFD(t *testing.T) {
 	assertFileValue(t, filepath.Join(sysfs.pciDevicesPath, "0000:e3:00.4", "nvidia", "current_vgpu_type"), "1148")
 }
 
+// A GPU with no framebuffer left prints the header and nothing else.
+func TestParseCreatableVGPUTypesHeaderOnly(t *testing.T) {
+	t.Parallel()
+
+	profiles, err := parseCreatableVGPUTypes("ID    : vGPU Name\n")
+	require.NoError(t, err)
+	assert.Empty(t, profiles)
+}
+
 func TestParseCreatableVGPUTypesRejectsMalformedLine(t *testing.T) {
 	t.Parallel()
 
-	_, err := parseCreatableVGPUTypes("NVIDIA L40S-1Q not-an-id")
+	_, err := parseCreatableVGPUTypes("NVIDIA L40S-1Q 1147")
+	require.Error(t, err)
+
+	_, err = parseCreatableVGPUTypes("not-an-id : NVIDIA L40S-1Q")
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
## Summary

Stacked on #321. Validated against an L40S host running vGPU Manager 580.159.01 on Ubuntu 24.04 / kernel 6.8, where the vendor VFIO framework is active and `/sys/class/mdev_bus` has no parents.

`creatable_vgpu_types` is a table with a header row and the type ID first:

```
ID    : vGPU Name
1145  : NVIDIA L40S-1B
1147  : NVIDIA L40S-1Q
...
```

The parser expected the name first and the ID last, so every line failed `strconv.Atoi` on the trailing word:

```
ListGPUProfilesWithVFs: n=0 err=parse vGPU type ID "Name": strconv.Atoi: parsing "Name": invalid syntax
```

`listProfiles` propagates that error, `getVGPUStatus` swallows it, and the host reports vGPU mode with 64 slots and zero profiles — so no vGPU placement can ever succeed.

Parsing on the `:` separator and skipping the header row fixes it. On the same host, profile enumeration now returns all 30 L40S types with correct framebuffer sizes.

There is a second case worth locking in: once a profile consumes a GPU's entire framebuffer, the remaining VFs on that GPU print the header and nothing else. That is a legitimately empty list, not a malformed file, so it now yields zero profiles rather than an error — otherwise a single 48Q allocation would take the whole GPU's remaining capacity out of the status response.

## Tests

- Updated the fixture to the real sysfs format and added a header-only case.
- `go test ./lib/devices/...` passes.
- Verified live: 30 profiles enumerated, availability drops from 64 to 32 slots after allocating a 48Q on one GPU, and back to 64 after release.