### PR TITLE
Implement remote OCI publication for completed builds

### DIFF
--- a/lib/builds/manager.go
+++ b/lib/builds/manager.go
@@ -151,9 +151,15 @@ func NewManager(
 		logger = slog.Default()
 	}
 
-	publisher, err := newBuildPublisher(config.Publish)
+	tokenGen := NewRegistryTokenGenerator(config.RegistrySecret)
+	publisher, err := newBuildPublisher(config.Publish, stripRegistryScheme(config.RegistryURL), tokenGen)
 	if err != nil {
 		return nil, fmt.Errorf("publish config: %w", err)
+	}
+	if config.Publish.Enabled() {
+		logger.Info("build image publication enabled",
+			"registry", config.Publish.Registry,
+			"repository_prefix", config.Publish.RepositoryPrefix)
 	}
 
 	m := &manager{
@@ -164,7 +170,7 @@ func NewManager(
 		volumeManager:     volumeMgr,
 		imageManager:      imageMgr,
 		secretProvider:    secretProvider,
-		tokenGenerator:    NewRegistryTokenGenerator(config.RegistrySecret),
+		tokenGenerator:    tokenGen,
 		publisher:         publisher,
 		logger:            logger,
 		statusSubscribers: make(map[string][]chan BuildEvent),

--- a/lib/builds/manager.go
+++ b/lib/builds/manager.go
@@ -152,7 +152,7 @@ func NewManager(
 	}
 
 	tokenGen := NewRegistryTokenGenerator(config.RegistrySecret)
-	publisher, err := newBuildPublisher(config.Publish, stripRegistryScheme(config.RegistryURL), tokenGen)
+	publisher, err := newBuildPublisher(config.Publish, stripRegistryScheme(config.RegistryURL), config.RegistryInsecure, config.RegistryCACert, tokenGen)
 	if err != nil {
 		return nil, fmt.Errorf("publish config: %w", err)
 	}

--- a/lib/builds/publish_remote.go
+++ b/lib/builds/publish_remote.go
@@ -2,10 +2,13 @@ package builds
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -23,23 +26,49 @@ import (
 // are read from a host-side Docker client config. Neither is sent to builder
 // VMs.
 type remotePublisher struct {
-	config        PublishConfig
-	localRegistry string
-	tokenGen      *RegistryTokenGenerator
-	keychain      authn.Keychain
+	config         PublishConfig
+	localRegistry  string
+	localInsecure  bool
+	localTransport http.RoundTripper
+	tokenGen       *RegistryTokenGenerator
+	keychain       authn.Keychain
 }
 
-func newRemotePublisher(cfg PublishConfig, localRegistry string, tokenGen *RegistryTokenGenerator) (BuildPublisher, error) {
+func newRemotePublisher(cfg PublishConfig, localRegistry string, localInsecure bool, localCACert string, tokenGen *RegistryTokenGenerator) (BuildPublisher, error) {
 	keychain, err := dockerFileKeychain(cfg.CredentialsFile)
 	if err != nil {
 		return nil, err
 	}
+	transport, err := registryCATransport(localCACert)
+	if err != nil {
+		return nil, err
+	}
 	return &remotePublisher{
-		config:        cfg,
-		localRegistry: localRegistry,
-		tokenGen:      tokenGen,
-		keychain:      keychain,
+		config:         cfg,
+		localRegistry:  localRegistry,
+		localInsecure:  localInsecure,
+		localTransport: transport,
+		tokenGen:       tokenGen,
+		keychain:       keychain,
 	}, nil
+}
+
+// registryCATransport returns a transport that additionally trusts the given
+// PEM-encoded CA certificate, or nil when no CA certificate is configured.
+func registryCATransport(caCert string) (http.RoundTripper, error) {
+	if caCert == "" {
+		return nil, nil
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM([]byte(caCert)) {
+		return nil, fmt.Errorf("publish: parse registry CA certificate: no valid PEM certificates")
+	}
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = &tls.Config{RootCAs: pool}
+	return t, nil
 }
 
 // Publish copies the completed local image to
@@ -51,7 +80,7 @@ func (p *remotePublisher) Publish(ctx context.Context, localRef, digest string) 
 		return "", fmt.Errorf("publish: digest is required")
 	}
 
-	srcRef, err := name.ParseReference(fmt.Sprintf("%s/%s@%s", p.localRegistry, localRef, digest))
+	srcRef, err := name.ParseReference(fmt.Sprintf("%s/%s@%s", p.localRegistry, localRef, digest), p.localNameOptions()...)
 	if err != nil {
 		return "", fmt.Errorf("publish: parse local reference: %w", err)
 	}
@@ -67,7 +96,11 @@ func (p *remotePublisher) Publish(ctx context.Context, localRef, digest string) 
 	}
 	localAuth := authn.FromConfig(authn.AuthConfig{Username: token, Password: "x"})
 
-	img, err := remote.Image(srcRef, remote.WithContext(ctx), remote.WithAuth(localAuth))
+	pullOpts := []remote.Option{remote.WithContext(ctx), remote.WithAuth(localAuth)}
+	if p.localTransport != nil {
+		pullOpts = append(pullOpts, remote.WithTransport(p.localTransport))
+	}
+	img, err := remote.Image(srcRef, pullOpts...)
 	if err != nil {
 		return "", fmt.Errorf("publish: fetch local image: %w", err)
 	}
@@ -83,6 +116,15 @@ func (p *remotePublisher) Publish(ctx context.Context, localRef, digest string) 
 	}
 
 	return dstRef.String(), nil
+}
+
+// localNameOptions returns the name parsing options for the local registry:
+// an insecure registry is contacted over plain HTTP.
+func (p *remotePublisher) localNameOptions() []name.Option {
+	if p.localInsecure {
+		return []name.Option{name.Insecure}
+	}
+	return nil
 }
 
 // pushWithRetry pushes the image, retrying transient registry errors.
@@ -202,7 +244,11 @@ func dockerFileKeychain(path string) (authn.Keychain, error) {
 		}
 		host = strings.TrimPrefix(host, "https://")
 		host = strings.TrimPrefix(host, "http://")
-		host = strings.TrimSuffix(host, "/")
+		// Keys may carry a path suffix (e.g. "registry.example.com/v1/");
+		// credentials are keyed by registry host only.
+		if idx := strings.Index(host, "/"); idx != -1 {
+			host = host[:idx]
+		}
 		auths[host] = ac
 	}
 

