### PR TITLE
Add BuildPublisher interface and disabled builds.publish config

### DIFF
--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -144,13 +144,26 @@ type ImagesConfig struct {
 	OCICacheGC OCICacheGCConfig       `koanf:"oci_cache_gc"`
 }
 
+// BuildPublishConfig holds optional remote publication settings for completed
+// build images. Disabled by default; set publish.registry to enable.
+type BuildPublishConfig struct {
+	// Registry is the remote registry host (e.g., "registry.example.com").
+	Registry string `koanf:"registry"`
+	// RepositoryPrefix is prepended to the build ID to form the remote repository.
+	RepositoryPrefix string `koanf:"repository_prefix"`
+	// CredentialsFile is a host-side Docker client config used to authenticate
+	// with the remote registry. Never sent to builder VMs.
+	CredentialsFile string `koanf:"credentials_file"`
+}
+
 // BuildConfig holds source-to-image build system settings.
 type BuildConfig struct {
-	MaxConcurrentSourceBuilds int    `koanf:"max_concurrent_source_builds"`
-	BuilderImage              string `koanf:"builder_image"`
-	Timeout                   int    `koanf:"timeout"`
-	SecretsDir                string `koanf:"secrets_dir"`
-	DockerSocket              string `koanf:"docker_socket"`
+	MaxConcurrentSourceBuilds int                `koanf:"max_concurrent_source_builds"`
+	BuilderImage              string             `koanf:"builder_image"`
+	Timeout                   int                `koanf:"timeout"`
+	SecretsDir                string             `koanf:"secrets_dir"`
+	DockerSocket              string             `koanf:"docker_socket"`
+	Publish                   BuildPublishConfig `koanf:"publish"`
 }
 
 // InstancesConfig holds instance-manager internal settings.
