### PR TITLE
builds: add disabled-by-default local cache volume lifecycle

### DIFF
--- a/cmd/api/api/builds.go
+++ b/cmd/api/api/builds.go
@@ -231,7 +231,10 @@ func (s *ApiService) CreateBuild(ctx context.Context, request oapi.CreateBuildRe
 			Message: "cache_scope requires the build:admin scope",
 		}, nil
 	}
-	deriveTenantScope := s.Config != nil && s.Config.Build.Cache.DeriveTenantScope
+	// Local cache volumes are per-scope, so enabling them also enables
+	// identity-derived tenant scopes.
+	deriveTenantScope := s.Config != nil &&
+		(s.Config.Build.Cache.DeriveTenantScope || s.Config.Build.Cache.Local.Enabled)
 	effectiveCacheScope, err := resolveEffectiveCacheScope(mw.GetUserIDFromContext(ctx), cacheScope, isAdmin, isAdminBuild, deriveTenantScope)
 	if err != nil {
 		return oapi.CreateBuild400JSONResponse{

--- a/cmd/api/api/builds_cache_scope_test.go
+++ b/cmd/api/api/builds_cache_scope_test.go
@@ -237,3 +237,29 @@ func TestCreateBuild_OrdinaryCallerGetsDerivedScopeWhenEnabled(t *testing.T) {
 	require.NotNil(t, mgr.createReq)
 	assert.Equal(t, builds.DeriveCacheScope("user-bob"), mgr.createReq.CacheScope)
 }
+
+func TestCreateBuild_LocalCacheEnabledImpliesDerivedScope(t *testing.T) {
+	mgr := &stubBuildManager{}
+	svc := &ApiService{
+		BuildManager: mgr,
+		Config: &config.Config{
+			Build: config.BuildConfig{
+				Cache: config.BuildCacheConfig{
+					Local: config.BuildCacheLocalConfig{Enabled: true},
+				},
+			},
+		},
+	}
+	ctx := scopes.ContextWithPermissions(context.Background(), []scopes.Scope{scopes.BuildWrite})
+	ctx = mw.ContextWithUserID(ctx, "user-bob")
+
+	resp, err := svc.CreateBuild(ctx, createBuildRequest(t, map[string]string{
+		"dockerfile": "FROM alpine",
+	}))
+
+	require.NoError(t, err)
+	_, ok := resp.(oapi.CreateBuild202JSONResponse)
+	require.True(t, ok, "expected 202, got %T", resp)
+	require.NotNil(t, mgr.createReq)
+	assert.Equal(t, builds.DeriveCacheScope("user-bob"), mgr.createReq.CacheScope)
+}

--- a/cmd/api/api/volumes.go
+++ b/cmd/api/api/volumes.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kernel/hypeman/lib/builds"
 	"github.com/kernel/hypeman/lib/logger"
 	mw "github.com/kernel/hypeman/lib/middleware"
 	"github.com/kernel/hypeman/lib/oapi"
@@ -49,7 +48,7 @@ func (s *ApiService) CreateVolume(ctx context.Context, request oapi.CreateVolume
 	}
 
 	if request.Body.Id != nil {
-		if prefix := builds.ReservedVolumeIDPrefix(*request.Body.Id); prefix != "" {
+		if prefix := volumes.ReservedVolumeIDPrefix(*request.Body.Id); prefix != "" {
 			return oapi.CreateVolume400JSONResponse{
 				Code:    "invalid_request",
 				Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
@@ -109,7 +108,7 @@ func (s *ApiService) CreateVolumeFromArchive(ctx context.Context, request oapi.C
 	// Empty/invalid archives will fail with a clear gzip error downstream
 
 	if request.Params.Id != nil {
-		if prefix := builds.ReservedVolumeIDPrefix(*request.Params.Id); prefix != "" {
+		if prefix := volumes.ReservedVolumeIDPrefix(*request.Params.Id); prefix != "" {
 			return oapi.CreateVolumeFromArchive400JSONResponse{
 				Code:    "invalid_request",
 				Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
@@ -181,7 +180,7 @@ func (s *ApiService) DeleteVolume(ctx context.Context, request oapi.DeleteVolume
 		}, nil
 	}
 	log := logger.FromContext(ctx)
-	if prefix := builds.ReservedVolumeIDPrefix(vol.Id); prefix != "" {
+	if prefix := volumes.ReservedVolumeIDPrefix(vol.Id); prefix != "" {
 		return oapi.DeleteVolume409JSONResponse{
 			Code:    "conflict",
 			Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),

--- a/cmd/api/api/volumes.go
+++ b/cmd/api/api/volumes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/kernel/hypeman/lib/logger"
 	mw "github.com/kernel/hypeman/lib/middleware"
@@ -54,6 +55,13 @@ func (s *ApiService) CreateVolume(ctx context.Context, request oapi.CreateVolume
 				Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
 			}, nil
 		}
+	}
+
+	if key := reservedTagKey(request.Body.Tags); key != "" {
+		return oapi.CreateVolume400JSONResponse{
+			Code:    "invalid_request",
+			Message: fmt.Sprintf("tag key %q is reserved for internal use", key),
+		}, nil
 	}
 
 	domainReq := volumes.CreateVolumeRequest{
@@ -114,6 +122,13 @@ func (s *ApiService) CreateVolumeFromArchive(ctx context.Context, request oapi.C
 				Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
 			}, nil
 		}
+	}
+
+	if key := reservedTagKey(request.Params.Tags); key != "" {
+		return oapi.CreateVolumeFromArchive400JSONResponse{
+			Code:    "invalid_request",
+			Message: fmt.Sprintf("tag key %q is reserved for internal use", key),
+		}, nil
 	}
 
 	// Create the volume from archive - stream directly without buffering
@@ -229,4 +244,23 @@ func volumeToOAPI(vol volumes.Volume) oapi.Volume {
 	}
 
 	return oapiVol
+}
+
+// reservedTagKey returns the first caller-supplied tag key in the reserved
+// internal namespace, or "" when all keys are usable by API callers.
+func reservedTagKey(resourceTags *oapi.Tags) string {
+	if resourceTags == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(*resourceTags))
+	for key := range *resourceTags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if volumes.ReservedTagNamespace(key) != "" {
+			return key
+		}
+	}
+	return ""
 }

--- a/cmd/api/api/volumes.go
+++ b/cmd/api/api/volumes.go
@@ -3,7 +3,9 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/kernel/hypeman/lib/builds"
 	"github.com/kernel/hypeman/lib/logger"
 	mw "github.com/kernel/hypeman/lib/middleware"
 	"github.com/kernel/hypeman/lib/oapi"
@@ -44,6 +46,15 @@ func (s *ApiService) CreateVolume(ctx context.Context, request oapi.CreateVolume
 			Code:    "invalid_request",
 			Message: "request body is required",
 		}, nil
+	}
+
+	if request.Body.Id != nil {
+		if prefix := builds.ReservedVolumeIDPrefix(*request.Body.Id); prefix != "" {
+			return oapi.CreateVolume400JSONResponse{
+				Code:    "invalid_request",
+				Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
+			}, nil
+		}
 	}
 
 	domainReq := volumes.CreateVolumeRequest{
@@ -96,6 +107,15 @@ func (s *ApiService) CreateVolumeFromArchive(ctx context.Context, request oapi.C
 	}
 	// Note: request.Body is never nil in Go's net/http (empty body = http.NoBody)
 	// Empty/invalid archives will fail with a clear gzip error downstream
+
+	if request.Params.Id != nil {
+		if prefix := builds.ReservedVolumeIDPrefix(*request.Params.Id); prefix != "" {
+			return oapi.CreateVolumeFromArchive400JSONResponse{
+				Code:    "invalid_request",
+				Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
+			}, nil
+		}
+	}
 
 	// Create the volume from archive - stream directly without buffering
 	domainReq := volumes.CreateVolumeFromArchiveRequest{

--- a/cmd/api/api/volumes.go
+++ b/cmd/api/api/volumes.go
@@ -181,6 +181,12 @@ func (s *ApiService) DeleteVolume(ctx context.Context, request oapi.DeleteVolume
 		}, nil
 	}
 	log := logger.FromContext(ctx)
+	if prefix := builds.ReservedVolumeIDPrefix(vol.Id); prefix != "" {
+		return oapi.DeleteVolume409JSONResponse{
+			Code:    "conflict",
+			Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
+		}, nil
+	}
 
 	err := s.VolumeManager.DeleteVolume(ctx, vol.Id)
 	if err != nil {

--- a/cmd/api/api/volumes_test.go
+++ b/cmd/api/api/volumes_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kernel/hypeman/lib/oapi"
+	"github.com/kernel/hypeman/lib/volumes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -113,4 +114,27 @@ func TestCreateVolumeFromArchive_ReservedIDPrefix(t *testing.T) {
 	bad, ok := resp.(oapi.CreateVolumeFromArchive400JSONResponse)
 	require.True(t, ok, "expected 400 for reserved ID")
 	assert.Contains(t, bad.Message, "reserved for internal use")
+}
+
+func TestDeleteVolume_ReservedIDPrefix(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	for _, id := range []string{"build-cache-abc", "build-disk-1", "build-source-1", "build-config-1"} {
+		_, err := svc.VolumeManager.CreateVolume(ctx(), volumes.CreateVolumeRequest{
+			Id:     &id,
+			Name:   id,
+			SizeGb: 1,
+		})
+		require.NoError(t, err)
+
+		resp, err := svc.DeleteVolume(ctxWithVolume(svc, id), oapi.DeleteVolumeRequestObject{Id: id})
+		require.NoError(t, err)
+		conflict, ok := resp.(oapi.DeleteVolume409JSONResponse)
+		require.True(t, ok, "expected 409 for reserved ID %q", id)
+		assert.Contains(t, conflict.Message, "reserved for internal use")
+
+		_, err = svc.VolumeManager.GetVolume(ctx(), id)
+		require.NoError(t, err, "reserved volume %q should not be deleted", id)
+	}
 }

--- a/cmd/api/api/volumes_test.go
+++ b/cmd/api/api/volumes_test.go
@@ -77,3 +77,40 @@ func TestDeleteVolume_ByName(t *testing.T) {
 	_, ok := resp.(oapi.DeleteVolume204Response)
 	assert.True(t, ok, "expected 204 response")
 }
+
+func TestCreateVolume_ReservedIDPrefix(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	for _, id := range []string{"build-cache-abc", "build-disk-1", "build-source-1", "build-config-1"} {
+		resp, err := svc.CreateVolume(ctx(), oapi.CreateVolumeRequestObject{
+			Body: &oapi.CreateVolumeRequest{
+				Name:   "squat",
+				SizeGb: 1,
+				Id:     &id,
+			},
+		})
+		require.NoError(t, err)
+		bad, ok := resp.(oapi.CreateVolume400JSONResponse)
+		require.True(t, ok, "expected 400 for reserved ID %q", id)
+		assert.Contains(t, bad.Message, "reserved for internal use")
+	}
+}
+
+func TestCreateVolumeFromArchive_ReservedIDPrefix(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	id := "build-cache-abc"
+	resp, err := svc.CreateVolumeFromArchive(ctx(), oapi.CreateVolumeFromArchiveRequestObject{
+		Params: oapi.CreateVolumeFromArchiveParams{
+			Name:   "squat",
+			SizeGb: 1,
+			Id:     &id,
+		},
+	})
+	require.NoError(t, err)
+	bad, ok := resp.(oapi.CreateVolumeFromArchive400JSONResponse)
+	require.True(t, ok, "expected 400 for reserved ID")
+	assert.Contains(t, bad.Message, "reserved for internal use")
+}

--- a/cmd/api/api/volumes_test.go
+++ b/cmd/api/api/volumes_test.go
@@ -79,6 +79,46 @@ func TestDeleteVolume_ByName(t *testing.T) {
 	assert.True(t, ok, "expected 204 response")
 }
 
+func TestCreateVolume_ReservedTagNamespace(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	resourceTags := oapi.Tags{"hypeman.system/managed-by": "build-cache"}
+	resp, err := svc.CreateVolume(ctx(), oapi.CreateVolumeRequestObject{
+		Body: &oapi.CreateVolumeRequest{
+			Name:   "spoofed-cache",
+			SizeGb: 1,
+			Tags:   &resourceTags,
+		},
+	})
+	require.NoError(t, err)
+	bad, ok := resp.(oapi.CreateVolume400JSONResponse)
+	require.True(t, ok, "expected 400 for reserved tag key")
+	assert.Contains(t, bad.Message, "reserved for internal use")
+
+	vols, err := svc.VolumeManager.ListVolumes(ctx())
+	require.NoError(t, err)
+	assert.Empty(t, vols, "spoofed volume should not be created")
+}
+
+func TestCreateVolumeFromArchive_ReservedTagNamespace(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	resourceTags := oapi.Tags{"hypeman.system/managed-by": "build-cache"}
+	resp, err := svc.CreateVolumeFromArchive(ctx(), oapi.CreateVolumeFromArchiveRequestObject{
+		Params: oapi.CreateVolumeFromArchiveParams{
+			Name:   "spoofed-cache",
+			SizeGb: 1,
+			Tags:   &resourceTags,
+		},
+	})
+	require.NoError(t, err)
+	bad, ok := resp.(oapi.CreateVolumeFromArchive400JSONResponse)
+	require.True(t, ok, "expected 400 for reserved tag key")
+	assert.Contains(t, bad.Message, "reserved for internal use")
+}
+
 func TestCreateVolume_ReservedIDPrefix(t *testing.T) {
 	t.Parallel()
 	svc := newTestService(t)

--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -168,8 +168,21 @@ type BuildCacheConfig struct {
 	// DeriveTenantScope derives the tenant cache scope for a build from the
 	// authenticated identity. Disabled by default: builds that do not carry an
 	// operator-supplied cache_scope run with no tenant cache scope, so no
-	// per-tenant registry cache is imported or exported.
-	DeriveTenantScope bool `koanf:"derive_tenant_scope"`
+	// per-tenant registry cache is imported or exported. Enabling the local
+	// cache below also enables derivation, since the per-scope cache volumes
+	// require a scope.
+	DeriveTenantScope bool                  `koanf:"derive_tenant_scope"`
+	Local             BuildCacheLocalConfig `koanf:"local"`
+}
+
+// BuildCacheLocalConfig holds settings for persistent per-scope BuildKit cache
+// volumes on this host. Disabled by default.
+type BuildCacheLocalConfig struct {
+	Enabled    bool   `koanf:"enabled"`
+	SizeGB     int    `koanf:"size_gb"`
+	IdleTTL    string `koanf:"idle_ttl"`
+	MaxBytes   string `koanf:"max_bytes"`
+	MaxVolumes int    `koanf:"max_volumes"`
 }
 
 // InstancesConfig holds instance-manager internal settings.
@@ -650,6 +663,27 @@ func (c *Config) Validate() error {
 	}
 	if c.Build.DiskRoot.SizeGB < 0 {
 		return fmt.Errorf("build.disk_root.size_gb must be >= 0, got %d", c.Build.DiskRoot.SizeGB)
+	}
+	if c.Build.Cache.Local.SizeGB < 0 {
+		return fmt.Errorf("build.cache.local.size_gb must be >= 0, got %d", c.Build.Cache.Local.SizeGB)
+	}
+	if c.Build.Cache.Local.MaxVolumes < 0 {
+		return fmt.Errorf("build.cache.local.max_volumes must be >= 0, got %d", c.Build.Cache.Local.MaxVolumes)
+	}
+	if c.Build.Cache.Local.IdleTTL != "" {
+		idleTTL, err := time.ParseDuration(c.Build.Cache.Local.IdleTTL)
+		if err != nil {
+			return fmt.Errorf("build.cache.local.idle_ttl must be a valid duration, got %q: %w", c.Build.Cache.Local.IdleTTL, err)
+		}
+		if idleTTL <= 0 {
+			return fmt.Errorf("build.cache.local.idle_ttl must be positive, got %q", c.Build.Cache.Local.IdleTTL)
+		}
+	}
+	if c.Build.Cache.Local.MaxBytes != "" {
+		var size datasize.ByteSize
+		if err := size.UnmarshalText([]byte(c.Build.Cache.Local.MaxBytes)); err != nil {
+			return fmt.Errorf("build.cache.local.max_bytes must be a valid byte size, got %q: %w", c.Build.Cache.Local.MaxBytes, err)
+		}
 	}
 	if c.Hypervisor.FirecrackerMaxConcurrentRestores < 0 {
 		return fmt.Errorf("hypervisor.firecracker_max_concurrent_restores must be >= 0, got %d", c.Hypervisor.FirecrackerMaxConcurrentRestores)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -160,6 +160,12 @@ data_dir: /var/lib/hypeman
 #     derive_tenant_scope: false    # derive a per-tenant build cache scope from the
 #                                   # authenticated identity (enables tenant registry
 #                                   # cache import/export for ordinary builds)
+#     local:
+#       enabled: false              # persistent per-tenant BuildKit cache volumes
+#       size_gb: 50                 # fixed size of each cache volume
+#       idle_ttl: 24h               # delete cache volumes unused for this long
+#       max_bytes: ""               # host-wide cap on cache volumes (e.g. 200GB, empty = unlimited)
+#       max_volumes: 0              # host-wide cap on cache volume count (0 = unlimited)
 
 # =============================================================================
 # Resource Limits

--- a/lib/builds/cache_volume.go
+++ b/lib/builds/cache_volume.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/tags"
 	"github.com/kernel/hypeman/lib/volumes"
 )
 
@@ -52,9 +53,39 @@ const (
 	// cacheVolumeIDPrefix prefixes all cache volume IDs.
 	cacheVolumeIDPrefix = "build-cache-"
 
+	// cacheVolumeManagedTagKey and cacheVolumeManagedTagValue mark volumes
+	// created by the build cache manager. The tag distinguishes cache
+	// volumes from caller-created volumes that happen to share the ID
+	// prefix: the manager only reuses tagged volumes and the reaper only
+	// evicts tagged volumes.
+	cacheVolumeManagedTagKey   = "hypeman.system/managed-by"
+	cacheVolumeManagedTagValue = "build-cache"
+
 	// cacheVolumeSweepInterval is how often the reaper evaluates eviction.
 	cacheVolumeSweepInterval = time.Minute
 )
+
+// managedVolumeIDPrefixes are volume ID prefixes reserved for volumes the
+// build manager creates internally. Public volume APIs reject
+// caller-supplied IDs with these prefixes so a caller cannot squat on or
+// tamper with an internal build volume.
+var managedVolumeIDPrefixes = []string{
+	cacheVolumeIDPrefix,
+	"build-config-",
+	"build-disk-",
+	"build-source-",
+}
+
+// ReservedVolumeIDPrefix returns the reserved internal prefix id starts
+// with, or "" when id is usable by API callers.
+func ReservedVolumeIDPrefix(id string) string {
+	for _, p := range managedVolumeIDPrefixes {
+		if strings.HasPrefix(id, p) {
+			return p
+		}
+	}
+	return ""
+}
 
 // cacheVolumeID returns the volume ID for a cache scope:
 // build-cache-<sha256(scope)>.
@@ -134,7 +165,10 @@ func (c *cacheVolumeManager) acquireVolume(volID string) func() {
 func (c *cacheVolumeManager) ensureCacheVolume(ctx context.Context, scope string) (string, error) {
 	volID := cacheVolumeID(scope)
 
-	if _, err := c.volumeManager.GetVolume(ctx, volID); err == nil {
+	if vol, err := c.volumeManager.GetVolume(ctx, volID); err == nil {
+		if !isManagedCacheVolume(vol) {
+			return "", fmt.Errorf("cache volume %s exists but was not created by the build cache; refusing to reuse it", volID)
+		}
 		c.touchLastUsed(volID)
 		return volID, nil
 	} else if !errors.Is(err, volumes.ErrNotFound) {
@@ -145,13 +179,29 @@ func (c *cacheVolumeManager) ensureCacheVolume(ctx context.Context, scope string
 		Id:     &volID,
 		Name:   volID,
 		SizeGb: c.config.SizeGB,
+		Tags:   tags.Tags{cacheVolumeManagedTagKey: cacheVolumeManagedTagValue},
 	})
-	if err != nil && !errors.Is(err, volumes.ErrAlreadyExists) {
+	if errors.Is(err, volumes.ErrAlreadyExists) {
+		// Lost a creation race; reuse the winner only if it is ours.
+		vol, getErr := c.volumeManager.GetVolume(ctx, volID)
+		if getErr != nil {
+			return "", fmt.Errorf("get cache volume after create race: %w", getErr)
+		}
+		if !isManagedCacheVolume(vol) {
+			return "", fmt.Errorf("cache volume %s exists but was not created by the build cache; refusing to reuse it", volID)
+		}
+	} else if err != nil {
 		return "", fmt.Errorf("create cache volume: %w", err)
 	}
 
 	c.touchLastUsed(volID)
 	return volID, nil
+}
+
+// isManagedCacheVolume reports whether a volume carries the internal tag
+// marking it as created by the build cache manager.
+func isManagedCacheVolume(vol *volumes.Volume) bool {
+	return vol.Tags[cacheVolumeManagedTagKey] == cacheVolumeManagedTagValue
 }
 
 // touchLastUsed records that a cache volume was used now.
@@ -223,7 +273,9 @@ func (c *cacheVolumeManager) startReaper(ctx context.Context) {
 
 // reap deletes cache volumes that are idle past the TTL, then evicts idle
 // volumes LRU-first until the byte and count limits are satisfied. Attached
-// or in-use volumes are never evicted.
+// or in-use volumes are never evicted. Only volumes tagged as managed by the
+// build cache are considered; caller-created volumes that happen to share
+// the ID prefix are left alone.
 func (c *cacheVolumeManager) reap(ctx context.Context) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -237,7 +289,7 @@ func (c *cacheVolumeManager) reap(ctx context.Context) {
 
 	cacheVols := make([]volumes.Volume, 0)
 	for _, v := range vols {
-		if strings.HasPrefix(v.Id, cacheVolumeIDPrefix) {
+		if isManagedCacheVolume(&v) {
 			cacheVols = append(cacheVols, v)
 		}
 	}

--- a/lib/builds/cache_volume.go
+++ b/lib/builds/cache_volume.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -64,28 +63,6 @@ const (
 	// cacheVolumeSweepInterval is how often the reaper evaluates eviction.
 	cacheVolumeSweepInterval = time.Minute
 )
-
-// managedVolumeIDPrefixes are volume ID prefixes reserved for volumes the
-// build manager creates internally. Public volume APIs reject
-// caller-supplied IDs with these prefixes so a caller cannot squat on or
-// tamper with an internal build volume.
-var managedVolumeIDPrefixes = []string{
-	cacheVolumeIDPrefix,
-	"build-config-",
-	"build-disk-",
-	"build-source-",
-}
-
-// ReservedVolumeIDPrefix returns the reserved internal prefix id starts
-// with, or "" when id is usable by API callers.
-func ReservedVolumeIDPrefix(id string) string {
-	for _, p := range managedVolumeIDPrefixes {
-		if strings.HasPrefix(id, p) {
-			return p
-		}
-	}
-	return ""
-}
 
 // cacheVolumeID returns the volume ID for a cache scope:
 // build-cache-<sha256(scope)>.

--- a/lib/builds/cache_volume.go
+++ b/lib/builds/cache_volume.go
@@ -258,20 +258,21 @@ func (c *cacheVolumeManager) reap(ctx context.Context) {
 		return v.CreatedAt
 	}
 
-	deleteLocked := func(v volumes.Volume) {
+	deleteLocked := func(v volumes.Volume) bool {
 		if err := c.volumeManager.DeleteVolume(ctx, v.Id); err != nil {
 			c.logger.Warn("failed to evict cache volume", "volume", v.Id, "error", err)
-			return
+			return false
 		}
 		c.logger.Info("evicted cache volume", "volume", v.Id)
 		delete(c.lastUsed, v.Id)
+		return true
 	}
 
-	// Idle TTL eviction
+	// Idle TTL eviction. Volumes whose delete fails stay in remaining so the
+	// limit accounting below still counts them and a later pass can retry.
 	remaining := make([]volumes.Volume, 0, len(cacheVols))
 	for _, v := range cacheVols {
-		if now.Sub(lastUsedLocked(v)) > c.config.IdleTTL && deletableLocked(v) {
-			deleteLocked(v)
+		if now.Sub(lastUsedLocked(v)) > c.config.IdleTTL && deletableLocked(v) && deleteLocked(v) {
 			continue
 		}
 		remaining = append(remaining, v)
@@ -291,8 +292,7 @@ func (c *cacheVolumeManager) reap(ctx context.Context) {
 	for _, v := range remaining {
 		overBytes := c.config.MaxBytes > 0 && totalBytes > c.config.MaxBytes
 		overCount := c.config.MaxVolumes > 0 && present > c.config.MaxVolumes
-		if (overBytes || overCount) && deletableLocked(v) {
-			deleteLocked(v)
+		if (overBytes || overCount) && deletableLocked(v) && deleteLocked(v) {
 			totalBytes -= int64(v.SizeGb) * 1024 * 1024 * 1024
 			present--
 		}

--- a/lib/builds/cache_volume.go
+++ b/lib/builds/cache_volume.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,8 +57,9 @@ const (
 	// created by the build cache manager. The tag distinguishes cache
 	// volumes from caller-created volumes that happen to share the ID
 	// prefix: the manager only reuses tagged volumes and the reaper only
-	// evicts tagged volumes.
-	cacheVolumeManagedTagKey   = "hypeman.system/managed-by"
+	// evicts tagged volumes. The key lives in a namespace public volume
+	// APIs reserve, so callers cannot spoof it.
+	cacheVolumeManagedTagKey   = volumes.SystemTagNamespace + "managed-by"
 	cacheVolumeManagedTagValue = "build-cache"
 
 	// cacheVolumeSweepInterval is how often the reaper evaluates eviction.
@@ -175,10 +177,14 @@ func (c *cacheVolumeManager) ensureCacheVolume(ctx context.Context, scope string
 	return volID, nil
 }
 
-// isManagedCacheVolume reports whether a volume carries the internal tag
-// marking it as created by the build cache manager.
+// isManagedCacheVolume reports whether a volume is a build cache volume:
+// it carries the internal managed-by tag and the reserved cache volume ID
+// prefix. The prefix check is defense in depth — public APIs already reject
+// both — so a volume created outside the public API cannot be mistaken for
+// a cache volume by tag alone.
 func isManagedCacheVolume(vol *volumes.Volume) bool {
-	return vol.Tags[cacheVolumeManagedTagKey] == cacheVolumeManagedTagValue
+	return strings.HasPrefix(vol.Id, cacheVolumeIDPrefix) &&
+		vol.Tags[cacheVolumeManagedTagKey] == cacheVolumeManagedTagValue
 }
 
 // touchLastUsed records that a cache volume was used now.

--- a/lib/builds/cache_volume.go
+++ b/lib/builds/cache_volume.go
@@ -1,0 +1,304 @@
+package builds
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/volumes"
+)
+
+// CacheVolumeConfig configures the local persistent build cache volumes.
+// The zero value is disabled.
+type CacheVolumeConfig struct {
+	// Enabled turns on persistent per-scope cache volumes.
+	Enabled bool
+
+	// SizeGB is the fixed size of each cache volume.
+	// Values <= 0 use DefaultCacheVolumeSizeGB.
+	SizeGB int
+
+	// IdleTTL is how long a cache volume may go unused before it is deleted.
+	// Values <= 0 use DefaultCacheVolumeIdleTTL.
+	IdleTTL time.Duration
+
+	// MaxBytes caps the total size of all cache volumes on the host
+	// (0 = unlimited). Idle volumes are evicted LRU-first to stay under it.
+	MaxBytes int64
+
+	// MaxVolumes caps the number of cache volumes on the host
+	// (0 = unlimited). Idle volumes are evicted LRU-first to stay under it.
+	MaxVolumes int
+}
+
+const (
+	// DefaultCacheVolumeSizeGB is the default fixed size of a cache volume.
+	DefaultCacheVolumeSizeGB = 50
+
+	// DefaultCacheVolumeIdleTTL is the default idle lifetime of a cache volume.
+	DefaultCacheVolumeIdleTTL = 24 * time.Hour
+
+	// cacheVolumeIDPrefix prefixes all cache volume IDs.
+	cacheVolumeIDPrefix = "build-cache-"
+
+	// cacheVolumeSweepInterval is how often the reaper evaluates eviction.
+	cacheVolumeSweepInterval = time.Minute
+)
+
+// cacheVolumeID returns the volume ID for a cache scope:
+// build-cache-<sha256(scope)>.
+func cacheVolumeID(scope string) string {
+	sum := sha256.Sum256([]byte(scope))
+	return cacheVolumeIDPrefix + hex.EncodeToString(sum[:])
+}
+
+// cacheVolumeManager owns the lifecycle of persistent per-scope BuildKit cache
+// volumes: creation, last-used tracking, and eviction. It never deletes a
+// volume that is attached or in use by a running build.
+type cacheVolumeManager struct {
+	config        CacheVolumeConfig
+	paths         *paths.Paths
+	volumeManager volumes.Manager
+	logger        *slog.Logger
+
+	mu       sync.Mutex // guards lastUsed, loaded, and inUse
+	lastUsed map[string]time.Time
+	loaded   bool
+	inUse    map[string]int
+
+	scopeLocks sync.Map // map[string]*sync.Mutex — per-scope build serialization
+
+	now func() time.Time // overridable for tests
+}
+
+func newCacheVolumeManager(config CacheVolumeConfig, p *paths.Paths, volumeMgr volumes.Manager, logger *slog.Logger) *cacheVolumeManager {
+	if config.SizeGB <= 0 {
+		config.SizeGB = DefaultCacheVolumeSizeGB
+	}
+	if config.IdleTTL <= 0 {
+		config.IdleTTL = DefaultCacheVolumeIdleTTL
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &cacheVolumeManager{
+		config:        config,
+		paths:         p,
+		volumeManager: volumeMgr,
+		logger:        logger,
+		inUse:         make(map[string]int),
+		now:           time.Now,
+	}
+}
+
+// lockScope serializes builds for a cache scope. The returned function
+// releases the lock.
+func (c *cacheVolumeManager) lockScope(scope string) func() {
+	l, _ := c.scopeLocks.LoadOrStore(scope, &sync.Mutex{})
+	mu := l.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+// acquireVolume marks a volume as in use by a running build so the reaper
+// never evicts it, including the window between creation and attachment.
+// The returned function releases the guard.
+func (c *cacheVolumeManager) acquireVolume(volID string) func() {
+	c.mu.Lock()
+	c.inUse[volID]++
+	c.mu.Unlock()
+
+	return func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.inUse[volID]--
+		if c.inUse[volID] <= 0 {
+			delete(c.inUse, volID)
+		}
+	}
+}
+
+// ensureCacheVolume returns the cache volume for a scope, creating it at the
+// configured fixed size if it does not exist yet, and marks it used.
+func (c *cacheVolumeManager) ensureCacheVolume(ctx context.Context, scope string) (string, error) {
+	volID := cacheVolumeID(scope)
+
+	if _, err := c.volumeManager.GetVolume(ctx, volID); err == nil {
+		c.touchLastUsed(volID)
+		return volID, nil
+	} else if !errors.Is(err, volumes.ErrNotFound) {
+		return "", fmt.Errorf("get cache volume: %w", err)
+	}
+
+	_, err := c.volumeManager.CreateVolume(ctx, volumes.CreateVolumeRequest{
+		Id:     &volID,
+		Name:   volID,
+		SizeGb: c.config.SizeGB,
+	})
+	if err != nil && !errors.Is(err, volumes.ErrAlreadyExists) {
+		return "", fmt.Errorf("create cache volume: %w", err)
+	}
+
+	c.touchLastUsed(volID)
+	return volID, nil
+}
+
+// touchLastUsed records that a cache volume was used now.
+func (c *cacheVolumeManager) touchLastUsed(volID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.loadLocked()
+	c.lastUsed[volID] = c.now()
+	if err := c.saveLocked(); err != nil {
+		c.logger.Warn("failed to persist cache volume state", "volume", volID, "error", err)
+	}
+}
+
+// statePath returns the path of the last-used metadata file.
+func (c *cacheVolumeManager) statePath() string {
+	return filepath.Join(c.paths.BuildsDir(), "cache-volumes.json")
+}
+
+// loadLocked loads last-used metadata from disk on first use.
+// c.mu must be held.
+func (c *cacheVolumeManager) loadLocked() {
+	if c.loaded {
+		return
+	}
+	c.lastUsed = make(map[string]time.Time)
+	if data, err := os.ReadFile(c.statePath()); err == nil {
+		raw := make(map[string]time.Time)
+		if json.Unmarshal(data, &raw) == nil {
+			c.lastUsed = raw
+		}
+	}
+	c.loaded = true
+}
+
+// saveLocked persists last-used metadata atomically.
+// c.mu must be held.
+func (c *cacheVolumeManager) saveLocked() error {
+	data, err := json.Marshal(c.lastUsed)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(c.statePath()), 0755); err != nil {
+		return err
+	}
+	tmp := c.statePath() + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, c.statePath())
+}
+
+// startReaper periodically evicts cache volumes that exceed the idle TTL or
+// the host-wide byte/count limits.
+func (c *cacheVolumeManager) startReaper(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(cacheVolumeSweepInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.reap(ctx)
+			}
+		}
+	}()
+}
+
+// reap deletes cache volumes that are idle past the TTL, then evicts idle
+// volumes LRU-first until the byte and count limits are satisfied. Attached
+// or in-use volumes are never evicted.
+func (c *cacheVolumeManager) reap(ctx context.Context) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.loadLocked()
+
+	vols, err := c.volumeManager.ListVolumes(ctx)
+	if err != nil {
+		c.logger.Warn("failed to list volumes for cache reaper", "error", err)
+		return
+	}
+
+	cacheVols := make([]volumes.Volume, 0)
+	for _, v := range vols {
+		if strings.HasPrefix(v.Id, cacheVolumeIDPrefix) {
+			cacheVols = append(cacheVols, v)
+		}
+	}
+
+	now := c.now()
+
+	deletableLocked := func(v volumes.Volume) bool {
+		if len(v.Attachments) > 0 {
+			return false
+		}
+		return c.inUse[v.Id] == 0
+	}
+
+	lastUsedLocked := func(v volumes.Volume) time.Time {
+		if t, ok := c.lastUsed[v.Id]; ok {
+			return t
+		}
+		return v.CreatedAt
+	}
+
+	deleteLocked := func(v volumes.Volume) {
+		if err := c.volumeManager.DeleteVolume(ctx, v.Id); err != nil {
+			c.logger.Warn("failed to evict cache volume", "volume", v.Id, "error", err)
+			return
+		}
+		c.logger.Info("evicted cache volume", "volume", v.Id)
+		delete(c.lastUsed, v.Id)
+	}
+
+	// Idle TTL eviction
+	remaining := make([]volumes.Volume, 0, len(cacheVols))
+	for _, v := range cacheVols {
+		if now.Sub(lastUsedLocked(v)) > c.config.IdleTTL && deletableLocked(v) {
+			deleteLocked(v)
+			continue
+		}
+		remaining = append(remaining, v)
+	}
+
+	// Host-wide limits: evict least recently used idle volumes first
+	sort.Slice(remaining, func(i, j int) bool {
+		return lastUsedLocked(remaining[i]).Before(lastUsedLocked(remaining[j]))
+	})
+
+	totalBytes := int64(0)
+	for _, v := range remaining {
+		totalBytes += int64(v.SizeGb) * 1024 * 1024 * 1024
+	}
+
+	present := len(remaining)
+	for _, v := range remaining {
+		overBytes := c.config.MaxBytes > 0 && totalBytes > c.config.MaxBytes
+		overCount := c.config.MaxVolumes > 0 && present > c.config.MaxVolumes
+		if (overBytes || overCount) && deletableLocked(v) {
+			deleteLocked(v)
+			totalBytes -= int64(v.SizeGb) * 1024 * 1024 * 1024
+			present--
+		}
+	}
+
+	if err := c.saveLocked(); err != nil {
+		c.logger.Warn("failed to persist cache volume state", "error", err)
+	}
+}

--- a/lib/builds/cache_volume_test.go
+++ b/lib/builds/cache_volume_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/tags"
 	"github.com/kernel/hypeman/lib/volumes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,6 +39,7 @@ func setupCacheVolumeManager(t *testing.T, config CacheVolumeConfig) (*cacheVolu
 			Id:        id,
 			Name:      req.Name,
 			SizeGb:    req.SizeGb,
+			Tags:      tags.Clone(req.Tags),
 			CreatedAt: time.Now(),
 		}
 		volumeMgr.volumes[id] = vol
@@ -97,6 +99,64 @@ func TestEnsureCacheVolume_ReusesExisting(t *testing.T) {
 
 	assert.Equal(t, volID1, volID2)
 	assert.Equal(t, 1, volumeMgr.createCallCount)
+}
+
+func TestEnsureCacheVolume_TagsCreatedVolume(t *testing.T) {
+	mgr, volumeMgr, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true})
+	defer os.RemoveAll(tempDir)
+
+	volID, err := mgr.ensureCacheVolume(context.Background(), "tenant-a")
+	require.NoError(t, err)
+
+	vol, err := volumeMgr.GetVolume(context.Background(), volID)
+	require.NoError(t, err)
+	assert.Equal(t, "build-cache", vol.Tags["hypeman.system/managed-by"])
+}
+
+func TestEnsureCacheVolume_RejectsUnmanagedVolume(t *testing.T) {
+	mgr, volumeMgr, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true})
+	defer os.RemoveAll(tempDir)
+
+	// A caller-created volume squatting on the deterministic cache volume ID.
+	volID := cacheVolumeID("tenant-a")
+	volumeMgr.volumes[volID] = &volumes.Volume{Id: volID, Name: volID, SizeGb: 1}
+
+	_, err := mgr.ensureCacheVolume(context.Background(), "tenant-a")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not created by the build cache")
+}
+
+func TestReap_IgnoresUnmanagedPrefixedVolume(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled: true,
+		SizeGB:  10,
+		IdleTTL: time.Hour,
+	})
+	defer os.RemoveAll(tempDir)
+
+	// An untagged user volume sharing the reserved prefix must survive the
+	// reaper even when it looks idle past the TTL.
+	userVol := &volumes.Volume{
+		Id:        "build-cache-user-data",
+		Name:      "user-data",
+		SizeGb:    10,
+		CreatedAt: now.Add(-72 * time.Hour),
+	}
+	volumeMgr.volumes[userVol.Id] = userVol
+
+	mgr.reap(context.Background())
+
+	_, err := volumeMgr.GetVolume(context.Background(), userVol.Id)
+	assert.NoError(t, err, "unmanaged volume must never be evicted")
+}
+
+func TestReservedVolumeIDPrefix(t *testing.T) {
+	assert.Equal(t, "build-cache-", ReservedVolumeIDPrefix("build-cache-abc"))
+	assert.Equal(t, "build-disk-", ReservedVolumeIDPrefix("build-disk-123"))
+	assert.Equal(t, "build-source-", ReservedVolumeIDPrefix("build-source-123"))
+	assert.Equal(t, "build-config-", ReservedVolumeIDPrefix("build-config-123"))
+	assert.Empty(t, ReservedVolumeIDPrefix("my-data"))
+	assert.Empty(t, ReservedVolumeIDPrefix("build-caches"))
 }
 
 func TestLockScope_SerializesSameScope(t *testing.T) {

--- a/lib/builds/cache_volume_test.go
+++ b/lib/builds/cache_volume_test.go
@@ -1,0 +1,415 @@
+package builds
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/volumes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupCacheVolumeManager returns a cache volume manager backed by mock
+// volumes, plus the mock itself and a settable clock.
+func setupCacheVolumeManager(t *testing.T, config CacheVolumeConfig) (*cacheVolumeManager, *mockVolumeManager, *time.Time, string) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "cache-volumes-test-*")
+	require.NoError(t, err)
+
+	volumeMgr := newMockVolumeManager()
+	// Honor custom IDs and sizes like the real volume manager.
+	volumeMgr.createFunc = func(ctx context.Context, req volumes.CreateVolumeRequest) (*volumes.Volume, error) {
+		id := req.Name
+		if req.Id != nil && *req.Id != "" {
+			id = *req.Id
+		}
+		if _, ok := volumeMgr.volumes[id]; ok {
+			return nil, volumes.ErrAlreadyExists
+		}
+		vol := &volumes.Volume{
+			Id:        id,
+			Name:      req.Name,
+			SizeGb:    req.SizeGb,
+			CreatedAt: time.Now(),
+		}
+		volumeMgr.volumes[id] = vol
+		return vol, nil
+	}
+
+	now := time.Now()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mgr := newCacheVolumeManager(config, paths.New(tempDir), volumeMgr, logger)
+	mgr.now = func() time.Time { return now }
+
+	return mgr, volumeMgr, &now, tempDir
+}
+
+func TestCacheVolumeID(t *testing.T) {
+	idA := cacheVolumeID("tenant-a")
+
+	assert.Equal(t, idA, cacheVolumeID("tenant-a"), "deterministic")
+	assert.NotEqual(t, idA, cacheVolumeID("tenant-b"), "distinct per scope")
+	assert.Contains(t, idA, "build-cache-")
+	assert.Len(t, idA, len("build-cache-")+64, "build-cache-<sha256 hex>")
+}
+
+func TestEnsureCacheVolume_CreatesWithFixedSize(t *testing.T) {
+	mgr, volumeMgr, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true, SizeGB: 42})
+	defer os.RemoveAll(tempDir)
+
+	volID, err := mgr.ensureCacheVolume(context.Background(), "tenant-a")
+
+	require.NoError(t, err)
+	assert.Equal(t, cacheVolumeID("tenant-a"), volID)
+	vol, err := volumeMgr.GetVolume(context.Background(), volID)
+	require.NoError(t, err)
+	assert.Equal(t, 42, vol.SizeGb)
+}
+
+func TestEnsureCacheVolume_DefaultSize(t *testing.T) {
+	mgr, volumeMgr, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true})
+	defer os.RemoveAll(tempDir)
+
+	volID, err := mgr.ensureCacheVolume(context.Background(), "tenant-a")
+
+	require.NoError(t, err)
+	vol, err := volumeMgr.GetVolume(context.Background(), volID)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultCacheVolumeSizeGB, vol.SizeGb)
+}
+
+func TestEnsureCacheVolume_ReusesExisting(t *testing.T) {
+	mgr, volumeMgr, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true, SizeGB: 42})
+	defer os.RemoveAll(tempDir)
+
+	volID1, err := mgr.ensureCacheVolume(context.Background(), "tenant-a")
+	require.NoError(t, err)
+	volID2, err := mgr.ensureCacheVolume(context.Background(), "tenant-a")
+	require.NoError(t, err)
+
+	assert.Equal(t, volID1, volID2)
+	assert.Equal(t, 1, volumeMgr.createCallCount)
+}
+
+func TestLockScope_SerializesSameScope(t *testing.T) {
+	mgr, _, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true})
+	defer os.RemoveAll(tempDir)
+
+	unlock := mgr.lockScope("tenant-a")
+
+	acquired := make(chan struct{})
+	go func() {
+		unlock2 := mgr.lockScope("tenant-a")
+		close(acquired)
+		unlock2()
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second lock on same scope acquired while first was held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	unlock()
+	select {
+	case <-acquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second lock not acquired after release")
+	}
+}
+
+func TestLockScope_IndependentAcrossScopes(t *testing.T) {
+	mgr, _, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true})
+	defer os.RemoveAll(tempDir)
+
+	unlockA := mgr.lockScope("tenant-a")
+	defer unlockA()
+
+	done := make(chan struct{})
+	go func() {
+		unlockB := mgr.lockScope("tenant-b")
+		unlockB()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("lock on a different scope blocked")
+	}
+}
+
+func TestReap_IdleTTLDeletesOldVolumes(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled: true,
+		SizeGB:  10,
+		IdleTTL: time.Hour,
+	})
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	oldVol, err := mgr.ensureCacheVolume(ctx, "tenant-old")
+	require.NoError(t, err)
+
+	// Age the volume beyond the TTL, then create a fresh one.
+	*now = now.Add(-2 * time.Hour)
+	mgr.touchLastUsed(oldVol)
+	*now = time.Now()
+
+	freshVol, err := mgr.ensureCacheVolume(ctx, "tenant-fresh")
+	require.NoError(t, err)
+
+	mgr.reap(ctx)
+
+	_, err = volumeMgr.GetVolume(ctx, oldVol)
+	assert.ErrorIs(t, err, volumes.ErrNotFound, "idle-past-TTL volume evicted")
+
+	_, err = volumeMgr.GetVolume(ctx, freshVol)
+	assert.NoError(t, err, "fresh volume kept")
+}
+
+func TestReap_NeverEvictsAttachedVolume(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled: true,
+		SizeGB:  10,
+		IdleTTL: time.Hour,
+	})
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	volID, err := mgr.ensureCacheVolume(ctx, "tenant-a")
+	require.NoError(t, err)
+
+	*now = now.Add(-2 * time.Hour)
+	mgr.touchLastUsed(volID)
+	*now = time.Now()
+
+	// Simulate an active attachment (e.g. a build in progress).
+	volumeMgr.volumes[volID].Attachments = []volumes.Attachment{
+		{InstanceID: "inst-1", MountPath: "/var/lib/buildkit"},
+	}
+
+	mgr.reap(ctx)
+
+	_, err = volumeMgr.GetVolume(ctx, volID)
+	assert.NoError(t, err, "attached volume must never be evicted")
+}
+
+func TestReap_NeverEvictsInUseVolume(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled: true,
+		SizeGB:  10,
+		IdleTTL: time.Hour,
+	})
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	volID, err := mgr.ensureCacheVolume(ctx, "tenant-a")
+	require.NoError(t, err)
+
+	*now = now.Add(-2 * time.Hour)
+	mgr.touchLastUsed(volID)
+	*now = time.Now()
+
+	release := mgr.acquireVolume(volID)
+	mgr.reap(ctx)
+
+	_, err = volumeMgr.GetVolume(ctx, volID)
+	assert.NoError(t, err, "in-use volume must never be evicted")
+
+	release()
+	mgr.reap(ctx)
+
+	_, err = volumeMgr.GetVolume(ctx, volID)
+	assert.ErrorIs(t, err, volumes.ErrNotFound, "volume evicted once released")
+}
+
+func TestReap_EnforcesMaxVolumesLRU(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled:    true,
+		SizeGB:     10,
+		IdleTTL:    100 * time.Hour, // TTL not in play
+		MaxVolumes: 2,
+	})
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	base := *now
+	volIDs := make([]string, 3)
+	for i, scope := range []string{"tenant-1", "tenant-2", "tenant-3"} {
+		volID, err := mgr.ensureCacheVolume(ctx, scope)
+		require.NoError(t, err)
+		// tenant-1 is least recently used, tenant-3 most recent
+		*now = base.Add(time.Duration(i-3) * time.Hour)
+		mgr.touchLastUsed(volID)
+		volIDs[i] = volID
+	}
+	*now = base
+
+	mgr.reap(ctx)
+
+	_, err := volumeMgr.GetVolume(ctx, volIDs[0])
+	assert.ErrorIs(t, err, volumes.ErrNotFound, "oldest volume evicted first")
+	for _, id := range volIDs[1:] {
+		_, err := volumeMgr.GetVolume(ctx, id)
+		assert.NoError(t, err, "newer volumes kept")
+	}
+}
+
+func TestReap_EnforcesMaxBytesLRU(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled:  true,
+		SizeGB:   10,
+		IdleTTL:  100 * time.Hour,
+		MaxBytes: 20 * 1024 * 1024 * 1024, // room for 2 of the 3 volumes
+	})
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	base := *now
+	volIDs := make([]string, 3)
+	for i, scope := range []string{"tenant-1", "tenant-2", "tenant-3"} {
+		volID, err := mgr.ensureCacheVolume(ctx, scope)
+		require.NoError(t, err)
+		*now = base.Add(time.Duration(i-3) * time.Hour)
+		mgr.touchLastUsed(volID)
+		volIDs[i] = volID
+	}
+	*now = base
+
+	mgr.reap(ctx)
+
+	_, err := volumeMgr.GetVolume(ctx, volIDs[0])
+	assert.ErrorIs(t, err, volumes.ErrNotFound, "oldest volume evicted to satisfy byte limit")
+	for _, id := range volIDs[1:] {
+		_, err := volumeMgr.GetVolume(ctx, id)
+		assert.NoError(t, err, "newer volumes kept")
+	}
+}
+
+func TestReap_LimitsSkipAttachedVolumes(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled:    true,
+		SizeGB:     10,
+		IdleTTL:    100 * time.Hour,
+		MaxVolumes: 1,
+	})
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	base := *now
+
+	attachedVol, err := mgr.ensureCacheVolume(ctx, "tenant-attached")
+	require.NoError(t, err)
+	*now = base.Add(-3 * time.Hour)
+	mgr.touchLastUsed(attachedVol)
+	volumeMgr.volumes[attachedVol].Attachments = []volumes.Attachment{
+		{InstanceID: "inst-1", MountPath: "/var/lib/buildkit"},
+	}
+
+	idleVol, err := mgr.ensureCacheVolume(ctx, "tenant-idle")
+	require.NoError(t, err)
+	*now = base.Add(-time.Hour)
+	mgr.touchLastUsed(idleVol)
+	*now = base
+
+	mgr.reap(ctx)
+
+	_, err = volumeMgr.GetVolume(ctx, attachedVol)
+	assert.NoError(t, err, "attached volume kept even over the count limit")
+	_, err = volumeMgr.GetVolume(ctx, idleVol)
+	assert.ErrorIs(t, err, volumes.ErrNotFound, "idle volume evicted instead")
+}
+
+func TestCacheVolumeStatePersistence(t *testing.T) {
+	config := CacheVolumeConfig{Enabled: true, SizeGB: 10}
+	mgr, _, now, tempDir := setupCacheVolumeManager(t, config)
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	volID, err := mgr.ensureCacheVolume(ctx, "tenant-a")
+	require.NoError(t, err)
+
+	*now = now.Add(-time.Hour)
+	mgr.touchLastUsed(volID)
+	lastUsed := *now
+
+	// A new manager over the same data dir sees the same last-used metadata.
+	mgr2, _, _, _ := setupCacheVolumeManager(t, config)
+	mgr2.paths = mgr.paths
+	mgr2.mu.Lock()
+	mgr2.loadLocked()
+	got := mgr2.lastUsed[volID]
+	mgr2.mu.Unlock()
+
+	assert.True(t, got.Equal(lastUsed), "last-used persisted across restarts: got %v want %v", got, lastUsed)
+}
+
+func TestNewManager_CacheVolumesWiring(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "builds-cache-wiring-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	p := paths.New(tempDir)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	config := Config{
+		MaxConcurrentBuilds: 1,
+		RegistryURL:         "localhost:5000",
+		RegistrySecret:      "test-secret",
+	}
+
+	// Disabled by default: no cache volume manager, no reaper.
+	disabled, err := NewManager(p, config, newMockInstanceManager(), newMockVolumeManager(), newMockImageManager(), &mockSecretProvider{}, logger, nil)
+	require.NoError(t, err)
+	assert.Nil(t, disabled.(*manager).cacheVolumes)
+
+	// Enabled: cache volume manager is constructed.
+	config.Cache.Enabled = true
+	enabled, err := NewManager(p, config, newMockInstanceManager(), newMockVolumeManager(), newMockImageManager(), &mockSecretProvider{}, logger, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, enabled.(*manager).cacheVolumes)
+}
+
+// TestCacheVolumeID_TenantIsolation verifies scopes never share a volume.
+func TestCacheVolumeID_TenantIsolation(t *testing.T) {
+	scopes := []string{"tenant-a", "tenant-b", "tenant-c", "my-team"}
+	seen := make(map[string]string)
+	for _, s := range scopes {
+		id := cacheVolumeID(s)
+		if other, dup := seen[id]; dup {
+			t.Fatalf("scopes %q and %q share volume ID %s", other, s, id)
+		}
+		seen[id] = s
+	}
+}
+
+// TestLockScope_ConcurrentEnsure verifies concurrent ensures for the same
+// scope create exactly one volume when serialized through lockScope.
+func TestLockScope_ConcurrentEnsure(t *testing.T) {
+	mgr, volumeMgr, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true, SizeGB: 10})
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			unlock := mgr.lockScope("tenant-a")
+			defer unlock()
+			_, err := mgr.ensureCacheVolume(ctx, "tenant-a")
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 1, volumeMgr.createCallCount, fmt.Sprintf("expected 1 create, got %d", volumeMgr.createCallCount))
+}