--- a/lib/builds/publish_remote.go
+++ b/lib/builds/publish_remote.go
@@ -1,0 +1,210 @@
+package builds
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// remotePublisher copies completed build images from the local registry to a
+// configured remote registry. All credentials stay on the host: the local
+// pull uses a short-lived token generated in-process, and remote credentials
+// are read from a host-side Docker client config. Neither is sent to builder
+// VMs.
+type remotePublisher struct {
+	config        PublishConfig
+	localRegistry string
+	tokenGen      *RegistryTokenGenerator
+	keychain      authn.Keychain
+}
+
+func newRemotePublisher(cfg PublishConfig, localRegistry string, tokenGen *RegistryTokenGenerator) (BuildPublisher, error) {
+	keychain, err := dockerFileKeychain(cfg.CredentialsFile)
+	if err != nil {
+		return nil, err
+	}
+	return &remotePublisher{
+		config:        cfg,
+		localRegistry: localRegistry,
+		tokenGen:      tokenGen,
+		keychain:      keychain,
+	}, nil
+}
+
+// Publish copies the completed local image to
+// <remote-registry>/<prefix>/<build-id>@<digest> and verifies the remote
+// manifest matches the build digest before returning the immutable remote
+// reference.
+func (p *remotePublisher) Publish(ctx context.Context, localRef, digest string) (string, error) {
+	if digest == "" {
+		return "", fmt.Errorf("publish: digest is required")
+	}
+
+	srcRef, err := name.ParseReference(fmt.Sprintf("%s/%s@%s", p.localRegistry, localRef, digest))
+	if err != nil {
+		return "", fmt.Errorf("publish: parse local reference: %w", err)
+	}
+	dstRef, err := name.NewDigest(fmt.Sprintf("%s@%s", publishedRepository(p.config, localRef), digest))
+	if err != nil {
+		return "", fmt.Errorf("publish: parse remote reference: %w", err)
+	}
+
+	// Short-lived pull token for the local registry, generated on the host.
+	token, err := p.tokenGen.GenerateToken(localRef, []RepoPermission{{Repo: localRef, Scope: "pull"}}, 10*time.Minute)
+	if err != nil {
+		return "", fmt.Errorf("publish: generate local registry token: %w", err)
+	}
+	localAuth := authn.FromConfig(authn.AuthConfig{Username: token, Password: "x"})
+
+	img, err := remote.Image(srcRef, remote.WithContext(ctx), remote.WithAuth(localAuth))
+	if err != nil {
+		return "", fmt.Errorf("publish: fetch local image: %w", err)
+	}
+
+	// Blobs are content-addressed and uploads are idempotent (existing blobs
+	// are skipped), so retrying a failed publish resumes safely.
+	if err := pushWithRetry(ctx, dstRef, img, p.keychain); err != nil {
+		return "", fmt.Errorf("publish: push to remote registry: %w", err)
+	}
+
+	if err := verifyRemoteDigest(ctx, dstRef, digest, p.keychain); err != nil {
+		return "", err
+	}
+
+	return dstRef.String(), nil
+}
+
+// pushWithRetry pushes the image, retrying transient registry errors.
+func pushWithRetry(ctx context.Context, ref name.Digest, img v1.Image, keychain authn.Keychain) error {
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		err = remote.Write(ref, img, remote.WithContext(ctx), remote.WithAuthFromKeychain(keychain))
+		if err == nil {
+			return nil
+		}
+		var terr *transport.Error
+		if !errors.As(err, &terr) {
+			// Non-registry errors (DNS, connection reset, EOF) are treated as
+			// transient; the upload is idempotent so retrying is safe.
+		} else if !terr.Temporary() {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt+1) * 500 * time.Millisecond):
+		}
+	}
+	return err
+}
+
+// verifyRemoteDigest reads the remote manifest and fails unless its digest
+// matches the build digest.
+func verifyRemoteDigest(ctx context.Context, ref name.Digest, want string, keychain authn.Keychain) error {
+	head, err := remote.Head(ref, remote.WithContext(ctx), remote.WithAuthFromKeychain(keychain))
+	if err != nil {
+		return fmt.Errorf("publish: verify remote manifest: %w", err)
+	}
+	if head.Digest.String() != want {
+		return fmt.Errorf("publish: verify remote manifest: digest mismatch: remote has %s, want %s", head.Digest, want)
+	}
+	return nil
+}
+
+// publishedRepository derives the remote repository for a completed local
+// build reference: the last path segment of the local repository (the build
+// ID for the canonical "builds/<id>" reference) under the configured prefix.
+func publishedRepository(cfg PublishConfig, localRef string) string {
+	repo := localRef
+	if idx := strings.LastIndex(repo, "@"); idx != -1 {
+		repo = repo[:idx]
+	}
+	if idx := strings.LastIndex(repo, ":"); idx > strings.LastIndex(repo, "/") {
+		repo = repo[:idx]
+	}
+	name := repo
+	if idx := strings.LastIndex(repo, "/"); idx != -1 {
+		name = repo[idx+1:]
+	}
+	return strings.TrimSuffix(cfg.Registry, "/") + "/" + strings.Trim(cfg.RepositoryPrefix, "/") + "/" + name
+}
+
+// dockerConfigFile is the subset of a Docker client config used for
+// registry authentication.
+type dockerConfigFile struct {
+	Auths map[string]struct {
+		Auth     string `json:"auth"`
+		Username string `json:"username"`
+		Password string `json:"password"`
+	} `json:"auths"`
+}
+
+// dockerConfigKeychain resolves registry credentials from a parsed Docker
+// client config, falling back to anonymous access for unknown registries.
+type dockerConfigKeychain struct {
+	auths map[string]authn.AuthConfig
+}
+
+func (k dockerConfigKeychain) Resolve(r authn.Resource) (authn.Authenticator, error) {
+	if cfg, ok := k.auths[r.RegistryStr()]; ok {
+		return authn.FromConfig(cfg), nil
+	}
+	return authn.Anonymous, nil
+}
+
+type anonymousKeychain struct{}
+
+func (anonymousKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	return authn.Anonymous, nil
+}
+
+// dockerFileKeychain loads registry credentials from a host-side Docker
+// client config. An empty path yields an anonymous keychain.
+func dockerFileKeychain(path string) (authn.Keychain, error) {
+	if path == "" {
+		return anonymousKeychain{}, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("publish: read credentials file: %w", err)
+	}
+
+	var cfg dockerConfigFile
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("publish: parse credentials file: %w", err)
+	}
+
+	auths := make(map[string]authn.AuthConfig, len(cfg.Auths))
+	for host, entry := range cfg.Auths {
+		ac := authn.AuthConfig{Username: entry.Username, Password: entry.Password}
+		if entry.Auth != "" {
+			decoded, err := base64.StdEncoding.DecodeString(entry.Auth)
+			if err != nil {
+				return nil, fmt.Errorf("publish: decode credentials for %s: %w", host, err)
+			}
+			user, pass, ok := strings.Cut(string(decoded), ":")
+			if !ok {
+				return nil, fmt.Errorf("publish: malformed credentials for %s", host)
+			}
+			ac.Username, ac.Password = user, pass
+		}
+		host = strings.TrimPrefix(host, "https://")
+		host = strings.TrimPrefix(host, "http://")
+		host = strings.TrimSuffix(host, "/")
+		auths[host] = ac
+	}
+
+	return dockerConfigKeychain{auths: auths}, nil
+}