@@ -392,6 +405,7 @@ func defaultConfig() *Config {
 			Timeout:                   600,
 			SecretsDir:                "",
 			DockerSocket:              "/var/run/docker.sock",
+			Publish:                   BuildPublishConfig{}, // remote publication disabled by default
 		},
 
 		Instances: InstancesConfig{
@@ -545,6 +559,7 @@ func (c *Config) expandPathFields() {
 	c.DataDir = expandHomePath(c.DataDir)
 	c.Build.SecretsDir = expandHomePath(c.Build.SecretsDir)
 	c.Build.DockerSocket = expandHomePath(c.Build.DockerSocket)
+	c.Build.Publish.CredentialsFile = expandHomePath(c.Build.Publish.CredentialsFile)
 	c.Registry.CACertFile = expandHomePath(c.Registry.CACertFile)
 	c.Hypervisor.FirecrackerBinaryPath = expandHomePath(c.Hypervisor.FirecrackerBinaryPath)
 }
@@ -628,6 +643,12 @@ func (c *Config) Validate() error {
 	}
 	if c.Build.Timeout <= 0 {
 		return fmt.Errorf("build.timeout must be positive, got %d", c.Build.Timeout)
+	}
+	if c.Build.Publish.Registry == "" && (c.Build.Publish.RepositoryPrefix != "" || c.Build.Publish.CredentialsFile != "") {
+		return fmt.Errorf("build.publish.registry is required when build.publish.repository_prefix or build.publish.credentials_file is set")
+	}
+	if c.Build.Publish.Registry != "" && c.Build.Publish.RepositoryPrefix == "" {
+		return fmt.Errorf("build.publish.repository_prefix is required when build.publish.registry is set")
 	}
 	if c.Hypervisor.FirecrackerMaxConcurrentRestores < 0 {
 		return fmt.Errorf("hypervisor.firecracker_max_concurrent_restores must be >= 0, got %d", c.Hypervisor.FirecrackerMaxConcurrentRestores)

--- a/cmd/api/config/config_test.go
+++ b/cmd/api/config/config_test.go
@@ -539,3 +539,68 @@ func TestValidateAllowsDisabledSnapshotCompressionDefaultWithoutValidAlgorithm(t
 		t.Fatalf("expected disabled snapshot compression default to ignore algorithm/level, got %v", err)
 	}
 }
+
+func TestDefaultConfigDisablesBuildPublish(t *testing.T) {
+	cfg := defaultConfig()
+
+	if cfg.Build.Publish.Registry != "" || cfg.Build.Publish.RepositoryPrefix != "" || cfg.Build.Publish.CredentialsFile != "" {
+		t.Fatalf("expected default build.publish to be empty (disabled), got %+v", cfg.Build.Publish)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected default config to validate, got %v", err)
+	}
+}
+
+func TestValidateBuildPublishRequiresRegistry(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Build.Publish.RepositoryPrefix = "team/builds"
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected validation error when build.publish.repository_prefix is set without registry")
+	}
+}
+
+func TestValidateBuildPublishRequiresRepositoryPrefix(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Build.Publish.Registry = "registry.example.com"
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected validation error when build.publish.registry is set without repository_prefix")
+	}
+
+	cfg.Build.Publish.RepositoryPrefix = "team/builds"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected publish config with registry and prefix to validate, got %v", err)
+	}
+}
+
+func TestLoadExpandsBuildPublishCredentialsFile(t *testing.T) {
+	clearPathEnvOverrides(t)
+
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+build:
+  publish:
+    registry: registry.example.com
+    repository_prefix: team/builds
+    credentials_file: ~/.docker/remote-registry.json
+`), 0600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("get home dir: %v", err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	want := filepath.Join(home, ".docker", "remote-registry.json")
+	if cfg.Build.Publish.CredentialsFile != want {
+		t.Fatalf("expected build.publish.credentials_file to expand to %q, got %q", want, cfg.Build.Publish.CredentialsFile)
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -152,6 +152,10 @@ data_dir: /var/lib/hypeman
 #   docker_socket: /var/run/docker.sock
 #   max_concurrent_source_builds: 2
 #   timeout: 600
+#   publish:                        # optional: publish completed build images to a remote registry
+#     registry: ""                  # remote registry host; empty = disabled
+#     repository_prefix: ""         # prepended to the build ID (e.g. "team/app-builds")
+#     credentials_file: ""          # host-side Docker client config for the remote registry
 
 # =============================================================================
 # Resource Limits

--- a/lib/builds/manager.go
+++ b/lib/builds/manager.go
@@ -89,6 +89,10 @@ type Config struct {
 
 	// DockerSocket is the path to the Docker socket for building the builder image
 	DockerSocket string
+
+	// Publish holds optional remote publication settings for completed build
+	// images. The zero value disables publication.
+	Publish PublishConfig
 }
 
 // DefaultConfig returns the default build manager configuration
@@ -121,6 +125,7 @@ type manager struct {
 	imageManager    images.Manager
 	secretProvider  SecretProvider
 	tokenGenerator  *RegistryTokenGenerator
+	publisher       BuildPublisher
 	logger          *slog.Logger
 	metrics         *Metrics
 	createMu        sync.Mutex
@@ -146,6 +151,11 @@ func NewManager(
 		logger = slog.Default()
 	}
 
+	publisher, err := newBuildPublisher(config.Publish)
+	if err != nil {
+		return nil, fmt.Errorf("publish config: %w", err)
+	}
+
 	m := &manager{
 		config:            config,
 		paths:             p,
@@ -155,6 +165,7 @@ func NewManager(
 		imageManager:      imageMgr,
 		secretProvider:    secretProvider,
 		tokenGenerator:    NewRegistryTokenGenerator(config.RegistrySecret),
+		publisher:         publisher,
 		logger:            logger,
 		statusSubscribers: make(map[string][]chan BuildEvent),
 	}
@@ -641,6 +652,26 @@ func (m *manager) runBuild(ctx context.Context, id string, req CreateBuildReques
 				}
 			}
 		}
+	}
+
+	// Publish the completed image to the configured remote registry. The
+	// default publisher returns the local reference unchanged, so behavior is
+	// identical when publication is not configured. A publication failure
+	// fails the build.
+	publishedRef, err := m.publisher.Publish(buildCtx, buildRepo, result.ImageDigest)
+	if err != nil {
+		duration = time.Since(start)
+		durationMS = duration.Milliseconds()
+		m.logger.Error("image publication failed after build", "id", id, "error", err, "duration", duration)
+		errMsg := fmt.Sprintf("image publication failed: %v", err)
+		m.updateBuildComplete(id, StatusFailed, nil, &errMsg, &result.Provenance, &durationMS)
+		if m.metrics != nil {
+			m.metrics.RecordBuild(buildCtx, "failed", duration)
+		}
+		return
+	}
+	if publishedRef != buildRepo {
+		imageRef = publishedRef
 	}
 
 	// Recalculate duration to include image wait time for accurate reporting

--- a/lib/builds/manager_test.go
+++ b/lib/builds/manager_test.go
@@ -437,6 +437,7 @@ func setupTestManagerWithImageMgr(t *testing.T) (*manager, *mockInstanceManager,
 		imageManager:      imageMgr,
 		secretProvider:    secretProvider,
 		tokenGenerator:    NewRegistryTokenGenerator(config.RegistrySecret),
+		publisher:         noopPublisher{},
 		logger:            logger,
 		statusSubscribers: make(map[string][]chan BuildEvent),
 	}

--- a/lib/builds/publisher.go
+++ b/lib/builds/publisher.go
@@ -1,0 +1,66 @@
+package builds
+
+import (
+	"context"
+	"fmt"
+)
+
+// PublishConfig holds optional remote publication settings for completed
+// build images. The zero value disables publication entirely.
+type PublishConfig struct {
+	// Registry is the remote registry host (e.g., "registry.example.com").
+	Registry string
+
+	// RepositoryPrefix is prepended to the build ID to form the remote
+	// repository (e.g., "team/app-builds" -> "team/app-builds/<build-id>").
+	RepositoryPrefix string
+
+	// CredentialsFile is a host-side path to a Docker client config used to
+	// authenticate with the remote registry. Credentials are read by the host
+	// only and are never sent to builder VMs.
+	CredentialsFile string
+}
+
+// Enabled reports whether remote publication is configured.
+func (c PublishConfig) Enabled() bool {
+	return c.Registry != ""
+}
+
+// validate checks that the publication settings are coherent.
+func (c PublishConfig) validate() error {
+	if c.Registry == "" {
+		if c.RepositoryPrefix != "" || c.CredentialsFile != "" {
+			return fmt.Errorf("publish: repository_prefix and credentials_file require registry to be set")
+		}
+		return nil
+	}
+	if c.RepositoryPrefix == "" {
+		return fmt.Errorf("publish: repository_prefix is required when registry is set")
+	}
+	return nil
+}
+
+// BuildPublisher publishes a completed build image and returns the resulting
+// reference to record on the build.
+type BuildPublisher interface {
+	// Publish publishes the image identified by localRef and digest, and
+	// returns the resulting reference.
+	Publish(ctx context.Context, localRef, digest string) (string, error)
+}
+
+// noopPublisher is the default publisher. It returns the local reference
+// unchanged, leaving build behavior identical to no publication configured.
+type noopPublisher struct{}
+
+func (noopPublisher) Publish(_ context.Context, localRef, _ string) (string, error) {
+	return localRef, nil
+}
+
+// newBuildPublisher returns the publisher for the given publication config.
+// Publication is a no-op unless a remote registry is configured.
+func newBuildPublisher(cfg PublishConfig) (BuildPublisher, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return noopPublisher{}, nil
+}

--- a/lib/builds/publisher_test.go
+++ b/lib/builds/publisher_test.go
@@ -1,0 +1,127 @@
+package builds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/hypervisor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopPublisher_ReturnsLocalRefUnchanged(t *testing.T) {
+	ref, err := noopPublisher{}.Publish(context.Background(), "builds/abc123", "sha256:deadbeef")
+	require.NoError(t, err)
+	assert.Equal(t, "builds/abc123", ref)
+}
+
+func TestNewBuildPublisher_DisabledByDefault(t *testing.T) {
+	p, err := newBuildPublisher(PublishConfig{})
+	require.NoError(t, err)
+	assert.IsType(t, noopPublisher{}, p)
+}
+
+func TestNewBuildPublisher_ValidatesConfig(t *testing.T) {
+	_, err := newBuildPublisher(PublishConfig{RepositoryPrefix: "team/builds"})
+	require.ErrorContains(t, err, "registry")
+
+	_, err = newBuildPublisher(PublishConfig{CredentialsFile: "/creds.json"})
+	require.ErrorContains(t, err, "registry")
+
+	_, err = newBuildPublisher(PublishConfig{Registry: "registry.example.com"})
+	require.ErrorContains(t, err, "repository_prefix")
+}
+
+func TestPublishConfig_Enabled(t *testing.T) {
+	assert.False(t, PublishConfig{}.Enabled())
+	assert.True(t, PublishConfig{Registry: "registry.example.com"}.Enabled())
+}
+
+// staticVsockDialer returns a fixed connection, letting a test play the
+// builder-agent side of the vsock protocol over net.Pipe.
+type staticVsockDialer struct {
+	conn net.Conn
+}
+
+func (d staticVsockDialer) DialVsock(ctx context.Context, port int) (net.Conn, error) {
+	return d.conn, nil
+}
+
+func (d staticVsockDialer) Key() string { return "static-test-dialer" }
+
+// serveFakeBuilderAgent answers host_ready with the given build result.
+func serveFakeBuilderAgent(conn net.Conn, result *BuildResult) {
+	dec := json.NewDecoder(conn)
+	enc := json.NewEncoder(conn)
+	for {
+		var msg VsockMessage
+		if err := dec.Decode(&msg); err != nil {
+			return
+		}
+		if msg.Type == "host_ready" {
+			_ = enc.Encode(VsockMessage{Type: "build_result", Result: result})
+			return
+		}
+	}
+}
+
+// runBuildToCompletion drives runBuild with a fake builder agent that returns
+// the given result, then returns the final build record.
+func runBuildToCompletion(t *testing.T, mgr *manager, instanceMgr *mockInstanceManager, imageMgr *mockImageManager, id string, result *BuildResult) *Build {
+	t.Helper()
+
+	require.NoError(t, writeMetadata(mgr.paths, &buildMetadata{
+		ID:        id,
+		Status:    StatusQueued,
+		Request:   &CreateBuildRequest{},
+		CreatedAt: time.Now(),
+	}))
+	require.NoError(t, mgr.storeSource(id, []byte("fake-tarball-data")))
+	require.NoError(t, writeBuildConfig(mgr.paths, id, &BuildConfig{
+		JobID:          id,
+		RegistryURL:    mgr.config.RegistryURL,
+		SourcePath:     "/src",
+		TimeoutSeconds: 600,
+		NetworkMode:    "egress",
+	}))
+
+	hostConn, agentConn := net.Pipe()
+	instanceMgr.vsockDialerFunc = func(ctx context.Context, instanceID string) (hypervisor.VsockDialer, error) {
+		return staticVsockDialer{conn: hostConn}, nil
+	}
+	go serveFakeBuilderAgent(agentConn, result)
+
+	imageMgr.SetImageReady(fmt.Sprintf("builds/%s", id))
+
+	policy := DefaultBuildPolicy()
+	mgr.runBuild(context.Background(), id, CreateBuildRequest{}, &policy)
+
+	build, err := mgr.GetBuild(context.Background(), id)
+	require.NoError(t, err)
+	return build
+}
+
+// With no publish configuration, a successful build records the local
+// builds/<id> reference, exactly as before publication existed.
+func TestRunBuild_NoPublishConfigured_LeavesImageRefLocal(t *testing.T) {
+	mgr, instanceMgr, _, imageMgr, tempDir := setupTestManagerWithImageMgr(t)
+	defer os.RemoveAll(tempDir)
+
+	digest := "sha256:" + strings.Repeat("ab", 32)
+	build := runBuildToCompletion(t, mgr, instanceMgr, imageMgr, "build-no-publisher", &BuildResult{
+		Success:     true,
+		ImageDigest: digest,
+	})
+
+	assert.Equal(t, StatusReady, build.Status)
+	require.NotNil(t, build.ImageDigest)
+	assert.Equal(t, digest, *build.ImageDigest)
+	require.NotNil(t, build.ImageRef)
+	assert.Equal(t, "builds/build-no-publisher", *build.ImageRef)
+}

--- a/lib/providers/providers.go
+++ b/lib/providers/providers.go
@@ -421,6 +421,11 @@ func ProvideBuildManager(p *paths.Paths, cfg *config.Config, instanceManager ins
 		DefaultTimeout:      cfg.Build.Timeout,
 		RegistrySecret:      cfg.JwtSecret, // Use same secret for registry tokens
 		DockerSocket:        cfg.Build.DockerSocket,
+		Publish: builds.PublishConfig{
+			Registry:         cfg.Build.Publish.Registry,
+			RepositoryPrefix: cfg.Build.Publish.RepositoryPrefix,
+			CredentialsFile:  cfg.Build.Publish.CredentialsFile,
+		},
 	}
 
 	// Configure secret provider (use NoOpSecretProvider as fallback to avoid nil panics)


### PR DESCRIPTION
## Summary

Foundation layer for publishing completed build images to a remote registry.

- Add an internal `builds.BuildPublisher` interface: publishes a completed local reference and digest, and returns the resulting reference. The default no-op implementation returns the local reference unchanged, so runtime behavior is exactly unchanged when publication is not configured.
- Add disabled-by-default `builds.publish` configuration (registry, repository prefix, host-side credentials file) to the API config, plumbed through providers to the build manager as `builds.PublishConfig`. Partial configuration is rejected at validation time.
- Wire the publish step into `runBuild` before the build is marked ready: a publication failure fails the build, and a publisher that returns a different reference replaces the recorded `Build.ImageRef`. With the no-op publisher the recorded reference is unchanged.

No remote publication is implemented yet — that lands in the next PR in this stack.

## Tests

- No-op publisher returns the local reference unchanged.
- Publisher construction defaults to no-op and validates partial config.
- API config: publish disabled by default, validation requires registry/prefix pairing, `~` expansion of the credentials file.
- End-to-end `runBuild` with a fake builder agent: with no publish config, the build reports ready and `ImageRef` stays `builds/<id>` (behavior unchanged).

`go build ./...`, `go vet`, and `go test ./lib/builds/ ./cmd/api/config/ ./lib/providers/` all pass. (`cmd/api/api` integration test `TestExecWithDebianMinimal` fails on unmodified main too — it needs KVM and Docker Hub access.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffolding only: default no-op publisher preserves existing behavior; publish failures would fail builds once a real publisher lands.
> 
> **Overview**
> Introduces optional **remote publication** for completed build images as a foundation layer; actual registry push is not implemented yet (the publisher stays a no-op even when `build.publish` is set).
> 
> Adds disabled-by-default **`build.publish`** settings (`registry`, `repository_prefix`, host-side `credentials_file`) in API config, with validation that registry and prefix must be set together, plus `~` expansion for the credentials path. These values flow through providers into `builds.PublishConfig`.
> 
> Defines **`BuildPublisher`** / **`PublishConfig`** and wires a publisher into the build manager. After a successful build and local image readiness (and optional re-tag), **`runBuild`** calls `Publish`; a failure marks the build failed, and a returned reference different from the local `builds/<id>` ref becomes **`ImageRef`**. With the default no-op publisher, behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86e3d1b3e76ad05748c79f5413093caae8e5e3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->