--- a/lib/builds/cache_volume_test.go
+++ b/lib/builds/cache_volume_test.go
@@ -329,6 +329,101 @@ func TestReap_LimitsSkipAttachedVolumes(t *testing.T) {
 	assert.ErrorIs(t, err, volumes.ErrNotFound, "idle volume evicted instead")
 }
 
+// TestReap_FailedDeleteStaysCounted verifies a volume whose delete fails
+// (e.g. ErrInUse from a concurrent attach) stays counted toward the limits,
+// so the reaper still evicts enough volumes to satisfy them.
+func TestReap_FailedDeleteStaysCounted(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled:    true,
+		SizeGB:     10,
+		IdleTTL:    100 * time.Hour,
+		MaxVolumes: 1,
+	})
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	base := *now
+
+	oldest, err := mgr.ensureCacheVolume(ctx, "tenant-old")
+	require.NoError(t, err)
+	*now = base.Add(-2 * time.Hour)
+	mgr.touchLastUsed(oldest)
+
+	newest, err := mgr.ensureCacheVolume(ctx, "tenant-new")
+	require.NoError(t, err)
+	*now = base.Add(-time.Hour)
+	mgr.touchLastUsed(newest)
+	*now = base
+
+	volumeMgr.deleteFunc = func(ctx context.Context, id string) error {
+		if id == oldest {
+			return volumes.ErrInUse
+		}
+		delete(volumeMgr.volumes, id)
+		return nil
+	}
+
+	mgr.reap(ctx)
+
+	_, err = volumeMgr.GetVolume(ctx, oldest)
+	assert.NoError(t, err, "volume with failed delete is kept")
+	_, err = volumeMgr.GetVolume(ctx, newest)
+	assert.ErrorIs(t, err, volumes.ErrNotFound, "failed delete still counts toward the limit, so the next volume is evicted")
+}
+
+// TestReap_FailedIdleDeleteRetried verifies an idle-past-TTL volume whose
+// delete fails remains in the candidate set and is retried by the limit pass
+// instead of being silently dropped from the accounting.
+func TestReap_FailedIdleDeleteRetried(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled:    true,
+		SizeGB:     10,
+		IdleTTL:    time.Hour,
+		MaxVolumes: 1,
+	})
+	defer os.RemoveAll(tempDir)
+
+	ctx := context.Background()
+	base := *now
+
+	oldest, err := mgr.ensureCacheVolume(ctx, "tenant-old")
+	require.NoError(t, err)
+	*now = base.Add(-2 * time.Hour) // past the TTL
+	mgr.touchLastUsed(oldest)
+
+	newest, err := mgr.ensureCacheVolume(ctx, "tenant-new")
+	require.NoError(t, err)
+	*now = base
+	mgr.touchLastUsed(newest)
+
+	oldestDeletes := 0
+	volumeMgr.deleteFunc = func(ctx context.Context, id string) error {
+		if id == oldest {
+			oldestDeletes++
+			return volumes.ErrInUse
+		}
+		delete(volumeMgr.volumes, id)
+		return nil
+	}
+
+	mgr.reap(ctx)
+
+	assert.Equal(t, 2, oldestDeletes, "TTL pass and limit pass both retry the failed delete")
+	_, err = volumeMgr.GetVolume(ctx, oldest)
+	assert.NoError(t, err, "volume with failed delete is kept")
+	_, err = volumeMgr.GetVolume(ctx, newest)
+	assert.ErrorIs(t, err, volumes.ErrNotFound)
+
+	// Once the delete can succeed, the next pass evicts it.
+	volumeMgr.deleteFunc = func(ctx context.Context, id string) error {
+		delete(volumeMgr.volumes, id)
+		return nil
+	}
+	mgr.reap(ctx)
+	_, err = volumeMgr.GetVolume(ctx, oldest)
+	assert.ErrorIs(t, err, volumes.ErrNotFound, "retried on the next pass")
+}
+
 func TestCacheVolumeStatePersistence(t *testing.T) {
 	config := CacheVolumeConfig{Enabled: true, SizeGB: 10}
 	mgr, _, now, tempDir := setupCacheVolumeManager(t, config)

--- a/lib/builds/cache_volume_test.go
+++ b/lib/builds/cache_volume_test.go
@@ -150,6 +150,32 @@ func TestReap_IgnoresUnmanagedPrefixedVolume(t *testing.T) {
 	assert.NoError(t, err, "unmanaged volume must never be evicted")
 }
 
+func TestReap_IgnoresTaggedVolumeWithoutPrefix(t *testing.T) {
+	mgr, volumeMgr, now, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{
+		Enabled: true,
+		SizeGB:  10,
+		IdleTTL: time.Hour,
+	})
+	defer os.RemoveAll(tempDir)
+
+	// A volume carrying the managed-by tag but an arbitrary ID — e.g. one
+	// created before the tag namespace was reserved, or outside the public
+	// API — must survive the reaper even when idle past the TTL.
+	userVol := &volumes.Volume{
+		Id:        "user-tagged-volume",
+		Name:      "user-data",
+		SizeGb:    10,
+		CreatedAt: now.Add(-72 * time.Hour),
+		Tags:      tags.Tags{cacheVolumeManagedTagKey: cacheVolumeManagedTagValue},
+	}
+	volumeMgr.volumes[userVol.Id] = userVol
+
+	mgr.reap(context.Background())
+
+	_, err := volumeMgr.GetVolume(context.Background(), userVol.Id)
+	assert.NoError(t, err, "tagged volume without the reserved ID prefix must never be evicted")
+}
+
 func TestLockScope_SerializesSameScope(t *testing.T) {
 	mgr, _, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true})
 	defer os.RemoveAll(tempDir)