--- a/lib/builds/publish_remote_test.go
+++ b/lib/builds/publish_remote_test.go
@@ -1,0 +1,392 @@
+package builds
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishedRepository(t *testing.T) {
+	cfg := PublishConfig{Registry: "registry.example.com", RepositoryPrefix: "team/builds"}
+
+	tests := []struct {
+		name     string
+		cfg      PublishConfig
+		localRef string
+		want     string
+	}{
+		{"build repo", cfg, "builds/abc123", "registry.example.com/team/builds/abc123"},
+		{"image name", cfg, "myapp", "registry.example.com/team/builds/myapp"},
+		{"nested repo uses last segment", cfg, "tenant/team/myapp", "registry.example.com/team/builds/myapp"},
+		{"tag stripped", cfg, "builds/abc123:latest", "registry.example.com/team/builds/abc123"},
+		{"digest stripped", cfg, "builds/abc123@sha256:abc", "registry.example.com/team/builds/abc123"},
+		{
+			"trailing slashes trimmed",
+			PublishConfig{Registry: "registry.example.com/", RepositoryPrefix: "/team/builds/"},
+			"builds/abc123",
+			"registry.example.com/team/builds/abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, publishedRepository(tt.cfg, tt.localRef))
+		})
+	}
+}
+
+// newFakeRegistry starts an in-memory OCI registry and returns its host.
+func newFakeRegistry(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+// pushRandomImage pushes a small random image to the registry and returns its digest.
+func pushRandomImage(t *testing.T, ref string) string {
+	t.Helper()
+	img, err := random.Image(256, 2)
+	require.NoError(t, err)
+	r, err := name.ParseReference(ref)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(r, img))
+	d, err := img.Digest()
+	require.NoError(t, err)
+	return d.String()
+}
+
+func newTestRemotePublisher(t *testing.T, cfg PublishConfig, localRegistry string) BuildPublisher {
+	t.Helper()
+	p, err := newRemotePublisher(cfg, localRegistry, NewRegistryTokenGenerator("test-secret"))
+	require.NoError(t, err)
+	return p
+}
+
+func TestRemotePublisher_PublishesAndVerifies(t *testing.T) {
+	srcHost := newFakeRegistry(t)
+	dstHost := newFakeRegistry(t)
+
+	digest := pushRandomImage(t, srcHost+"/builds/build-1:latest")
+
+	p := newTestRemotePublisher(t, PublishConfig{
+		Registry:         dstHost,
+		RepositoryPrefix: "team/builds",
+	}, srcHost)
+
+	ref, err := p.Publish(context.Background(), "builds/build-1", digest)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%s/team/builds/build-1@%s", dstHost, digest), ref)
+
+	// The remote manifest is reachable by digest
+	dstRef, err := name.NewDigest(ref)
+	require.NoError(t, err)
+	head, err := remote.Head(dstRef)
+	require.NoError(t, err)
+	assert.Equal(t, digest, head.Digest.String())
+}
+
+func TestRemotePublisher_IdempotentRetrySafe(t *testing.T) {
+	srcHost := newFakeRegistry(t)
+	dstHost := newFakeRegistry(t)
+
+	digest := pushRandomImage(t, srcHost+"/builds/build-2:latest")
+
+	p := newTestRemotePublisher(t, PublishConfig{
+		Registry:         dstHost,
+		RepositoryPrefix: "team/builds",
+	}, srcHost)
+
+	// Publishing the same image twice must succeed and return the same ref —
+	// blob and manifest uploads are idempotent.
+	ref1, err := p.Publish(context.Background(), "builds/build-2", digest)
+	require.NoError(t, err)
+	ref2, err := p.Publish(context.Background(), "builds/build-2", digest)
+	require.NoError(t, err)
+	assert.Equal(t, ref1, ref2)
+}
+
+func TestRemotePublisher_RetriesTransientFailures(t *testing.T) {
+	srcHost := newFakeRegistry(t)
+	digest := pushRandomImage(t, srcHost+"/builds/build-3:latest")
+
+	// Destination registry that fails the first two blob uploads with a 500,
+	// then proxies to the real in-memory registry.
+	var failures atomic.Int32
+	handler := registry.New()
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if failures.Add(1) <= 2 && strings.Contains(r.URL.Path, "/blobs/") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(backend.Close)
+	dstHost := strings.TrimPrefix(backend.URL, "http://")
+
+	p := newTestRemotePublisher(t, PublishConfig{
+		Registry:         dstHost,
+		RepositoryPrefix: "team/builds",
+	}, srcHost)
+
+	ref, err := p.Publish(context.Background(), "builds/build-3", digest)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%s/team/builds/build-3@%s", dstHost, digest), ref)
+}
+
+func TestRemotePublisher_DoesNotRetryPermanentFailures(t *testing.T) {
+	srcHost := newFakeRegistry(t)
+	digest := pushRandomImage(t, srcHost+"/builds/build-4:latest")
+
+	// Destination registry that always rejects blob uploads with a 401.
+	// remote.Write pings /v2/ once per call, so counting pings counts
+	// pushWithRetry attempts: a permanent error must not be retried.
+	var attempts atomic.Int32
+	handler := registry.New()
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/" {
+			attempts.Add(1)
+		}
+		if strings.Contains(r.URL.Path, "/blobs/uploads/") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(backend.Close)
+	dstHost := strings.TrimPrefix(backend.URL, "http://")
+
+	p := newTestRemotePublisher(t, PublishConfig{
+		Registry:         dstHost,
+		RepositoryPrefix: "team/builds",
+	}, srcHost)
+
+	_, err := p.Publish(context.Background(), "builds/build-4", digest)
+	require.Error(t, err)
+	assert.EqualValues(t, 1, attempts.Load(), "permanent errors must not be retried")
+}
+
+func TestVerifyRemoteDigest_Mismatch(t *testing.T) {
+	dstHost := newFakeRegistry(t)
+	digest := pushRandomImage(t, dstHost+"/team/builds/build-5:latest")
+	otherDigest := pushRandomImage(t, dstHost+"/team/builds/other:latest")
+
+	ref, err := name.NewDigest(fmt.Sprintf("%s/team/builds/build-5@%s", dstHost, digest))
+	require.NoError(t, err)
+
+	err = verifyRemoteDigest(context.Background(), ref, otherDigest, anonymousKeychain{})
+	require.ErrorContains(t, err, "digest mismatch")
+}
+
+func TestVerifyRemoteDigest_NotFound(t *testing.T) {
+	dstHost := newFakeRegistry(t)
+	missing := fmt.Sprintf("%s/team/builds/never-pushed@sha256:%s", dstHost, strings.Repeat("0", 64))
+
+	ref, err := name.NewDigest(missing)
+	require.NoError(t, err)
+
+	err = verifyRemoteDigest(context.Background(), ref, "sha256:"+strings.Repeat("0", 64), anonymousKeychain{})
+	require.ErrorContains(t, err, "verify remote manifest")
+}
+
+func TestRemotePublisher_UnreachableRegistry(t *testing.T) {
+	srcHost := newFakeRegistry(t)
+	digest := pushRandomImage(t, srcHost+"/builds/build-6:latest")
+
+	// Point the destination at a server that is already closed.
+	dead := httptest.NewServer(registry.New())
+	dstHost := strings.TrimPrefix(dead.URL, "http://")
+	dead.Close()
+
+	p := newTestRemotePublisher(t, PublishConfig{
+		Registry:         dstHost,
+		RepositoryPrefix: "team/builds",
+	}, srcHost)
+
+	_, err := p.Publish(context.Background(), "builds/build-6", digest)
+	require.ErrorContains(t, err, "push to remote registry")
+}
+
+func TestRemotePublisher_AuthenticatesWithCredentialsFile(t *testing.T) {
+	srcHost := newFakeRegistry(t)
+	digest := pushRandomImage(t, srcHost+"/builds/build-7:latest")
+
+	// Destination registry that requires basic auth.
+	const user, pass = "builder-bot", "s3cr3t-token"
+	var authenticated atomic.Bool
+	handler := registry.New()
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+		if !ok || u != user || p != pass {
+			w.Header().Set("WWW-Authenticate", `Basic realm="registry"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		authenticated.Store(true)
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(backend.Close)
+	dstHost := strings.TrimPrefix(backend.URL, "http://")
+
+	credFile := filepath.Join(t.TempDir(), "config.json")
+	auth := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+	require.NoError(t, os.WriteFile(credFile, []byte(fmt.Sprintf(
+		`{"auths":{"http://%s/":{"auth":%q}}}`, dstHost, auth)), 0600))
+
+	p, err := newRemotePublisher(PublishConfig{
+		Registry:         dstHost,
+		RepositoryPrefix: "team/builds",
+		CredentialsFile:  credFile,
+	}, srcHost, NewRegistryTokenGenerator("test-secret"))
+	require.NoError(t, err)
+
+	ref, err := p.Publish(context.Background(), "builds/build-7", digest)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%s/team/builds/build-7@%s", dstHost, digest), ref)
+	assert.True(t, authenticated.Load(), "expected the remote registry to see the credentials")
+}
+
+func TestDockerFileKeychain(t *testing.T) {
+	t.Run("empty path is anonymous", func(t *testing.T) {
+		k, err := dockerFileKeychain("")
+		require.NoError(t, err)
+		auth, err := k.Resolve(mustRegistry(t, "registry.example.com"))
+		require.NoError(t, err)
+		assert.Equal(t, authn.Anonymous, auth)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := dockerFileKeychain(filepath.Join(t.TempDir(), "nope.json"))
+		require.ErrorContains(t, err, "read credentials file")
+	})
+
+	t.Run("malformed json", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "config.json")
+		require.NoError(t, os.WriteFile(f, []byte("{not json"), 0600))
+		_, err := dockerFileKeychain(f)
+		require.ErrorContains(t, err, "parse credentials file")
+	})
+
+	t.Run("resolves credentials by registry host", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "config.json")
+		auth := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+		require.NoError(t, os.WriteFile(f, []byte(fmt.Sprintf(
+			`{"auths":{"https://registry.example.com/":{"auth":%q}}}`, auth)), 0600))
+
+		k, err := dockerFileKeychain(f)
+		require.NoError(t, err)
+
+		authenticator, err := k.Resolve(mustRegistry(t, "registry.example.com"))
+		require.NoError(t, err)
+		cfg, err := authenticator.Authorization()
+		require.NoError(t, err)
+		assert.Equal(t, "user", cfg.Username)
+		assert.Equal(t, "pass", cfg.Password)
+
+		// Unknown registries fall back to anonymous
+		other, err := k.Resolve(mustRegistry(t, "other.example.com"))
+		require.NoError(t, err)
+		assert.Equal(t, authn.Anonymous, other)
+	})
+}
+
+func mustRegistry(t *testing.T, host string) name.Registry {
+	t.Helper()
+	r, err := name.NewRegistry(host)
+	require.NoError(t, err)
+	return r
+}
+
+// stubPublisher returns a fixed result for manager-level publish tests.
+type stubPublisher struct {
+	ref string
+	err error
+}
+
+func (s stubPublisher) Publish(_ context.Context, _, _ string) (string, error) {
+	return s.ref, s.err
+}
+
+// A configured publication failure fails the build, even though the build and
+// local image conversion succeeded.
+func TestRunBuild_PublishFailure_FailsBuild(t *testing.T) {
+	mgr, instanceMgr, _, imageMgr, tempDir := setupTestManagerWithImageMgr(t)
+	defer os.RemoveAll(tempDir)
+
+	mgr.publisher = stubPublisher{err: errors.New("remote registry unreachable")}
+
+	digest := "sha256:" + strings.Repeat("cd", 32)
+	build := runBuildToCompletion(t, mgr, instanceMgr, imageMgr, "build-pub-fails", &BuildResult{
+		Success:     true,
+		ImageDigest: digest,
+	})
+
+	assert.Equal(t, StatusFailed, build.Status)
+	require.NotNil(t, build.Error)
+	assert.Contains(t, *build.Error, "image publication failed")
+	assert.Contains(t, *build.Error, "remote registry unreachable")
+	assert.Nil(t, build.ImageRef)
+}
+
+// With publication configured, the build records the immutable remote
+// reference returned by the publisher.
+func TestRunBuild_PublishConfigured_RecordsRemoteRef(t *testing.T) {
+	mgr, instanceMgr, _, imageMgr, tempDir := setupTestManagerWithImageMgr(t)
+	defer os.RemoveAll(tempDir)
+
+	digest := "sha256:" + strings.Repeat("ef", 32)
+	remoteRef := "registry.example.com/team/builds/build-pub-ok@" + digest
+	mgr.publisher = stubPublisher{ref: remoteRef}
+
+	build := runBuildToCompletion(t, mgr, instanceMgr, imageMgr, "build-pub-ok", &BuildResult{
+		Success:     true,
+		ImageDigest: digest,
+	})
+
+	assert.Equal(t, StatusReady, build.Status)
+	require.NotNil(t, build.ImageRef)
+	assert.Equal(t, remoteRef, *build.ImageRef)
+}
+
+// Publish credentials stay on the host: the build config written for the
+// builder VM must never contain publish settings or credential material.
+func TestCreateBuild_ConfigNeverContainsPublishCredentials(t *testing.T) {
+	mgr, _, _, tempDir := setupTestManager(t)
+	defer os.RemoveAll(tempDir)
+
+	credFile := filepath.Join(tempDir, "creds.json")
+	require.NoError(t, os.WriteFile(credFile, []byte(
+		`{"auths":{"registry.example.com":{"auth":"dXNlcjpwYXNz"}}}`), 0600))
+	mgr.config.Publish = PublishConfig{
+		Registry:         "registry.example.com",
+		RepositoryPrefix: "team/builds",
+		CredentialsFile:  credFile,
+	}
+
+	build, err := mgr.CreateBuild(context.Background(), CreateBuildRequest{
+		Dockerfile: "FROM alpine",
+	}, []byte("fake-tarball-data"))
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(mgr.paths.BuildConfig(build.ID))
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "registry.example.com")
+	assert.NotContains(t, string(data), credFile)
+	assert.NotContains(t, string(data), "dXNlcjpwYXNz")
+}

--- a/lib/builds/publish_remote_test.go
+++ b/lib/builds/publish_remote_test.go
@@ -3,6 +3,7 @@ package builds
 import (
 	"context"
 	"encoding/base64"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net/http"
@@ -74,7 +75,7 @@ func pushRandomImage(t *testing.T, ref string) string {
 
 func newTestRemotePublisher(t *testing.T, cfg PublishConfig, localRegistry string) BuildPublisher {
 	t.Helper()
-	p, err := newRemotePublisher(cfg, localRegistry, NewRegistryTokenGenerator("test-secret"))
+	p, err := newRemotePublisher(cfg, localRegistry, false, "", NewRegistryTokenGenerator("test-secret"))
 	require.NoError(t, err)
 	return p
 }
@@ -253,7 +254,7 @@ func TestRemotePublisher_AuthenticatesWithCredentialsFile(t *testing.T) {
 		Registry:         dstHost,
 		RepositoryPrefix: "team/builds",
 		CredentialsFile:  credFile,
-	}, srcHost, NewRegistryTokenGenerator("test-secret"))
+	}, srcHost, false, "", NewRegistryTokenGenerator("test-secret"))
 	require.NoError(t, err)
 
 	ref, err := p.Publish(context.Background(), "builds/build-7", digest)
@@ -303,6 +304,76 @@ func TestDockerFileKeychain(t *testing.T) {
 		other, err := k.Resolve(mustRegistry(t, "other.example.com"))
 		require.NoError(t, err)
 		assert.Equal(t, authn.Anonymous, other)
+	})
+
+	t.Run("resolves credentials for keys with /v1/ or /v2/ path suffixes", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "config.json")
+		auth := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+		require.NoError(t, os.WriteFile(f, []byte(fmt.Sprintf(
+			`{"auths":{"https://registry.example.com/v1/":{"auth":%q},"https://other.example.com/v2/":{"auth":%q}}}`,
+			auth, auth)), 0600))
+
+		k, err := dockerFileKeychain(f)
+		require.NoError(t, err)
+
+		for _, host := range []string{"registry.example.com", "other.example.com"} {
+			authenticator, err := k.Resolve(mustRegistry(t, host))
+			require.NoError(t, err)
+			cfg, err := authenticator.Authorization()
+			require.NoError(t, err)
+			assert.Equal(t, "user", cfg.Username, host)
+			assert.Equal(t, "pass", cfg.Password, host)
+		}
+	})
+}
+
+// The local registry TLS settings must be honored when pulling completed
+// images: an insecure registry is contacted over plain HTTP, a secure one
+// over HTTPS.
+func TestRemotePublisher_LocalNameOptions(t *testing.T) {
+	ref := "registry.internal:5000/builds/abc123@sha256:" + strings.Repeat("ab", 32)
+
+	secure := &remotePublisher{}
+	parsed, err := name.ParseReference(ref, secure.localNameOptions()...)
+	require.NoError(t, err)
+	assert.Equal(t, "https", parsed.Context().Registry.Scheme())
+
+	insecure := &remotePublisher{localInsecure: true}
+	parsed, err = name.ParseReference(ref, insecure.localNameOptions()...)
+	require.NoError(t, err)
+	assert.Equal(t, "http", parsed.Context().Registry.Scheme())
+}
+
+func TestRegistryCATransport(t *testing.T) {
+	t.Run("empty CA cert uses the default transport", func(t *testing.T) {
+		transport, err := registryCATransport("")
+		require.NoError(t, err)
+		assert.Nil(t, transport)
+	})
+
+	t.Run("invalid PEM is rejected", func(t *testing.T) {
+		_, err := registryCATransport("not a pem certificate")
+		require.ErrorContains(t, err, "CA certificate")
+	})
+
+	t.Run("configured CA cert is trusted", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		// The server cert is self-signed: the default transport rejects it.
+		_, err := http.Get(srv.URL)
+		require.Error(t, err)
+
+		pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+		transport, err := registryCATransport(string(pemBytes))
+		require.NoError(t, err)
+
+		resp, err := (&http.Client{Transport: transport}).Get(srv.URL)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 }
 

--- a/lib/builds/publisher.go
+++ b/lib/builds/publisher.go
@@ -57,13 +57,15 @@ func (noopPublisher) Publish(_ context.Context, localRef, _ string) (string, err
 }
 
 // newBuildPublisher returns the publisher for the given publication config.
-// Publication is a no-op unless a remote registry is configured.
-func newBuildPublisher(cfg PublishConfig, localRegistry string, tokenGen *RegistryTokenGenerator) (BuildPublisher, error) {
+// Publication is a no-op unless a remote registry is configured. The local
+// registry TLS settings apply when pulling completed images from the local
+// registry.
+func newBuildPublisher(cfg PublishConfig, localRegistry string, localInsecure bool, localCACert string, tokenGen *RegistryTokenGenerator) (BuildPublisher, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
 	if !cfg.Enabled() {
 		return noopPublisher{}, nil
 	}
-	return newRemotePublisher(cfg, localRegistry, tokenGen)
+	return newRemotePublisher(cfg, localRegistry, localInsecure, localCACert, tokenGen)
 }

--- a/lib/builds/publisher.go
+++ b/lib/builds/publisher.go
@@ -58,9 +58,12 @@ func (noopPublisher) Publish(_ context.Context, localRef, _ string) (string, err
 
 // newBuildPublisher returns the publisher for the given publication config.
 // Publication is a no-op unless a remote registry is configured.
-func newBuildPublisher(cfg PublishConfig) (BuildPublisher, error) {
+func newBuildPublisher(cfg PublishConfig, localRegistry string, tokenGen *RegistryTokenGenerator) (BuildPublisher, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
-	return noopPublisher{}, nil
+	if !cfg.Enabled() {
+		return noopPublisher{}, nil
+	}
+	return newRemotePublisher(cfg, localRegistry, tokenGen)
 }

--- a/lib/builds/publisher_test.go
+++ b/lib/builds/publisher_test.go
@@ -22,19 +22,21 @@ func TestNoopPublisher_ReturnsLocalRefUnchanged(t *testing.T) {
 }
 
 func TestNewBuildPublisher_DisabledByDefault(t *testing.T) {
-	p, err := newBuildPublisher(PublishConfig{})
+	p, err := newBuildPublisher(PublishConfig{}, "localhost:5000", NewRegistryTokenGenerator("test"))
 	require.NoError(t, err)
 	assert.IsType(t, noopPublisher{}, p)
 }
 
 func TestNewBuildPublisher_ValidatesConfig(t *testing.T) {
-	_, err := newBuildPublisher(PublishConfig{RepositoryPrefix: "team/builds"})
+	tokenGen := NewRegistryTokenGenerator("test")
+
+	_, err := newBuildPublisher(PublishConfig{RepositoryPrefix: "team/builds"}, "localhost:5000", tokenGen)
 	require.ErrorContains(t, err, "registry")
 
-	_, err = newBuildPublisher(PublishConfig{CredentialsFile: "/creds.json"})
+	_, err = newBuildPublisher(PublishConfig{CredentialsFile: "/creds.json"}, "localhost:5000", tokenGen)
 	require.ErrorContains(t, err, "registry")
 
-	_, err = newBuildPublisher(PublishConfig{Registry: "registry.example.com"})
+	_, err = newBuildPublisher(PublishConfig{Registry: "registry.example.com"}, "localhost:5000", tokenGen)
 	require.ErrorContains(t, err, "repository_prefix")
 }
 

--- a/lib/builds/publisher_test.go
+++ b/lib/builds/publisher_test.go
@@ -22,7 +22,7 @@ func TestNoopPublisher_ReturnsLocalRefUnchanged(t *testing.T) {
 }
 
 func TestNewBuildPublisher_DisabledByDefault(t *testing.T) {
-	p, err := newBuildPublisher(PublishConfig{}, "localhost:5000", NewRegistryTokenGenerator("test"))
+	p, err := newBuildPublisher(PublishConfig{}, "localhost:5000", false, "", NewRegistryTokenGenerator("test"))
 	require.NoError(t, err)
 	assert.IsType(t, noopPublisher{}, p)
 }
@@ -30,13 +30,13 @@ func TestNewBuildPublisher_DisabledByDefault(t *testing.T) {
 func TestNewBuildPublisher_ValidatesConfig(t *testing.T) {
 	tokenGen := NewRegistryTokenGenerator("test")
 
-	_, err := newBuildPublisher(PublishConfig{RepositoryPrefix: "team/builds"}, "localhost:5000", tokenGen)
+	_, err := newBuildPublisher(PublishConfig{RepositoryPrefix: "team/builds"}, "localhost:5000", false, "", tokenGen)
 	require.ErrorContains(t, err, "registry")
 
-	_, err = newBuildPublisher(PublishConfig{CredentialsFile: "/creds.json"}, "localhost:5000", tokenGen)
+	_, err = newBuildPublisher(PublishConfig{CredentialsFile: "/creds.json"}, "localhost:5000", false, "", tokenGen)
 	require.ErrorContains(t, err, "registry")
 
-	_, err = newBuildPublisher(PublishConfig{Registry: "registry.example.com"}, "localhost:5000", tokenGen)
+	_, err = newBuildPublisher(PublishConfig{Registry: "registry.example.com"}, "localhost:5000", false, "", tokenGen)
 	require.ErrorContains(t, err, "repository_prefix")
 }
 


### PR DESCRIPTION
## Summary

Builds on #329. When `builds.publish` is configured, the host now publishes each completed build image to a remote OCI registry.

- Host-side copy of the completed local image to `<remote-registry>/<prefix>/<build-id>@<digest>`, using the existing go-containerregistry client — no new dependency.
- The remote manifest is verified by digest after the push and before the build reports ready; a verification mismatch or missing manifest fails the publish.
- A configured publication failure fails the build. `Build.ImageRef` records the immutable remote reference. Local image conversion (`waitForImageReady`, re-tag via `image_name`) is exactly as before.
- Credentials stay on the host: the local pull uses a short-lived registry token generated in-process, and remote credentials are read from a host-side Docker client config. Neither is written into the builder VM's `build.json`.
- Blob and manifest uploads are content-addressed and idempotent (existing blobs are skipped); transient registry errors are retried with backoff, permanent errors (e.g. 401) fail immediately.

## Tests

All against in-memory OCI registries (no live external registry):

- Destination derivation (build repo, image name, tag/digest stripping, slash trimming).
- Successful publication + remote manifest verification.
- Digest-mismatch and not-found verification failures.
- Idempotent re-publish (retry-safe).
- Retry of transient 500s; permanent 401 is not retried.
- Credential-file auth honored by the remote registry; keychain parsing errors.
- Credential confinement: the build config given to the builder VM contains no publish settings or credential material.
- Build-level: publication failure fails the build; configured publication records the remote ref on `Build.ImageRef`.

`go build ./...`, `go vet`, and `go test ./lib/builds/ ./cmd/api/config/ ./lib/providers/` all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-build image handling and registry I/O with host-stored credentials; misconfiguration or registry outages can fail otherwise successful builds, but builder VMs do not receive publish secrets.
> 
> **Overview**
> When **`builds.publish`** is set, the build manager no longer stops at a local image: it **copies** each finished build from the local registry to **`&lt;remote&gt;/&lt;prefix&gt;/&lt;build-id&gt;@&lt;digest&gt;`**, then **HEAD-verifies** the remote manifest matches the build digest before marking the build ready.
> 
> **`newBuildPublisher`** now selects a **`remotePublisher`** (via go-containerregistry) instead of always using a no-op. The host pulls locally with a **short-lived registry token** and pushes remotely using **Docker config credentials** read only on the host—publish settings and secrets are **not** written to the builder VM **`build.json`**. Local registry **insecure/CA** settings apply to the pull; pushes **retry** transient registry errors and **fail the build** on publish failure, with **`Build.ImageRef`** set to the immutable remote digest ref when publication succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564c4e26ae2d8a2fb0a8ae937d539ac0662684b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->