--- a/lib/builds/cache_volume_test.go
+++ b/lib/builds/cache_volume_test.go
@@ -150,15 +150,6 @@ func TestReap_IgnoresUnmanagedPrefixedVolume(t *testing.T) {
 	assert.NoError(t, err, "unmanaged volume must never be evicted")
 }
 
-func TestReservedVolumeIDPrefix(t *testing.T) {
-	assert.Equal(t, "build-cache-", ReservedVolumeIDPrefix("build-cache-abc"))
-	assert.Equal(t, "build-disk-", ReservedVolumeIDPrefix("build-disk-123"))
-	assert.Equal(t, "build-source-", ReservedVolumeIDPrefix("build-source-123"))
-	assert.Equal(t, "build-config-", ReservedVolumeIDPrefix("build-config-123"))
-	assert.Empty(t, ReservedVolumeIDPrefix("my-data"))
-	assert.Empty(t, ReservedVolumeIDPrefix("build-caches"))
-}
-
 func TestLockScope_SerializesSameScope(t *testing.T) {
 	mgr, _, _, tempDir := setupCacheVolumeManager(t, CacheVolumeConfig{Enabled: true})
 	defer os.RemoveAll(tempDir)

--- a/lib/builds/manager.go
+++ b/lib/builds/manager.go
@@ -98,6 +98,10 @@ type Config struct {
 	// DiskRootSizeGB is the size of the per-build BuildKit root volume.
 	// Values <= 0 use DefaultDiskRootSizeGB.
 	DiskRootSizeGB int
+
+	// Cache configures persistent per-scope BuildKit cache volumes.
+	// The zero value keeps cache volumes disabled.
+	Cache CacheVolumeConfig
 }
 
 // buildkitRootMountPath is where the BuildKit root volume is mounted in the
@@ -141,6 +145,7 @@ type manager struct {
 	metrics         *Metrics
 	createMu        sync.Mutex
 	builderReady    atomic.Bool
+	cacheVolumes    *cacheVolumeManager
 
 	// Status subscription system for SSE streaming
 	statusSubscribers map[string][]chan BuildEvent
@@ -184,6 +189,10 @@ func NewManager(
 		m.metrics = metrics
 	}
 
+	if config.Cache.Enabled {
+		m.cacheVolumes = newCacheVolumeManager(config.Cache, p, volumeMgr, logger)
+	}
+
 	return m, nil
 }
 
@@ -195,6 +204,9 @@ func (m *manager) Start(ctx context.Context) error {
 		// otherwise recovered builds fail with "builder image is being prepared".
 		m.RecoverPendingBuilds()
 	}()
+	if m.cacheVolumes != nil {
+		m.cacheVolumes.startReaper(ctx)
+	}
 	m.logger.Info("build manager started")
 	return nil
 }

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -651,10 +651,10 @@ func validateCreateRequest(req *CreateInstanceRequest) error {
 // validateVolumeAttachments validates volume attachment requests.
 // allowSystemPaths permits mounts at the reserved paths in
 // allowedSystemMountPaths and is only set for internal instances.
-func validateVolumeAttachments(volumes []VolumeAttachment, allowSystemPaths bool) error {
+func validateVolumeAttachments(vols []VolumeAttachment, allowSystemPaths bool) error {
 	// Count total devices needed (each overlay volume needs 2 devices: base + overlay)
 	totalDevices := 0
-	for _, vol := range volumes {
+	for _, vol := range vols {
 		totalDevices++
 		if vol.Overlay {
 			totalDevices++ // Overlay needs an additional device
@@ -665,7 +665,16 @@ func validateVolumeAttachments(volumes []VolumeAttachment, allowSystemPaths bool
 	}
 
 	seenPaths := make(map[string]bool)
-	for _, vol := range volumes {
+	for _, vol := range vols {
+		// Internal build volumes (cache, config, disk, source) are reserved:
+		// only internal instances may attach them, so a caller cannot tamper
+		// with or hold another scope's build volumes.
+		if !allowSystemPaths {
+			if prefix := volumes.ReservedVolumeIDPrefix(vol.VolumeID); prefix != "" {
+				return fmt.Errorf("volume %s: volume ID prefix %q is reserved for internal use", vol.VolumeID, prefix)
+			}
+		}
+
 		// Validate mount path is absolute
 		if !filepath.IsAbs(vol.MountPath) {
 			return fmt.Errorf("volume %s: mount path %q must be absolute", vol.VolumeID, vol.MountPath)

--- a/lib/instances/resource_limits_test.go
+++ b/lib/instances/resource_limits_test.go
@@ -113,6 +113,37 @@ func TestValidateVolumeAttachments_AllowedSystemMountPath(t *testing.T) {
 	}
 }
 
+func TestValidateVolumeAttachments_ReservedVolumeIDPrefix(t *testing.T) {
+	t.Parallel()
+	// Internal build volume IDs are rejected for external requests
+	// (allowSystemPaths=false) so a caller cannot attach, tamper with, or
+	// hold another scope's build volumes.
+	for _, id := range []string{"build-cache-abc", "build-disk-123", "build-config-123", "build-source-123"} {
+		err := validateVolumeAttachments([]VolumeAttachment{{
+			VolumeID:  id,
+			MountPath: "/mnt/x",
+		}}, false)
+		assert.Error(t, err, "expected reserved volume ID %q to be rejected", id)
+		assert.Contains(t, err.Error(), "reserved for internal use")
+	}
+
+	// Internal instances (e.g. builder VMs) may attach them.
+	for _, id := range []string{"build-cache-abc", "build-disk-123", "build-config-123", "build-source-123"} {
+		err := validateVolumeAttachments([]VolumeAttachment{{
+			VolumeID:  id,
+			MountPath: "/mnt/x",
+		}}, true)
+		assert.NoError(t, err, "expected reserved volume ID %q to be allowed for internal instances", id)
+	}
+
+	// Lookalike IDs that do not match a reserved prefix stay allowed.
+	err := validateVolumeAttachments([]VolumeAttachment{{
+		VolumeID:  "build-caches",
+		MountPath: "/mnt/x",
+	}}, false)
+	assert.NoError(t, err)
+}
+
 func TestValidateVolumeAttachments_OverlayRequiresReadonly(t *testing.T) {
 	t.Parallel()
 	// Overlay=true with Readonly=false should fail

--- a/lib/providers/providers.go
+++ b/lib/providers/providers.go
@@ -425,6 +425,27 @@ func ProvideBuildManager(p *paths.Paths, cfg *config.Config, instanceManager ins
 		DiskRootSizeGB:      cfg.Build.DiskRoot.SizeGB,
 	}
 
+	cacheLocal := cfg.Build.Cache.Local
+	buildConfig.Cache = builds.CacheVolumeConfig{
+		Enabled:    cacheLocal.Enabled,
+		SizeGB:     cacheLocal.SizeGB,
+		MaxVolumes: cacheLocal.MaxVolumes,
+	}
+	if cacheLocal.IdleTTL != "" {
+		idleTTL, err := parseRequiredDuration(cacheLocal.IdleTTL)
+		if err != nil {
+			return nil, fmt.Errorf("build.cache.local.idle_ttl: %w", err)
+		}
+		buildConfig.Cache.IdleTTL = idleTTL
+	}
+	if cacheLocal.MaxBytes != "" {
+		var size datasize.ByteSize
+		if err := size.UnmarshalText([]byte(cacheLocal.MaxBytes)); err != nil {
+			return nil, fmt.Errorf("build.cache.local.max_bytes: %w", err)
+		}
+		buildConfig.Cache.MaxBytes = int64(size.Bytes())
+	}
+
 	// Configure secret provider (use NoOpSecretProvider as fallback to avoid nil panics)
 	var secretProvider builds.SecretProvider
 	if cfg.Build.SecretsDir != "" {

--- a/lib/volumes/reserved.go
+++ b/lib/volumes/reserved.go
@@ -1,0 +1,27 @@
+package volumes
+
+import "strings"
+
+// managedVolumeIDPrefixes are volume ID prefixes reserved for volumes the
+// build manager creates internally ("build-cache-" covers the per-scope
+// BuildKit cache volumes). Public volume APIs reject caller-supplied IDs
+// with these prefixes, and instance volume attachments reject them unless
+// the request is internal, so a caller cannot squat on or tamper with an
+// internal build volume.
+var managedVolumeIDPrefixes = []string{
+	"build-cache-",
+	"build-config-",
+	"build-disk-",
+	"build-source-",
+}
+
+// ReservedVolumeIDPrefix returns the reserved internal prefix id starts
+// with, or "" when id is usable by API callers.
+func ReservedVolumeIDPrefix(id string) string {
+	for _, p := range managedVolumeIDPrefixes {
+		if strings.HasPrefix(id, p) {
+			return p
+		}
+	}
+	return ""
+}

--- a/lib/volumes/reserved.go
+++ b/lib/volumes/reserved.go
@@ -25,3 +25,18 @@ func ReservedVolumeIDPrefix(id string) string {
 	}
 	return ""
 }
+
+// SystemTagNamespace is the tag key namespace reserved for internal,
+// server-managed metadata (e.g. the tag marking build cache volumes).
+const SystemTagNamespace = "hypeman.system/"
+
+// ReservedTagNamespace returns the reserved internal tag namespace key
+// starts with, or "" when key is usable by API callers. Public APIs must
+// reject caller-supplied tags in this namespace so a caller cannot
+// impersonate an internally managed volume.
+func ReservedTagNamespace(key string) string {
+	if strings.HasPrefix(key, SystemTagNamespace) {
+		return SystemTagNamespace
+	}
+	return ""
+}

--- a/lib/volumes/reserved_test.go
+++ b/lib/volumes/reserved_test.go
@@ -14,3 +14,11 @@ func TestReservedVolumeIDPrefix(t *testing.T) {
 	assert.Empty(t, ReservedVolumeIDPrefix("my-data"))
 	assert.Empty(t, ReservedVolumeIDPrefix("build-caches"))
 }
+
+func TestReservedTagNamespace(t *testing.T) {
+	assert.Equal(t, SystemTagNamespace, ReservedTagNamespace("hypeman.system/managed-by"))
+	assert.Equal(t, SystemTagNamespace, ReservedTagNamespace("hypeman.system/anything"))
+	assert.Empty(t, ReservedTagNamespace("managed-by"))
+	assert.Empty(t, ReservedTagNamespace("hypeman.system"))
+	assert.Empty(t, ReservedTagNamespace("team"))
+}

--- a/lib/volumes/reserved_test.go
+++ b/lib/volumes/reserved_test.go
@@ -1,0 +1,16 @@
+package volumes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReservedVolumeIDPrefix(t *testing.T) {
+	assert.Equal(t, "build-cache-", ReservedVolumeIDPrefix("build-cache-abc"))
+	assert.Equal(t, "build-disk-", ReservedVolumeIDPrefix("build-disk-123"))
+	assert.Equal(t, "build-source-", ReservedVolumeIDPrefix("build-source-123"))
+	assert.Equal(t, "build-config-", ReservedVolumeIDPrefix("build-config-123"))
+	assert.Empty(t, ReservedVolumeIDPrefix("my-data"))
+	assert.Empty(t, ReservedVolumeIDPrefix("build-caches"))
+}


### PR DESCRIPTION
## Summary

Introduces a small local cache-volume manager for persistent per-scope BuildKit cache volumes, gated by `build.cache.local.enabled` (default **false** — the disabled runtime path is unchanged). This layer adds the lifecycle machinery only; attaching volumes to builds lands in the PR above.

Behavior:

- Volume IDs are `build-cache-<sha256(effective-scope)>`; each volume is created at a configurable fixed size (`build.cache.local.size_gb`, default 50 GB).
- Per-scope serialization via `lockScope`, so concurrent builds for one scope can be serialized by callers.
- Last-used metadata persisted to `builds/cache-volumes.json` (atomic write) and reloaded on restart.
- A reaper (started from `Manager.Start` only when enabled) deletes volumes idle past `idle_ttl` (default 24h) and evicts idle volumes LRU-first to satisfy host-wide `max_bytes` / `max_volumes` limits.
- Attached volumes and volumes guarded by an in-flight build (`acquireVolume`) are never evicted, including the window between creation and attachment.
- Enabling the local cache implies identity-derived tenant scopes (`resolveEffectiveCacheScope` treats `cache.local.enabled` like `cache.derive_tenant_scope`), since the per-scope volumes require a non-empty scope.

## Changes

- `lib/builds/cache_volume.go`: `CacheVolumeConfig`, `cacheVolumeManager` (ID derivation, ensure/create, per-scope locks, in-use guards, last-used persistence, reaper with TTL + LRU byte/count eviction).
- `lib/builds/manager.go`: `Config.Cache`; manager constructed only when enabled; reaper launched in `Start`.
- `cmd/api/api/builds.go`: `cache.local.enabled` also enables tenant scope derivation.
- Config plumbing: `build.cache.local.*` in `cmd/api/config` (with validation), `lib/providers`, `config.example.yaml`.

## Tests

`lib/builds/cache_volume_test.go`:

- ID derivation (deterministic, `build-cache-<64 hex>`, distinct per scope / tenant isolation)
- ensure: create at fixed/default size, reuse on second call, exactly one create under concurrent same-scope ensures
- locking: same scope serializes, different scopes independent
- eviction: idle TTL delete/keep, LRU under `max_volumes` and `max_bytes`, attached and in-use volumes never evicted (including limit pressure)
- last-used persistence across manager restarts; `NewManager` wiring (nil when disabled)

`cmd/api/api/builds_cache_scope_test.go`: `cache.local.enabled` implies the identity-derived scope for ordinary callers.

`go test -race ./lib/builds/...`, `go test ./cmd/api/config/... ./lib/providers/...`, and `go build ./...` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches volume APIs, instance attachment rules, and build cache scope behavior when local cache is enabled; default-off path is unchanged but misconfiguration could derive tenant scopes or evict cache volumes unexpectedly.
> 
> **Overview**
> Adds **persistent per-scope BuildKit cache volume lifecycle** behind `build.cache.local.enabled` (default off). When enabled, a `cacheVolumeManager` creates volumes as `build-cache-<sha256(scope)>`, tracks last use in `cache-volumes.json`, serializes work per scope, and runs a background reaper for idle TTL plus LRU eviction under `max_bytes` / `max_volumes` without touching attached or in-flight volumes.
> 
> **Enabling local cache also turns on identity-derived tenant cache scopes** (same as `derive_tenant_scope`), since each volume needs a non-empty scope. Config is wired through API config validation, providers, and `config.example.yaml`.
> 
> **Hardens internal build volumes** so callers cannot squat on or spoof system resources: reserved ID prefixes (`build-cache-`, `build-disk-`, etc.) and `hypeman.system/` tags are rejected on volume create/archive and delete; non-internal instance attachments block those IDs unless `allowSystemPaths` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e84163c4667431bc75ee52a4ea36ed16949093e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->