### PR TITLE
builders: add Builder resource domain with persistent cache disks

### DIFF
--- a/cmd/api/api/volumes.go
+++ b/cmd/api/api/volumes.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sort"
 
 	"github.com/kernel/hypeman/lib/logger"
 	mw "github.com/kernel/hypeman/lib/middleware"
@@ -43,6 +45,21 @@ func (s *ApiService) CreateVolume(ctx context.Context, request oapi.CreateVolume
 		return oapi.CreateVolume400JSONResponse{
 			Code:    "invalid_request",
 			Message: "request body is required",
+		}, nil
+	}
+
+	if request.Body.Id != nil {
+		if prefix := volumes.ReservedVolumeIDPrefix(*request.Body.Id); prefix != "" {
+			return oapi.CreateVolume400JSONResponse{
+				Code:    "invalid_request",
+				Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
+			}, nil
+		}
+	}
+	if key := reservedTagKey(request.Body.Tags); key != "" {
+		return oapi.CreateVolume400JSONResponse{
+			Code:    "invalid_request",
+			Message: fmt.Sprintf("tag key %q is reserved for internal use", key),
 		}, nil
 	}
 
@@ -96,6 +113,21 @@ func (s *ApiService) CreateVolumeFromArchive(ctx context.Context, request oapi.C
 	}
 	// Note: request.Body is never nil in Go's net/http (empty body = http.NoBody)
 	// Empty/invalid archives will fail with a clear gzip error downstream
+
+	if request.Params.Id != nil {
+		if prefix := volumes.ReservedVolumeIDPrefix(*request.Params.Id); prefix != "" {
+			return oapi.CreateVolumeFromArchive400JSONResponse{
+				Code:    "invalid_request",
+				Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
+			}, nil
+		}
+	}
+	if key := reservedTagKey(request.Params.Tags); key != "" {
+		return oapi.CreateVolumeFromArchive400JSONResponse{
+			Code:    "invalid_request",
+			Message: fmt.Sprintf("tag key %q is reserved for internal use", key),
+		}, nil
+	}
 
 	// Create the volume from archive - stream directly without buffering
 	domainReq := volumes.CreateVolumeFromArchiveRequest{
@@ -162,6 +194,13 @@ func (s *ApiService) DeleteVolume(ctx context.Context, request oapi.DeleteVolume
 	}
 	log := logger.FromContext(ctx)
 
+	if prefix := volumes.ReservedVolumeIDPrefix(vol.Id); prefix != "" {
+		return oapi.DeleteVolume409JSONResponse{
+			Code:    "conflict",
+			Message: fmt.Sprintf("volume IDs with the prefix %q are reserved for internal use", prefix),
+		}, nil
+	}
+
 	err := s.VolumeManager.DeleteVolume(ctx, vol.Id)
 	if err != nil {
 		switch {
@@ -179,6 +218,25 @@ func (s *ApiService) DeleteVolume(ctx context.Context, request oapi.DeleteVolume
 		}
 	}
 	return oapi.DeleteVolume204Response{}, nil
+}
+
+// reservedTagKey returns the first caller-supplied tag key in the reserved
+// internal namespace, or "" when all keys are usable by API callers.
+func reservedTagKey(resourceTags *oapi.Tags) string {
+	if resourceTags == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(*resourceTags))
+	for key := range *resourceTags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if volumes.ReservedTagNamespace(key) != "" {
+			return key
+		}
+	}
+	return ""
 }
 
 func volumeToOAPI(vol volumes.Volume) oapi.Volume {

--- a/cmd/api/api/volumes_test.go
+++ b/cmd/api/api/volumes_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kernel/hypeman/lib/oapi"
+	"github.com/kernel/hypeman/lib/volumes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,4 +77,97 @@ func TestDeleteVolume_ByName(t *testing.T) {
 	require.NoError(t, err)
 	_, ok := resp.(oapi.DeleteVolume204Response)
 	assert.True(t, ok, "expected 204 response")
+}
+
+func TestCreateVolume_ReservedIDPrefix(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	id := "builder-disk-abc123"
+	resp, err := svc.CreateVolume(ctx(), oapi.CreateVolumeRequestObject{
+		Body: &oapi.CreateVolumeRequest{
+			Name:   "squat",
+			SizeGb: 1,
+			Id:     &id,
+		},
+	})
+	require.NoError(t, err)
+	bad, ok := resp.(oapi.CreateVolume400JSONResponse)
+	require.True(t, ok, "expected 400 for reserved ID prefix")
+	assert.Contains(t, bad.Message, "reserved for internal use")
+
+	// A near-prefix that does not match exactly stays allowed.
+	id = "builder-disks"
+	resp, err = svc.CreateVolume(ctx(), oapi.CreateVolumeRequestObject{
+		Body: &oapi.CreateVolumeRequest{
+			Name:   "not-reserved",
+			SizeGb: 1,
+			Id:     &id,
+		},
+	})
+	require.NoError(t, err)
+	_, ok = resp.(oapi.CreateVolume201JSONResponse)
+	assert.True(t, ok, "expected 201 for non-reserved ID")
+}
+
+func TestCreateVolume_ReservedTagNamespace(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	resourceTags := oapi.Tags{"hypeman.system/managed-by": "builder"}
+	resp, err := svc.CreateVolume(ctx(), oapi.CreateVolumeRequestObject{
+		Body: &oapi.CreateVolumeRequest{
+			Name:   "spoofed",
+			SizeGb: 1,
+			Tags:   &resourceTags,
+		},
+	})
+	require.NoError(t, err)
+	bad, ok := resp.(oapi.CreateVolume400JSONResponse)
+	require.True(t, ok, "expected 400 for reserved tag key")
+	assert.Contains(t, bad.Message, "reserved for internal use")
+
+	vols, err := svc.VolumeManager.ListVolumes(ctx())
+	require.NoError(t, err)
+	assert.Empty(t, vols, "spoofed volume should not be created")
+}
+
+func TestCreateVolumeFromArchive_ReservedTagNamespace(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	resourceTags := oapi.Tags{"hypeman.system/managed-by": "builder"}
+	resp, err := svc.CreateVolumeFromArchive(ctx(), oapi.CreateVolumeFromArchiveRequestObject{
+		Params: oapi.CreateVolumeFromArchiveParams{
+			Name:   "spoofed",
+			SizeGb: 1,
+			Tags:   &resourceTags,
+		},
+	})
+	require.NoError(t, err)
+	bad, ok := resp.(oapi.CreateVolumeFromArchive400JSONResponse)
+	require.True(t, ok, "expected 400 for reserved tag key")
+	assert.Contains(t, bad.Message, "reserved for internal use")
+}
+
+func TestDeleteVolume_ReservedIDPrefix(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	id := "builder-disk-abc123"
+	_, err := svc.VolumeManager.CreateVolume(ctx(), volumes.CreateVolumeRequest{
+		Id:     &id,
+		Name:   id,
+		SizeGb: 1,
+	})
+	require.NoError(t, err)
+
+	resp, err := svc.DeleteVolume(ctxWithVolume(svc, id), oapi.DeleteVolumeRequestObject{Id: id})
+	require.NoError(t, err)
+	conflict, ok := resp.(oapi.DeleteVolume409JSONResponse)
+	require.True(t, ok, "expected 409 for reserved ID prefix")
+	assert.Contains(t, conflict.Message, "reserved for internal use")
+
+	_, err = svc.VolumeManager.GetVolume(ctx(), id)
+	require.NoError(t, err, "reserved volume must not be deleted")
 }

--- a/lib/builders/errors.go
+++ b/lib/builders/errors.go
@@ -1,0 +1,22 @@
+package builders
+
+import "errors"
+
+var (
+	// ErrNotFound is returned when a builder is not found
+	ErrNotFound = errors.New("builder not found")
+
+	// ErrAlreadyExists is returned when a builder with the same ID already exists
+	ErrAlreadyExists = errors.New("builder already exists")
+
+	// ErrInUse is returned when a builder is acquired by a build, has its
+	// disk attached, or is mid-prune/delete
+	ErrInUse = errors.New("builder is in use")
+
+	// ErrInvalidID is returned when a caller-supplied builder ID is invalid
+	ErrInvalidID = errors.New("invalid builder id")
+
+	// ErrQuotaExceeded is returned when a create would exceed the configured
+	// builder count limit
+	ErrQuotaExceeded = errors.New("builder quota exceeded")
+)

--- a/lib/builders/errors.go
+++ b/lib/builders/errors.go
@@ -20,6 +20,9 @@ var (
 	// builder count limit
 	ErrQuotaExceeded = errors.New("builder quota exceeded")
 
+	// ErrInvalidDiskSize is returned when a requested disk size is negative
+	ErrInvalidDiskSize = errors.New("invalid builder disk size")
+
 	// ErrDiskSizeExceeded is returned when a requested disk size exceeds the
 	// configured maximum
 	ErrDiskSizeExceeded = errors.New("builder disk size exceeds maximum")

--- a/lib/builders/errors.go
+++ b/lib/builders/errors.go
@@ -19,4 +19,8 @@ var (
 	// ErrQuotaExceeded is returned when a create would exceed the configured
 	// builder count limit
 	ErrQuotaExceeded = errors.New("builder quota exceeded")
+
+	// ErrDiskSizeExceeded is returned when a requested disk size exceeds the
+	// configured maximum
+	ErrDiskSizeExceeded = errors.New("builder disk size exceeds maximum")
 )

--- a/lib/builders/manager.go
+++ b/lib/builders/manager.go
@@ -50,10 +50,10 @@ type Manager interface {
 	ReleaseBuild(ctx context.Context, id string, buildID string) error
 
 	// ResetDisk resets a builder's cache by recreating its disk
-	// asynchronously: the builder transitions to pruning, then ready (or
-	// error). Returns ErrInUse while the builder is acquired by a build,
-	// has its disk attached, or is mid-delete.
-	ResetDisk(ctx context.Context, id string) error
+	// asynchronously: the returned snapshot has status pruning, followed by
+	// ready (or error). Returns ErrInUse while the builder is acquired by a
+	// build, has its disk attached, or is mid-delete.
+	ResetDisk(ctx context.Context, id string) (*Builder, error)
 }
 
 // instanceChecker is the subset of the instance manager reconciliation
@@ -127,7 +127,7 @@ func NewManager(
 // Start reconciles on-disk state after a restart and starts the idle reaper
 func (m *manager) Start(ctx context.Context) error {
 	if err := m.reconcile(ctx); err != nil {
-		m.logger.Error("builder reconciliation failed", "error", err)
+		return fmt.Errorf("reconcile builders: %w", err)
 	}
 	if m.config.IdleTTL > 0 {
 		go m.runIdleReaper(ctx)
@@ -139,6 +139,9 @@ func (m *manager) Start(ctx context.Context) error {
 // CreateBuilder creates a builder and eagerly provisions its disk
 func (m *manager) CreateBuilder(ctx context.Context, req CreateBuilderRequest) (*Builder, error) {
 	start := time.Now()
+	result := "error"
+	defer func() { m.recordCreateDuration(ctx, start, result) }()
+
 	if err := tags.Validate(req.Tags); err != nil {
 		return nil, err
 	}
@@ -152,7 +155,10 @@ func (m *manager) CreateBuilder(ctx context.Context, req CreateBuilderRequest) (
 	}
 
 	sizeGb := req.DiskSizeGb
-	if sizeGb <= 0 {
+	if sizeGb < 0 {
+		return nil, fmt.Errorf("%w: disk_size_gb must not be negative", ErrInvalidDiskSize)
+	}
+	if sizeGb == 0 {
 		sizeGb = m.config.DefaultDiskSizeGb
 	}
 	if m.config.MaxDiskSizeGb > 0 && sizeGb > m.config.MaxDiskSizeGb {
@@ -182,30 +188,42 @@ func (m *manager) CreateBuilder(ctx context.Context, req CreateBuilderRequest) (
 	// which startup reconciliation recreates. The reverse order would
 	// orphan a reserved volume with no owning metadata.
 	meta := &storedMetadata{
-		ID:           id,
-		Name:         req.Name,
-		DiskSizeGb:   sizeGb,
-		Tags:         tags.Clone(req.Tags),
-		Status:       StatusReady,
-		CreatedAt:    time.Now(),
-		DiskVolumeID: DiskVolumeID(id),
+		ID:         id,
+		Name:       req.Name,
+		DiskSizeGb: sizeGb,
+		Tags:       tags.Clone(req.Tags),
+		Status:     StatusReady,
+		CreatedAt:  time.Now(),
 	}
 	if err := saveMetadata(m.paths, meta); err != nil {
 		return nil, err
 	}
 
 	if err := m.createDisk(ctx, meta); err != nil {
-		deleteBuilderData(m.paths, id)
+		// Keep ownership metadata until any partially-created reserved volume
+		// is gone. Otherwise the volume becomes invisible to reconciliation
+		// and a same-ID retry cannot recover it.
+		meta.Status = StatusError
+		if saveErr := saveMetadata(m.paths, meta); saveErr != nil {
+			return nil, errors.Join(err, fmt.Errorf("persist builder create failure: %w", saveErr))
+		}
+		cleanupErr := m.volumeManager.DeleteVolume(ctx, meta.diskVolumeID())
+		if cleanupErr != nil && !errors.Is(cleanupErr, volumes.ErrNotFound) {
+			return nil, errors.Join(err, fmt.Errorf("clean up builder disk: %w", cleanupErr))
+		}
+		if cleanupErr := deleteBuilderData(m.paths, id); cleanupErr != nil {
+			return nil, errors.Join(err, cleanupErr)
+		}
 		return nil, err
 	}
 
-	m.recordCreateDuration(ctx, start, "success")
+	result = "success"
 	return meta.toBuilder(), nil
 }
 
 // createDisk provisions the builder's ext4 disk volume
 func (m *manager) createDisk(ctx context.Context, meta *storedMetadata) error {
-	volID := meta.DiskVolumeID
+	volID := meta.diskVolumeID()
 	_, err := m.volumeManager.CreateVolume(ctx, volumes.CreateVolumeRequest{
 		Id:     &volID,
 		Name:   volID,
@@ -238,7 +256,7 @@ func (m *manager) ListBuilders(ctx context.Context) ([]Builder, error) {
 	for _, id := range ids {
 		meta, err := loadMetadata(m.paths, id)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("load builder %s: %w", id, err)
 		}
 		builders = append(builders, *meta.toBuilder())
 	}
@@ -262,7 +280,7 @@ func (m *manager) DeleteBuilder(ctx context.Context, id string) error {
 		if meta.Status == StatusPruning {
 			return ErrInUse
 		}
-		attached, err := m.diskAttached(ctx, meta.DiskVolumeID)
+		attached, err := m.diskAttached(ctx, meta.diskVolumeID())
 		if err != nil {
 			return err
 		}
@@ -278,7 +296,7 @@ func (m *manager) DeleteBuilder(ctx context.Context, id string) error {
 		}
 	}
 
-	if err := m.volumeManager.DeleteVolume(ctx, meta.DiskVolumeID); err != nil && !errors.Is(err, volumes.ErrNotFound) {
+	if err := m.volumeManager.DeleteVolume(ctx, meta.diskVolumeID()); err != nil && !errors.Is(err, volumes.ErrNotFound) {
 		return fmt.Errorf("delete builder disk: %w", err)
 	}
 
@@ -307,7 +325,7 @@ func (m *manager) AcquireForBuild(ctx context.Context, id string, buildID string
 		return nil, err
 	}
 
-	attached, err := m.diskAttached(ctx, meta.DiskVolumeID)
+	attached, err := m.diskAttached(ctx, meta.diskVolumeID())
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +334,7 @@ func (m *manager) AcquireForBuild(ctx context.Context, id string, buildID string
 		// attachment: it is a leaked record or a stale VM from a crashed
 		// build. Clear it rather than failing every build until the next
 		// restart reconciliation.
-		if err := m.clearStaleAttachments(ctx, meta.DiskVolumeID); err != nil {
+		if err := m.clearStaleAttachments(ctx, meta.diskVolumeID()); err != nil {
 			return nil, fmt.Errorf("clear stale builder disk attachments: %w", err)
 		}
 	}
@@ -359,30 +377,30 @@ func (m *manager) ReleaseBuild(ctx context.Context, id string, buildID string) e
 }
 
 // ResetDisk resets a builder's cache by recreating its disk asynchronously
-func (m *manager) ResetDisk(ctx context.Context, id string) error {
+func (m *manager) ResetDisk(ctx context.Context, id string) (*Builder, error) {
 	m.mu.Lock()
 
 	meta, err := loadMetadata(m.paths, id)
 	if err != nil {
 		m.mu.Unlock()
-		return err
+		return nil, err
 	}
 	if _, held := m.acquired[id]; held {
 		m.mu.Unlock()
-		return ErrInUse
+		return nil, ErrInUse
 	}
 	if meta.Status != StatusReady && meta.Status != StatusError {
 		m.mu.Unlock()
-		return ErrInUse
+		return nil, ErrInUse
 	}
-	attached, err := m.diskAttached(ctx, meta.DiskVolumeID)
+	attached, err := m.diskAttached(ctx, meta.diskVolumeID())
 	if err != nil {
 		m.mu.Unlock()
-		return err
+		return nil, err
 	}
 	if attached {
 		m.mu.Unlock()
-		return ErrInUse
+		return nil, ErrInUse
 	}
 
 	// Persist the transition before any side effect so a crash mid-prune
@@ -390,8 +408,9 @@ func (m *manager) ResetDisk(ctx context.Context, id string) error {
 	meta.Status = StatusPruning
 	if err := saveMetadata(m.paths, meta); err != nil {
 		m.mu.Unlock()
-		return err
+		return nil, err
 	}
+	accepted := meta.toBuilder()
 	m.mu.Unlock()
 
 	go func() {
@@ -399,7 +418,7 @@ func (m *manager) ResetDisk(ctx context.Context, id string) error {
 			m.logger.Error("builder disk reset failed", "id", id, "error", err)
 		}
 	}()
-	return nil
+	return accepted, nil
 }
 
 // resetDisk recreates a builder's disk and transitions it back to ready,
@@ -423,7 +442,7 @@ func (m *manager) resetDisk(ctx context.Context, id string) error {
 		return err
 	}
 
-	if err := m.volumeManager.DeleteVolume(ctx, meta.DiskVolumeID); err != nil && !errors.Is(err, volumes.ErrNotFound) {
+	if err := m.volumeManager.DeleteVolume(ctx, meta.diskVolumeID()); err != nil && !errors.Is(err, volumes.ErrNotFound) {
 		return fail(fmt.Errorf("delete builder disk: %w", err))
 	}
 	if err := m.createDisk(ctx, meta); err != nil {
@@ -437,14 +456,14 @@ func (m *manager) resetDisk(ctx context.Context, id string) error {
 // ensureDisk recreates the builder's disk when it is missing. Returns nil
 // when the disk already exists.
 func (m *manager) ensureDisk(ctx context.Context, meta *storedMetadata) error {
-	_, err := m.volumeManager.GetVolume(ctx, meta.DiskVolumeID)
+	_, err := m.volumeManager.GetVolume(ctx, meta.diskVolumeID())
 	if err == nil {
 		return nil
 	}
 	if !errors.Is(err, volumes.ErrNotFound) {
 		return fmt.Errorf("get builder disk: %w", err)
 	}
-	m.logger.Warn("builder disk missing, recreating empty", "id", meta.ID, "volume", meta.DiskVolumeID)
+	m.logger.Warn("builder disk missing, recreating empty", "id", meta.ID, "volume", meta.diskVolumeID())
 	if err := m.createDisk(ctx, meta); err != nil && !errors.Is(err, volumes.ErrAlreadyExists) {
 		return err
 	}
@@ -472,9 +491,11 @@ func (m *manager) reconcile(ctx context.Context) error {
 		return err
 	}
 
+	var reconcileErrs []error
 	for _, id := range ids {
 		meta, err := loadMetadata(m.paths, id)
 		if err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("load builder %s: %w", id, err))
 			continue
 		}
 
@@ -482,26 +503,26 @@ func (m *manager) reconcile(ctx context.Context) error {
 		case StatusDeleting:
 			m.logger.Info("resuming interrupted builder delete", "id", id)
 			if err := m.DeleteBuilder(ctx, id); err != nil {
-				m.logger.Error("failed to resume builder delete", "id", id, "error", err)
+				reconcileErrs = append(reconcileErrs, fmt.Errorf("resume builder %s delete: %w", id, err))
 			}
 			continue
 		case StatusPruning:
 			m.logger.Info("resuming interrupted builder prune", "id", id)
 			if err := m.resetDisk(ctx, id); err != nil {
-				m.logger.Error("failed to resume builder prune", "id", id, "error", err)
+				reconcileErrs = append(reconcileErrs, fmt.Errorf("resume builder %s prune: %w", id, err))
 			}
 			continue
 		}
 
 		if err := m.ensureDisk(ctx, meta); err != nil {
-			m.logger.Error("failed to recreate missing builder disk", "id", id, "error", err)
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("recreate builder %s disk: %w", id, err))
 			continue
 		}
-		if err := m.clearStaleAttachments(ctx, meta.DiskVolumeID); err != nil {
-			m.logger.Error("failed to clear stale builder disk attachments", "id", id, "error", err)
+		if err := m.clearStaleAttachments(ctx, meta.diskVolumeID()); err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("clear builder %s stale attachments: %w", id, err))
 		}
 	}
-	return nil
+	return errors.Join(reconcileErrs...)
 }
 
 // clearStaleAttachments removes attachment records from a builder disk that
@@ -574,12 +595,10 @@ func (m *manager) runIdleReaper(ctx context.Context) {
 }
 
 // reapIdle deletes ready builders whose last use (or creation) is older
-// than the idle TTL. Builders that are acquired, attached, or mid-transition
-// are skipped; DeleteBuilder re-checks those conditions.
+// than the idle TTL. Candidate discovery does not hold the manager lock;
+// DeleteBuilder re-checks ownership, attachment, and lifecycle state before
+// changing anything.
 func (m *manager) reapIdle(ctx context.Context) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	ids, err := listBuilderIDs(m.paths)
 	if err != nil {
 		m.logger.Error("idle reaper failed to list builders", "error", err)
@@ -588,14 +607,24 @@ func (m *manager) reapIdle(ctx context.Context) {
 	cutoff := time.Now().Add(-m.config.IdleTTL)
 
 	for _, id := range ids {
+		m.mu.Lock()
 		meta, err := loadMetadata(m.paths, id)
+		_, held := m.acquired[id]
+		m.mu.Unlock()
 		if err != nil {
+			m.logger.Error("idle reaper failed to load builder", "id", id, "error", err)
+			continue
+		}
+		if held {
+			continue
+		}
+		if meta.Status == StatusDeleting {
+			if err := m.DeleteBuilder(ctx, id); err != nil && !errors.Is(err, ErrInUse) && !errors.Is(err, ErrNotFound) {
+				m.logger.Error("idle reaper failed to resume builder delete", "id", id, "error", err)
+			}
 			continue
 		}
 		if meta.Status != StatusReady {
-			continue
-		}
-		if _, held := m.acquired[id]; held {
 			continue
 		}
 		lastActivity := meta.CreatedAt
@@ -606,33 +635,9 @@ func (m *manager) reapIdle(ctx context.Context) {
 			continue
 		}
 
-		attached, err := m.diskAttached(ctx, meta.DiskVolumeID)
-		if err != nil {
-			m.logger.Error("idle reaper failed to check builder disk", "id", id, "error", err)
-			continue
-		}
-		if attached {
-			continue
-		}
-
 		m.logger.Info("deleting idle builder", "id", id, "last_activity", lastActivity)
-		meta.Status = StatusDeleting
-		if err := saveMetadata(m.paths, meta); err != nil {
-			m.logger.Error("idle reaper failed to mark builder deleting", "id", id, "error", err)
-			continue
-		}
-		if err := m.volumeManager.DeleteVolume(ctx, meta.DiskVolumeID); err != nil && !errors.Is(err, volumes.ErrNotFound) {
-			m.logger.Error("idle reaper failed to delete builder disk", "id", id, "error", err)
-			// Revert to ready so the next tick retries; a builder left in
-			// deleting is skipped by the reaper until restart reconciliation.
-			meta.Status = StatusReady
-			if saveErr := saveMetadata(m.paths, meta); saveErr != nil {
-				m.logger.Error("idle reaper failed to revert builder status", "id", id, "error", saveErr)
-			}
-			continue
-		}
-		if err := deleteBuilderData(m.paths, id); err != nil {
-			m.logger.Error("idle reaper failed to delete builder metadata", "id", id, "error", err)
+		if err := m.DeleteBuilder(ctx, id); err != nil && !errors.Is(err, ErrInUse) && !errors.Is(err, ErrNotFound) {
+			m.logger.Error("idle reaper failed to delete builder", "id", id, "error", err)
 		}
 	}
 }

--- a/lib/builders/manager.go
+++ b/lib/builders/manager.go
@@ -502,6 +502,10 @@ func (m *manager) reconcile(ctx context.Context) error {
 		switch meta.Status {
 		case StatusDeleting:
 			m.logger.Info("resuming interrupted builder delete", "id", id)
+			if err := m.clearStaleAttachments(ctx, meta.diskVolumeID()); err != nil {
+				reconcileErrs = append(reconcileErrs, fmt.Errorf("clear builder %s attachments before delete: %w", id, err))
+				continue
+			}
 			if err := m.DeleteBuilder(ctx, id); err != nil {
 				reconcileErrs = append(reconcileErrs, fmt.Errorf("resume builder %s delete: %w", id, err))
 			}
@@ -595,9 +599,8 @@ func (m *manager) runIdleReaper(ctx context.Context) {
 }
 
 // reapIdle deletes ready builders whose last use (or creation) is older
-// than the idle TTL. Candidate discovery does not hold the manager lock;
-// DeleteBuilder re-checks ownership, attachment, and lifecycle state before
-// changing anything.
+// than the idle TTL. It marks a candidate deleting before clearing stale
+// attachments, preventing a build from acquiring it during cleanup.
 func (m *manager) reapIdle(ctx context.Context) {
 	ids, err := listBuilderIDs(m.paths)
 	if err != nil {
@@ -607,37 +610,55 @@ func (m *manager) reapIdle(ctx context.Context) {
 	cutoff := time.Now().Add(-m.config.IdleTTL)
 
 	for _, id := range ids {
-		m.mu.Lock()
-		meta, err := loadMetadata(m.paths, id)
-		_, held := m.acquired[id]
-		m.mu.Unlock()
+		meta, shouldDelete, err := m.markIdleBuilderDeleting(id, cutoff)
 		if err != nil {
-			m.logger.Error("idle reaper failed to load builder", "id", id, "error", err)
+			m.logger.Error("idle reaper failed to inspect builder", "id", id, "error", err)
 			continue
 		}
-		if held {
-			continue
-		}
-		if meta.Status == StatusDeleting {
-			if err := m.DeleteBuilder(ctx, id); err != nil && !errors.Is(err, ErrInUse) && !errors.Is(err, ErrNotFound) {
-				m.logger.Error("idle reaper failed to resume builder delete", "id", id, "error", err)
-			}
-			continue
-		}
-		if meta.Status != StatusReady {
-			continue
-		}
-		lastActivity := meta.CreatedAt
-		if meta.LastUsedAt != nil {
-			lastActivity = *meta.LastUsedAt
-		}
-		if lastActivity.After(cutoff) {
+		if !shouldDelete {
 			continue
 		}
 
-		m.logger.Info("deleting idle builder", "id", id, "last_activity", lastActivity)
-		if err := m.DeleteBuilder(ctx, id); err != nil && !errors.Is(err, ErrInUse) && !errors.Is(err, ErrNotFound) {
+		if err := m.clearStaleAttachments(ctx, meta.diskVolumeID()); err != nil {
+			m.logger.Error("idle reaper failed to clear stale attachments", "id", id, "error", err)
+			continue
+		}
+		if err := m.DeleteBuilder(ctx, id); err != nil && !errors.Is(err, ErrNotFound) {
 			m.logger.Error("idle reaper failed to delete builder", "id", id, "error", err)
 		}
 	}
+}
+
+func (m *manager) markIdleBuilderDeleting(id string, cutoff time.Time) (*storedMetadata, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	meta, err := loadMetadata(m.paths, id)
+	if err != nil {
+		return nil, false, err
+	}
+	if meta.Status == StatusDeleting {
+		return meta, true, nil
+	}
+	if meta.Status != StatusReady {
+		return meta, false, nil
+	}
+	if _, held := m.acquired[id]; held {
+		return meta, false, nil
+	}
+
+	lastActivity := meta.CreatedAt
+	if meta.LastUsedAt != nil {
+		lastActivity = *meta.LastUsedAt
+	}
+	if lastActivity.After(cutoff) {
+		return meta, false, nil
+	}
+
+	m.logger.Info("deleting idle builder", "id", id, "last_activity", lastActivity)
+	meta.Status = StatusDeleting
+	if err := saveMetadata(m.paths, meta); err != nil {
+		return nil, false, err
+	}
+	return meta, true, nil
 }

--- a/lib/builders/manager.go
+++ b/lib/builders/manager.go
@@ -1,0 +1,626 @@
+package builders
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/kernel/hypeman/lib/instances"
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/tags"
+	"github.com/kernel/hypeman/lib/volumes"
+	"github.com/nrednav/cuid2"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// Manager provides builder lifecycle operations
+type Manager interface {
+	// Start reconciles on-disk state after a restart and starts the idle
+	// reaper when configured. Called once when the API server starts.
+	Start(ctx context.Context) error
+
+	// CreateBuilder creates a builder and eagerly provisions its disk
+	CreateBuilder(ctx context.Context, req CreateBuilderRequest) (*Builder, error)
+
+	// GetBuilder returns a builder by ID
+	GetBuilder(ctx context.Context, id string) (*Builder, error)
+
+	// ListBuilders returns all builders
+	ListBuilders(ctx context.Context) ([]Builder, error)
+
+	// DeleteBuilder deletes a builder and its disk. Deletion is total and
+	// irreversible. Returns ErrInUse while the builder is acquired by a
+	// build, has its disk attached, or is mid-prune.
+	DeleteBuilder(ctx context.Context, id string) error
+
+	// AcquireForBuild marks a builder as held by a build, recreating a
+	// missing disk as best-effort cache recovery. Returns ErrInUse when the
+	// builder is already held or not ready. A disk attachment on an unheld,
+	// ready builder can only be a leaked record or a stale VM from a
+	// crashed build, so it is cleared before the acquisition instead of
+	// failing builds until the next restart reconciliation.
+	AcquireForBuild(ctx context.Context, id string, buildID string) (*Builder, error)
+
+	// ReleaseBuild releases a builder held by AcquireForBuild and records
+	// last_used_at, including for failed builds.
+	ReleaseBuild(ctx context.Context, id string, buildID string) error
+
+	// ResetDisk resets a builder's cache by recreating its disk
+	// asynchronously: the builder transitions to pruning, then ready (or
+	// error). Returns ErrInUse while the builder is acquired by a build,
+	// has its disk attached, or is mid-delete.
+	ResetDisk(ctx context.Context, id string) error
+}
+
+// instanceChecker is the subset of the instance manager reconciliation
+// needs to clear stale disk attachments.
+type instanceChecker interface {
+	GetInstance(ctx context.Context, idOrName string) (*instances.Instance, error)
+	DeleteInstance(ctx context.Context, id string) error
+}
+
+// builderIDPattern constrains caller-supplied builder IDs to characters
+// that are safe in volume IDs and filesystem paths.
+var builderIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`)
+
+// ValidateBuilderID validates a caller-supplied builder ID.
+func ValidateBuilderID(id string) error {
+	if !builderIDPattern.MatchString(id) {
+		return fmt.Errorf("%w: must match %s", ErrInvalidID, builderIDPattern)
+	}
+	return nil
+}
+
+type manager struct {
+	config        Config
+	paths         *paths.Paths
+	volumeManager volumes.Manager
+	instanceMgr   instanceChecker
+	logger        *slog.Logger
+	metrics       *Metrics
+
+	mu       sync.Mutex
+	acquired map[string]string // builder ID -> build ID holding it
+}
+
+// NewManager creates a new builders manager.
+// If meter is nil, metrics are disabled.
+func NewManager(
+	p *paths.Paths,
+	config Config,
+	volumeMgr volumes.Manager,
+	instanceMgr instanceChecker,
+	logger *slog.Logger,
+	meter metric.Meter,
+) (Manager, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if config.DefaultDiskSizeGb <= 0 {
+		config.DefaultDiskSizeGb = DefaultDiskSizeGb
+	}
+
+	m := &manager{
+		config:        config,
+		paths:         p,
+		volumeManager: volumeMgr,
+		instanceMgr:   instanceMgr,
+		logger:        logger,
+		acquired:      make(map[string]string),
+	}
+
+	if meter != nil {
+		metrics, err := newBuilderMetrics(meter, m)
+		if err != nil {
+			return nil, fmt.Errorf("create metrics: %w", err)
+		}
+		m.metrics = metrics
+	}
+
+	return m, nil
+}
+
+// Start reconciles on-disk state after a restart and starts the idle reaper
+func (m *manager) Start(ctx context.Context) error {
+	if err := m.reconcile(ctx); err != nil {
+		m.logger.Error("builder reconciliation failed", "error", err)
+	}
+	if m.config.IdleTTL > 0 {
+		go m.runIdleReaper(ctx)
+	}
+	m.logger.Info("builders manager started")
+	return nil
+}
+
+// CreateBuilder creates a builder and eagerly provisions its disk
+func (m *manager) CreateBuilder(ctx context.Context, req CreateBuilderRequest) (*Builder, error) {
+	start := time.Now()
+	if err := tags.Validate(req.Tags); err != nil {
+		return nil, err
+	}
+
+	id := cuid2.Generate()
+	if req.ID != nil && *req.ID != "" {
+		if err := ValidateBuilderID(*req.ID); err != nil {
+			return nil, err
+		}
+		id = *req.ID
+	}
+
+	sizeGb := req.DiskSizeGb
+	if sizeGb <= 0 {
+		sizeGb = m.config.DefaultDiskSizeGb
+	}
+	if m.config.MaxDiskSizeGb > 0 && sizeGb > m.config.MaxDiskSizeGb {
+		return nil, fmt.Errorf("disk_size_gb %d exceeds maximum of %d", sizeGb, m.config.MaxDiskSizeGb)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, err := loadMetadata(m.paths, id); err == nil {
+		return nil, ErrAlreadyExists
+	} else if !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
+
+	if m.config.MaxCount > 0 {
+		ids, err := listBuilderIDs(m.paths)
+		if err != nil {
+			return nil, err
+		}
+		if len(ids) >= m.config.MaxCount {
+			return nil, fmt.Errorf("%w: max_count %d", ErrQuotaExceeded, m.config.MaxCount)
+		}
+	}
+
+	// Metadata first: a crash before the disk exists is a missing disk,
+	// which startup reconciliation recreates. The reverse order would
+	// orphan a reserved volume with no owning metadata.
+	meta := &storedMetadata{
+		ID:           id,
+		Name:         req.Name,
+		DiskSizeGb:   sizeGb,
+		Tags:         tags.Clone(req.Tags),
+		Status:       StatusReady,
+		CreatedAt:    time.Now(),
+		DiskVolumeID: DiskVolumeID(id),
+	}
+	if err := saveMetadata(m.paths, meta); err != nil {
+		return nil, err
+	}
+
+	if err := m.createDisk(ctx, meta); err != nil {
+		deleteBuilderData(m.paths, id)
+		return nil, err
+	}
+
+	m.recordCreateDuration(ctx, start, "success")
+	return meta.toBuilder(), nil
+}
+
+// createDisk provisions the builder's ext4 disk volume
+func (m *manager) createDisk(ctx context.Context, meta *storedMetadata) error {
+	volID := meta.DiskVolumeID
+	_, err := m.volumeManager.CreateVolume(ctx, volumes.CreateVolumeRequest{
+		Id:     &volID,
+		Name:   volID,
+		SizeGb: meta.DiskSizeGb,
+		Tags:   tags.Tags{volumes.SystemTagNamespace + "managed-by": managedByTagValue},
+	})
+	if err != nil {
+		return fmt.Errorf("create builder disk: %w", err)
+	}
+	return nil
+}
+
+// GetBuilder returns a builder by ID
+func (m *manager) GetBuilder(ctx context.Context, id string) (*Builder, error) {
+	meta, err := loadMetadata(m.paths, id)
+	if err != nil {
+		return nil, err
+	}
+	return meta.toBuilder(), nil
+}
+
+// ListBuilders returns all builders
+func (m *manager) ListBuilders(ctx context.Context) ([]Builder, error) {
+	ids, err := listBuilderIDs(m.paths)
+	if err != nil {
+		return nil, err
+	}
+
+	builders := make([]Builder, 0, len(ids))
+	for _, id := range ids {
+		meta, err := loadMetadata(m.paths, id)
+		if err != nil {
+			continue
+		}
+		builders = append(builders, *meta.toBuilder())
+	}
+	return builders, nil
+}
+
+// DeleteBuilder deletes a builder and its disk
+func (m *manager) DeleteBuilder(ctx context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	meta, err := loadMetadata(m.paths, id)
+	if err != nil {
+		return err
+	}
+
+	if meta.Status != StatusDeleting {
+		if _, held := m.acquired[id]; held {
+			return ErrInUse
+		}
+		if meta.Status == StatusPruning {
+			return ErrInUse
+		}
+		attached, err := m.diskAttached(ctx, meta.DiskVolumeID)
+		if err != nil {
+			return err
+		}
+		if attached {
+			return ErrInUse
+		}
+
+		// Persist the transition before any side effect so a crash
+		// mid-delete is resumed by reconciliation.
+		meta.Status = StatusDeleting
+		if err := saveMetadata(m.paths, meta); err != nil {
+			return err
+		}
+	}
+
+	if err := m.volumeManager.DeleteVolume(ctx, meta.DiskVolumeID); err != nil && !errors.Is(err, volumes.ErrNotFound) {
+		return fmt.Errorf("delete builder disk: %w", err)
+	}
+
+	return deleteBuilderData(m.paths, id)
+}
+
+// AcquireForBuild marks a builder as held by a build
+func (m *manager) AcquireForBuild(ctx context.Context, id string, buildID string) (*Builder, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	meta, err := loadMetadata(m.paths, id)
+	if err != nil {
+		return nil, err
+	}
+	if meta.Status != StatusReady {
+		return nil, ErrInUse
+	}
+	if _, held := m.acquired[id]; held {
+		return nil, ErrInUse
+	}
+
+	// Best-effort cache recovery: a missing disk is recreated empty rather
+	// than failing the build.
+	if err := m.ensureDisk(ctx, meta); err != nil {
+		return nil, err
+	}
+
+	attached, err := m.diskAttached(ctx, meta.DiskVolumeID)
+	if err != nil {
+		return nil, err
+	}
+	if attached {
+		// The builder is ready and unheld, so no live build can own an
+		// attachment: it is a leaked record or a stale VM from a crashed
+		// build. Clear it rather than failing every build until the next
+		// restart reconciliation.
+		if err := m.clearStaleAttachments(ctx, meta.DiskVolumeID); err != nil {
+			return nil, fmt.Errorf("clear stale builder disk attachments: %w", err)
+		}
+	}
+
+	m.acquired[id] = buildID
+	return meta.toBuilder(), nil
+}
+
+// ReleaseBuild releases a builder held by AcquireForBuild
+func (m *manager) ReleaseBuild(ctx context.Context, id string, buildID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	holder, held := m.acquired[id]
+	if !held {
+		return fmt.Errorf("builder %s is not acquired", id)
+	}
+	if holder != buildID {
+		return fmt.Errorf("builder %s is acquired by build %s, not %s", id, holder, buildID)
+	}
+	delete(m.acquired, id)
+
+	// Record usage even for failed builds: last_used_at drives idle TTL.
+	meta, err := loadMetadata(m.paths, id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil // builder was deleted while held
+		}
+		return err
+	}
+	now := time.Now()
+	meta.LastUsedAt = &now
+	return saveMetadata(m.paths, meta)
+}
+
+// ResetDisk resets a builder's cache by recreating its disk asynchronously
+func (m *manager) ResetDisk(ctx context.Context, id string) error {
+	m.mu.Lock()
+
+	meta, err := loadMetadata(m.paths, id)
+	if err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	if _, held := m.acquired[id]; held {
+		m.mu.Unlock()
+		return ErrInUse
+	}
+	if meta.Status != StatusReady && meta.Status != StatusError {
+		m.mu.Unlock()
+		return ErrInUse
+	}
+	attached, err := m.diskAttached(ctx, meta.DiskVolumeID)
+	if err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	if attached {
+		m.mu.Unlock()
+		return ErrInUse
+	}
+
+	// Persist the transition before any side effect so a crash mid-prune
+	// is resumed by reconciliation.
+	meta.Status = StatusPruning
+	if err := saveMetadata(m.paths, meta); err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	m.mu.Unlock()
+
+	go func() {
+		if err := m.resetDisk(context.Background(), id); err != nil {
+			m.logger.Error("builder disk reset failed", "id", id, "error", err)
+		}
+	}()
+	return nil
+}
+
+// resetDisk recreates a builder's disk and transitions it back to ready,
+// or to error when the reset fails. The volume manager rejects deletion of
+// an attached volume, so the pruning state is never left with a new disk
+// that a stale VM could write to.
+func (m *manager) resetDisk(ctx context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	meta, err := loadMetadata(m.paths, id)
+	if err != nil {
+		return err
+	}
+
+	fail := func(err error) error {
+		meta.Status = StatusError
+		if saveErr := saveMetadata(m.paths, meta); saveErr != nil {
+			m.logger.Error("failed to persist builder error status", "id", id, "error", saveErr)
+		}
+		return err
+	}
+
+	if err := m.volumeManager.DeleteVolume(ctx, meta.DiskVolumeID); err != nil && !errors.Is(err, volumes.ErrNotFound) {
+		return fail(fmt.Errorf("delete builder disk: %w", err))
+	}
+	if err := m.createDisk(ctx, meta); err != nil {
+		return fail(err)
+	}
+
+	meta.Status = StatusReady
+	return saveMetadata(m.paths, meta)
+}
+
+// ensureDisk recreates the builder's disk when it is missing. Returns nil
+// when the disk already exists.
+func (m *manager) ensureDisk(ctx context.Context, meta *storedMetadata) error {
+	_, err := m.volumeManager.GetVolume(ctx, meta.DiskVolumeID)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, volumes.ErrNotFound) {
+		return fmt.Errorf("get builder disk: %w", err)
+	}
+	m.logger.Warn("builder disk missing, recreating empty", "id", meta.ID, "volume", meta.DiskVolumeID)
+	if err := m.createDisk(ctx, meta); err != nil && !errors.Is(err, volumes.ErrAlreadyExists) {
+		return err
+	}
+	return nil
+}
+
+// diskAttached reports whether the builder's disk has any attachments
+func (m *manager) diskAttached(ctx context.Context, volID string) (bool, error) {
+	vol, err := m.volumeManager.GetVolume(ctx, volID)
+	if errors.Is(err, volumes.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get builder disk: %w", err)
+	}
+	return len(vol.Attachments) > 0, nil
+}
+
+// reconcile restores consistency after a restart: interrupted deletes are
+// finished, interrupted prunes are re-run, missing disks are recreated, and
+// attachments no build can hold are removed.
+func (m *manager) reconcile(ctx context.Context) error {
+	ids, err := listBuilderIDs(m.paths)
+	if err != nil {
+		return err
+	}
+
+	for _, id := range ids {
+		meta, err := loadMetadata(m.paths, id)
+		if err != nil {
+			continue
+		}
+
+		switch meta.Status {
+		case StatusDeleting:
+			m.logger.Info("resuming interrupted builder delete", "id", id)
+			if err := m.DeleteBuilder(ctx, id); err != nil {
+				m.logger.Error("failed to resume builder delete", "id", id, "error", err)
+			}
+			continue
+		case StatusPruning:
+			m.logger.Info("resuming interrupted builder prune", "id", id)
+			if err := m.resetDisk(ctx, id); err != nil {
+				m.logger.Error("failed to resume builder prune", "id", id, "error", err)
+			}
+			continue
+		}
+
+		if err := m.ensureDisk(ctx, meta); err != nil {
+			m.logger.Error("failed to recreate missing builder disk", "id", id, "error", err)
+			continue
+		}
+		if err := m.clearStaleAttachments(ctx, meta.DiskVolumeID); err != nil {
+			m.logger.Error("failed to clear stale builder disk attachments", "id", id, "error", err)
+		}
+	}
+	return nil
+}
+
+// clearStaleAttachments removes attachment records from a builder disk that
+// no running build can own: records whose instance is gone are detached
+// directly; records backed by a surviving (stale) VM are cleared by
+// deleting that VM, then detaching any records that survive the deletion.
+// No build holds an acquisition at startup, so every attachment is stale.
+func (m *manager) clearStaleAttachments(ctx context.Context, volID string) error {
+	vol, err := m.volumeManager.GetVolume(ctx, volID)
+	if errors.Is(err, volumes.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get builder disk: %w", err)
+	}
+
+	deletedInstance := false
+	for _, att := range vol.Attachments {
+		_, err := m.instanceMgr.GetInstance(ctx, att.InstanceID)
+		if err == nil {
+			if delErr := m.instanceMgr.DeleteInstance(ctx, att.InstanceID); delErr != nil && !errors.Is(delErr, instances.ErrNotFound) {
+				return fmt.Errorf("delete stale instance %s holding builder disk: %w", att.InstanceID, delErr)
+			}
+			deletedInstance = true
+			m.logger.Warn("deleted stale instance holding builder disk", "instance", att.InstanceID, "volume", volID)
+			continue
+		}
+		if !errors.Is(err, instances.ErrNotFound) {
+			return fmt.Errorf("inspect instance %s holding builder disk: %w", att.InstanceID, err)
+		}
+		if detachErr := m.volumeManager.DetachVolume(ctx, volID, att.InstanceID); detachErr != nil {
+			return fmt.Errorf("detach orphan attachment %s from builder disk: %w", att.InstanceID, detachErr)
+		}
+		m.logger.Warn("detached orphan builder disk attachment", "instance", att.InstanceID, "volume", volID)
+	}
+
+	// DeleteInstance only warns when a volume detach fails, so records can
+	// survive the deletion; re-fetch and detach them.
+	if deletedInstance {
+		vol, err := m.volumeManager.GetVolume(ctx, volID)
+		if errors.Is(err, volumes.ErrNotFound) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("re-fetch builder disk after stale instance deletion: %w", err)
+		}
+		for _, att := range vol.Attachments {
+			if detachErr := m.volumeManager.DetachVolume(ctx, volID, att.InstanceID); detachErr != nil {
+				return fmt.Errorf("detach surviving attachment %s from builder disk: %w", att.InstanceID, detachErr)
+			}
+			m.logger.Warn("detached surviving builder disk attachment", "instance", att.InstanceID, "volume", volID)
+		}
+	}
+	return nil
+}
+
+// runIdleReaper periodically deletes builders idle past the configured TTL.
+// Deletion is total and irreversible; the reaper only runs when IdleTTL > 0.
+func (m *manager) runIdleReaper(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.reapIdle(ctx)
+		}
+	}
+}
+
+// reapIdle deletes ready builders whose last use (or creation) is older
+// than the idle TTL. Builders that are acquired, attached, or mid-transition
+// are skipped; DeleteBuilder re-checks those conditions.
+func (m *manager) reapIdle(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ids, err := listBuilderIDs(m.paths)
+	if err != nil {
+		m.logger.Error("idle reaper failed to list builders", "error", err)
+		return
+	}
+	cutoff := time.Now().Add(-m.config.IdleTTL)
+
+	for _, id := range ids {
+		meta, err := loadMetadata(m.paths, id)
+		if err != nil {
+			continue
+		}
+		if meta.Status != StatusReady {
+			continue
+		}
+		if _, held := m.acquired[id]; held {
+			continue
+		}
+		lastActivity := meta.CreatedAt
+		if meta.LastUsedAt != nil {
+			lastActivity = *meta.LastUsedAt
+		}
+		if lastActivity.After(cutoff) {
+			continue
+		}
+
+		attached, err := m.diskAttached(ctx, meta.DiskVolumeID)
+		if err != nil {
+			m.logger.Error("idle reaper failed to check builder disk", "id", id, "error", err)
+			continue
+		}
+		if attached {
+			continue
+		}
+
+		m.logger.Info("deleting idle builder", "id", id, "last_activity", lastActivity)
+		meta.Status = StatusDeleting
+		if err := saveMetadata(m.paths, meta); err != nil {
+			m.logger.Error("idle reaper failed to mark builder deleting", "id", id, "error", err)
+			continue
+		}
+		if err := m.volumeManager.DeleteVolume(ctx, meta.DiskVolumeID); err != nil && !errors.Is(err, volumes.ErrNotFound) {
+			m.logger.Error("idle reaper failed to delete builder disk", "id", id, "error", err)
+			continue
+		}
+		if err := deleteBuilderData(m.paths, id); err != nil {
+			m.logger.Error("idle reaper failed to delete builder metadata", "id", id, "error", err)
+		}
+	}
+}

--- a/lib/builders/manager.go
+++ b/lib/builders/manager.go
@@ -156,7 +156,7 @@ func (m *manager) CreateBuilder(ctx context.Context, req CreateBuilderRequest) (
 		sizeGb = m.config.DefaultDiskSizeGb
 	}
 	if m.config.MaxDiskSizeGb > 0 && sizeGb > m.config.MaxDiskSizeGb {
-		return nil, fmt.Errorf("disk_size_gb %d exceeds maximum of %d", sizeGb, m.config.MaxDiskSizeGb)
+		return nil, fmt.Errorf("%w: disk_size_gb %d exceeds maximum of %d", ErrDiskSizeExceeded, sizeGb, m.config.MaxDiskSizeGb)
 	}
 
 	m.mu.Lock()

--- a/lib/builders/manager.go
+++ b/lib/builders/manager.go
@@ -337,19 +337,25 @@ func (m *manager) ReleaseBuild(ctx context.Context, id string, buildID string) e
 	if holder != buildID {
 		return fmt.Errorf("builder %s is acquired by build %s, not %s", id, holder, buildID)
 	}
-	delete(m.acquired, id)
 
 	// Record usage even for failed builds: last_used_at drives idle TTL.
+	// Persist before releasing the hold so a failed call leaves the
+	// builder acquired and the caller can retry.
 	meta, err := loadMetadata(m.paths, id)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
+			delete(m.acquired, id)
 			return nil // builder was deleted while held
 		}
 		return err
 	}
 	now := time.Now()
 	meta.LastUsedAt = &now
-	return saveMetadata(m.paths, meta)
+	if err := saveMetadata(m.paths, meta); err != nil {
+		return err
+	}
+	delete(m.acquired, id)
+	return nil
 }
 
 // ResetDisk resets a builder's cache by recreating its disk asynchronously
@@ -617,6 +623,12 @@ func (m *manager) reapIdle(ctx context.Context) {
 		}
 		if err := m.volumeManager.DeleteVolume(ctx, meta.DiskVolumeID); err != nil && !errors.Is(err, volumes.ErrNotFound) {
 			m.logger.Error("idle reaper failed to delete builder disk", "id", id, "error", err)
+			// Revert to ready so the next tick retries; a builder left in
+			// deleting is skipped by the reaper until restart reconciliation.
+			meta.Status = StatusReady
+			if saveErr := saveMetadata(m.paths, meta); saveErr != nil {
+				m.logger.Error("idle reaper failed to revert builder status", "id", id, "error", saveErr)
+			}
 			continue
 		}
 		if err := deleteBuilderData(m.paths, id); err != nil {

--- a/lib/builders/manager_test.go
+++ b/lib/builders/manager_test.go
@@ -1,0 +1,525 @@
+package builders
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/instances"
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/tags"
+	"github.com/kernel/hypeman/lib/volumes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockInstanceChecker implements instanceChecker for testing
+type mockInstanceChecker struct {
+	instances  map[string]*instances.Instance
+	getErr     error
+	deleteFunc func(id string) error
+	deleted    []string
+}
+
+func (m *mockInstanceChecker) GetInstance(ctx context.Context, idOrName string) (*instances.Instance, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if inst, ok := m.instances[idOrName]; ok {
+		return inst, nil
+	}
+	return nil, instances.ErrNotFound
+}
+
+func (m *mockInstanceChecker) DeleteInstance(ctx context.Context, id string) error {
+	m.deleted = append(m.deleted, id)
+	if m.deleteFunc != nil {
+		return m.deleteFunc(id)
+	}
+	delete(m.instances, id)
+	return nil
+}
+
+func setupTestManager(t *testing.T, cfg Config) (*manager, volumes.Manager, *mockInstanceChecker, *paths.Paths) {
+	t.Helper()
+	p := paths.New(t.TempDir())
+	volumeMgr := volumes.NewManager(p, 0, nil)
+	instMgr := &mockInstanceChecker{instances: map[string]*instances.Instance{}}
+	mgr, err := NewManager(p, cfg, volumeMgr, instMgr, slog.Default(), nil)
+	require.NoError(t, err)
+	return mgr.(*manager), volumeMgr, instMgr, p
+}
+
+func waitForStatus(t *testing.T, mgr Manager, id, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := mgr.GetBuilder(context.Background(), id)
+		if err == nil && b.Status == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	b, err := mgr.GetBuilder(context.Background(), id)
+	require.NoError(t, err)
+	require.Equal(t, want, b.Status, "builder did not reach status %q", want)
+}
+
+func TestCreateBuilder_Defaults(t *testing.T) {
+	mgr, volumeMgr, _, _ := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{Name: "cache"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, b.ID)
+	assert.Equal(t, "cache", b.Name)
+	assert.Equal(t, DefaultDiskSizeGb, b.DiskSizeGb)
+	assert.Equal(t, StatusReady, b.Status)
+	assert.Equal(t, DiskVolumeID(b.ID), b.DiskVolumeID)
+	assert.Nil(t, b.LastUsedAt)
+
+	// Disk is provisioned eagerly with the managed-by tag.
+	vol, err := volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultDiskSizeGb, vol.SizeGb)
+	assert.Equal(t, managedByTagValue, vol.Tags[volumes.SystemTagNamespace+"managed-by"])
+}
+
+func TestCreateBuilder_CallerSuppliedID(t *testing.T) {
+	mgr, _, _, _ := setupTestManager(t, Config{})
+
+	id := "team-cache-1"
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{ID: &id, DiskSizeGb: 20})
+	require.NoError(t, err)
+	assert.Equal(t, id, b.ID)
+	assert.Equal(t, "builder-disk-team-cache-1", b.DiskVolumeID)
+	assert.Equal(t, 20, b.DiskSizeGb)
+
+	// Same ID is a conflict, supporting control-plane idempotency.
+	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{ID: &id})
+	assert.ErrorIs(t, err, ErrAlreadyExists)
+}
+
+func TestCreateBuilder_InvalidID(t *testing.T) {
+	mgr, _, _, _ := setupTestManager(t, Config{})
+
+	for _, id := range []string{"has/slash", "has space", "..", "-leading-dash", "dot.name"} {
+		_, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{ID: &id})
+		assert.ErrorIs(t, err, ErrInvalidID, "id %q", id)
+	}
+}
+
+func TestCreateBuilder_Quotas(t *testing.T) {
+	mgr, _, _, _ := setupTestManager(t, Config{MaxCount: 1, MaxDiskSizeGb: 60})
+
+	_, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{DiskSizeGb: 61})
+	assert.ErrorContains(t, err, "exceeds maximum")
+
+	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{DiskSizeGb: 60})
+	require.NoError(t, err)
+
+	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{DiskSizeGb: 60})
+	assert.ErrorIs(t, err, ErrQuotaExceeded)
+}
+
+func TestGetBuilder_NotFound(t *testing.T) {
+	mgr, _, _, _ := setupTestManager(t, Config{})
+	_, err := mgr.GetBuilder(context.Background(), "nope")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestListBuilders(t *testing.T) {
+	mgr, _, _, _ := setupTestManager(t, Config{})
+
+	list, err := mgr.ListBuilders(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, list)
+	assert.Empty(t, list)
+
+	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{Name: "a"})
+	require.NoError(t, err)
+	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{Name: "a"}) // non-unique name ok
+	require.NoError(t, err)
+
+	list, err = mgr.ListBuilders(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+}
+
+func TestBuilderSurvivesRestart(t *testing.T) {
+	mgr, volumeMgr, instMgr, p := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{Name: "cache", Tags: tags.Tags{"team": "x"}})
+	require.NoError(t, err)
+
+	// New manager over the same data dir loads on-disk state.
+	restarted, err := NewManager(p, Config{}, volumeMgr, instMgr, slog.Default(), nil)
+	require.NoError(t, err)
+
+	got, err := restarted.GetBuilder(context.Background(), b.ID)
+	require.NoError(t, err)
+	assert.Equal(t, b.ID, got.ID)
+	assert.Equal(t, "cache", got.Name)
+	assert.Equal(t, tags.Tags{"team": "x"}, got.Tags)
+	assert.Equal(t, StatusReady, got.Status)
+}
+
+func TestDeleteBuilder(t *testing.T) {
+	mgr, volumeMgr, _, p := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.DeleteBuilder(context.Background(), b.ID))
+
+	_, err = mgr.GetBuilder(context.Background(), b.ID)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	assert.ErrorIs(t, err, volumes.ErrNotFound)
+	_, err = os.Stat(p.BuilderDir(b.ID))
+	assert.True(t, os.IsNotExist(err))
+
+	assert.ErrorIs(t, mgr.DeleteBuilder(context.Background(), b.ID), ErrNotFound)
+}
+
+func TestDeleteBuilder_InUse(t *testing.T) {
+	mgr, volumeMgr, _, _ := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	// While acquired.
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-1")
+	require.NoError(t, err)
+	assert.ErrorIs(t, mgr.DeleteBuilder(context.Background(), b.ID), ErrInUse)
+	require.NoError(t, mgr.ReleaseBuild(context.Background(), b.ID, "build-1"))
+
+	// While attached.
+	err = volumeMgr.AttachVolume(context.Background(), b.DiskVolumeID, volumes.AttachVolumeRequest{
+		InstanceID: "inst-1", MountPath: "/var/lib/buildkit",
+	})
+	require.NoError(t, err)
+	assert.ErrorIs(t, mgr.DeleteBuilder(context.Background(), b.ID), ErrInUse)
+}
+
+func TestAcquireRelease_Exclusivity(t *testing.T) {
+	mgr, _, _, _ := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-1")
+	require.NoError(t, err)
+
+	// Second acquisition is rejected, even by the same build.
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-2")
+	assert.ErrorIs(t, err, ErrInUse)
+
+	// Wrong holder cannot release.
+	assert.Error(t, mgr.ReleaseBuild(context.Background(), b.ID, "build-2"))
+
+	require.NoError(t, mgr.ReleaseBuild(context.Background(), b.ID, "build-1"))
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-2")
+	require.NoError(t, err)
+}
+
+func TestReleaseBuild_StampsLastUsed(t *testing.T) {
+	mgr, _, _, _ := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-1")
+	require.NoError(t, err)
+	require.NoError(t, mgr.ReleaseBuild(context.Background(), b.ID, "build-1"))
+
+	got, err := mgr.GetBuilder(context.Background(), b.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastUsedAt)
+	assert.WithinDuration(t, time.Now(), *got.LastUsedAt, time.Minute)
+}
+
+func TestAcquireForBuild_RecreatesMissingDisk(t *testing.T) {
+	mgr, volumeMgr, _, _ := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+	require.NoError(t, volumeMgr.DeleteVolume(context.Background(), b.DiskVolumeID))
+
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-1")
+	require.NoError(t, err)
+
+	_, err = volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	assert.NoError(t, err, "missing disk must be recreated empty as best-effort recovery")
+}
+
+func TestAcquireForBuild_ClearsStaleAttachments(t *testing.T) {
+	mgr, volumeMgr, instMgr, _ := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	// A stale builder VM from a crashed build holds the disk, alongside an
+	// orphan record whose instance is already gone.
+	instMgr.instances["inst-stale"] = &instances.Instance{
+		StoredMetadata: instances.StoredMetadata{Id: "inst-stale", Name: "builder-build-0"},
+		State:          instances.StateRunning,
+	}
+	require.NoError(t, volumeMgr.AttachVolume(context.Background(), b.DiskVolumeID, volumes.AttachVolumeRequest{
+		InstanceID: "inst-stale", MountPath: "/var/lib/buildkit", Readonly: true,
+	}))
+	require.NoError(t, volumeMgr.AttachVolume(context.Background(), b.DiskVolumeID, volumes.AttachVolumeRequest{
+		InstanceID: "inst-gone", MountPath: "/var/lib/buildkit", Readonly: true,
+	}))
+
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-1")
+	require.NoError(t, err, "acquire must clear stale attachments instead of failing")
+
+	assert.Contains(t, instMgr.deleted, "inst-stale")
+	vol, err := volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	require.NoError(t, err)
+	assert.Empty(t, vol.Attachments, "stale holder and orphan records must be cleared")
+}
+
+func TestAcquireForBuild_StaleAttachmentClearFailsLoudly(t *testing.T) {
+	mgr, volumeMgr, instMgr, _ := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	instMgr.instances["inst-stuck"] = &instances.Instance{
+		StoredMetadata: instances.StoredMetadata{Id: "inst-stuck", Name: "builder-build-0"},
+		State:          instances.StateRunning,
+	}
+	require.NoError(t, volumeMgr.AttachVolume(context.Background(), b.DiskVolumeID, volumes.AttachVolumeRequest{
+		InstanceID: "inst-stuck", MountPath: "/var/lib/buildkit",
+	}))
+	instMgr.deleteFunc = func(id string) error { return errors.New("hypervisor unreachable") }
+
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "holding builder disk")
+
+	// The failed acquisition must not hold the builder.
+	delete(instMgr.instances, "inst-stuck")
+	instMgr.deleteFunc = nil
+	require.NoError(t, volumeMgr.DetachVolume(context.Background(), b.DiskVolumeID, "inst-stuck"))
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-1")
+	assert.NoError(t, err)
+}
+
+func TestResetDisk(t *testing.T) {
+	mgr, volumeMgr, _, p := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	// Marker inside the volume dir proves the disk was recreated, not kept.
+	marker := p.VolumeDir(b.DiskVolumeID) + "/marker"
+	require.NoError(t, os.WriteFile(marker, []byte("x"), 0644))
+
+	require.NoError(t, mgr.ResetDisk(context.Background(), b.ID))
+	waitForStatus(t, mgr, b.ID, StatusReady)
+
+	_, err = os.Stat(marker)
+	assert.True(t, os.IsNotExist(err), "old disk must be gone")
+	vol, err := volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	require.NoError(t, err)
+	assert.Equal(t, managedByTagValue, vol.Tags[volumes.SystemTagNamespace+"managed-by"])
+
+	// Identity is preserved.
+	got, err := mgr.GetBuilder(context.Background(), b.ID)
+	require.NoError(t, err)
+	assert.Equal(t, b.ID, got.ID)
+	assert.True(t, b.CreatedAt.Equal(got.CreatedAt), "created_at must survive the reset")
+}
+
+func TestResetDisk_InUse(t *testing.T) {
+	mgr, volumeMgr, _, _ := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-1")
+	require.NoError(t, err)
+	assert.ErrorIs(t, mgr.ResetDisk(context.Background(), b.ID), ErrInUse)
+	require.NoError(t, mgr.ReleaseBuild(context.Background(), b.ID, "build-1"))
+
+	err = volumeMgr.AttachVolume(context.Background(), b.DiskVolumeID, volumes.AttachVolumeRequest{
+		InstanceID: "inst-1", MountPath: "/var/lib/buildkit",
+	})
+	require.NoError(t, err)
+	assert.ErrorIs(t, mgr.ResetDisk(context.Background(), b.ID), ErrInUse)
+}
+
+func TestReconcile_MissingDisk(t *testing.T) {
+	mgr, volumeMgr, instMgr, p := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+	require.NoError(t, volumeMgr.DeleteVolume(context.Background(), b.DiskVolumeID))
+
+	restarted, err := NewManager(p, Config{}, volumeMgr, instMgr, slog.Default(), nil)
+	require.NoError(t, err)
+	require.NoError(t, restarted.Start(context.Background()))
+
+	_, err = volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	assert.NoError(t, err, "reconciliation must recreate a missing disk")
+}
+
+func TestReconcile_OrphanAttachment(t *testing.T) {
+	mgr, volumeMgr, instMgr, p := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+	err = volumeMgr.AttachVolume(context.Background(), b.DiskVolumeID, volumes.AttachVolumeRequest{
+		InstanceID: "inst-gone", MountPath: "/var/lib/buildkit",
+	})
+	require.NoError(t, err)
+
+	restarted, err := NewManager(p, Config{}, volumeMgr, instMgr, slog.Default(), nil)
+	require.NoError(t, err)
+	require.NoError(t, restarted.Start(context.Background()))
+
+	vol, err := volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	require.NoError(t, err)
+	assert.Empty(t, vol.Attachments, "attachment whose instance is gone must be detached")
+}
+
+func TestReconcile_StaleInstanceDeleted(t *testing.T) {
+	mgr, volumeMgr, instMgr, p := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+	err = volumeMgr.AttachVolume(context.Background(), b.DiskVolumeID, volumes.AttachVolumeRequest{
+		InstanceID: "inst-stale", MountPath: "/var/lib/buildkit",
+	})
+	require.NoError(t, err)
+	instMgr.instances["inst-stale"] = &instances.Instance{
+		StoredMetadata: instances.StoredMetadata{Id: "inst-stale"},
+	}
+	// Simulate DeleteInstance failing to detach: the record survives deletion.
+	instMgr.deleteFunc = func(id string) error {
+		delete(instMgr.instances, id)
+		return nil
+	}
+
+	restarted, err := NewManager(p, Config{}, volumeMgr, instMgr, slog.Default(), nil)
+	require.NoError(t, err)
+	require.NoError(t, restarted.Start(context.Background()))
+
+	assert.Contains(t, instMgr.deleted, "inst-stale")
+	vol, err := volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	require.NoError(t, err)
+	assert.Empty(t, vol.Attachments, "surviving attachment records must be detached after stale instance deletion")
+}
+
+func TestReconcile_InterruptedDelete(t *testing.T) {
+	mgr, volumeMgr, instMgr, p := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	// Crash mid-delete: status persisted as deleting, disk and metadata remain.
+	meta, err := loadMetadata(p, b.ID)
+	require.NoError(t, err)
+	meta.Status = StatusDeleting
+	require.NoError(t, saveMetadata(p, meta))
+
+	restarted, err := NewManager(p, Config{}, volumeMgr, instMgr, slog.Default(), nil)
+	require.NoError(t, err)
+	require.NoError(t, restarted.Start(context.Background()))
+
+	_, err = restarted.GetBuilder(context.Background(), b.ID)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	assert.ErrorIs(t, err, volumes.ErrNotFound)
+}
+
+func TestReconcile_InterruptedPrune(t *testing.T) {
+	mgr, volumeMgr, instMgr, p := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	// Crash mid-prune after the old disk was deleted.
+	require.NoError(t, volumeMgr.DeleteVolume(context.Background(), b.DiskVolumeID))
+	meta, err := loadMetadata(p, b.ID)
+	require.NoError(t, err)
+	meta.Status = StatusPruning
+	require.NoError(t, saveMetadata(p, meta))
+
+	restarted, err := NewManager(p, Config{}, volumeMgr, instMgr, slog.Default(), nil)
+	require.NoError(t, err)
+	require.NoError(t, restarted.Start(context.Background()))
+
+	got, err := restarted.GetBuilder(context.Background(), b.ID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusReady, got.Status)
+	_, err = volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	assert.NoError(t, err, "interrupted prune must finish recreating the disk")
+}
+
+func TestIdleReaper(t *testing.T) {
+	m, volumeMgr, _, p := setupTestManager(t, Config{IdleTTL: time.Hour})
+
+	b, err := m.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	// Backdate last activity beyond the TTL.
+	meta, err := loadMetadata(p, b.ID)
+	require.NoError(t, err)
+	old := time.Now().Add(-2 * time.Hour)
+	meta.LastUsedAt = &old
+	require.NoError(t, saveMetadata(p, meta))
+
+	m.reapIdle(context.Background())
+
+	_, err = m.GetBuilder(context.Background(), b.ID)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	assert.ErrorIs(t, err, volumes.ErrNotFound)
+
+	// A fresh builder is kept.
+	b2, err := m.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+	m.reapIdle(context.Background())
+	_, err = m.GetBuilder(context.Background(), b2.ID)
+	assert.NoError(t, err)
+
+	// An acquired builder past TTL is kept.
+	_, err = m.AcquireForBuild(context.Background(), b2.ID, "build-1")
+	require.NoError(t, err)
+	meta, err = loadMetadata(p, b2.ID)
+	require.NoError(t, err)
+	meta.LastUsedAt = &old
+	require.NoError(t, saveMetadata(p, meta))
+	m.reapIdle(context.Background())
+	_, err = m.GetBuilder(context.Background(), b2.ID)
+	assert.NoError(t, err, "acquired builder must not be reaped")
+}
+
+func TestValidateBuilderID(t *testing.T) {
+	assert.NoError(t, ValidateBuilderID("abc"))
+	assert.NoError(t, ValidateBuilderID("team-cache_1"))
+	assert.ErrorIs(t, ValidateBuilderID(""), ErrInvalidID)
+	assert.ErrorIs(t, ValidateBuilderID("../escape"), ErrInvalidID)
+	assert.ErrorIs(t, ValidateBuilderID("a/b"), ErrInvalidID)
+}
+
+func TestResetDisk_NotFound(t *testing.T) {
+	mgr, _, _, _ := setupTestManager(t, Config{})
+	assert.ErrorIs(t, mgr.ResetDisk(context.Background(), "nope"), ErrNotFound)
+}
+
+func TestDeleteBuilder_ToleratesMissingDisk(t *testing.T) {
+	mgr, volumeMgr, _, _ := setupTestManager(t, Config{})
+
+	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+	require.NoError(t, volumeMgr.DeleteVolume(context.Background(), b.DiskVolumeID))
+
+	assert.NoError(t, mgr.DeleteBuilder(context.Background(), b.ID))
+}

--- a/lib/builders/manager_test.go
+++ b/lib/builders/manager_test.go
@@ -115,7 +115,7 @@ func TestCreateBuilder_Quotas(t *testing.T) {
 	mgr, _, _, _ := setupTestManager(t, Config{MaxCount: 1, MaxDiskSizeGb: 60})
 
 	_, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{DiskSizeGb: 61})
-	assert.ErrorContains(t, err, "exceeds maximum")
+	assert.ErrorIs(t, err, ErrDiskSizeExceeded)
 
 	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{DiskSizeGb: 60})
 	require.NoError(t, err)

--- a/lib/builders/manager_test.go
+++ b/lib/builders/manager_test.go
@@ -24,6 +24,26 @@ type mockInstanceChecker struct {
 	deleted    []string
 }
 
+type createThenFailVolumeManager struct {
+	volumes.Manager
+	createErr error
+	deleteErr error
+}
+
+func (m *createThenFailVolumeManager) CreateVolume(ctx context.Context, req volumes.CreateVolumeRequest) (*volumes.Volume, error) {
+	if _, err := m.Manager.CreateVolume(ctx, req); err != nil {
+		return nil, err
+	}
+	return nil, m.createErr
+}
+
+func (m *createThenFailVolumeManager) DeleteVolume(ctx context.Context, id string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	return m.Manager.DeleteVolume(ctx, id)
+}
+
 func (m *mockInstanceChecker) GetInstance(ctx context.Context, idOrName string) (*instances.Instance, error) {
 	if m.getErr != nil {
 		return nil, m.getErr
@@ -97,7 +117,8 @@ func TestCreateBuilder_CallerSuppliedID(t *testing.T) {
 	assert.Equal(t, "builder-disk-team-cache-1", b.DiskVolumeID)
 	assert.Equal(t, 20, b.DiskSizeGb)
 
-	// Same ID is a conflict, supporting control-plane idempotency.
+	// Same ID is an explicit conflict; caller-supplied IDs are not an
+	// idempotency mechanism.
 	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{ID: &id})
 	assert.ErrorIs(t, err, ErrAlreadyExists)
 }
@@ -114,7 +135,10 @@ func TestCreateBuilder_InvalidID(t *testing.T) {
 func TestCreateBuilder_Quotas(t *testing.T) {
 	mgr, _, _, _ := setupTestManager(t, Config{MaxCount: 1, MaxDiskSizeGb: 60})
 
-	_, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{DiskSizeGb: 61})
+	_, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{DiskSizeGb: -1})
+	assert.ErrorIs(t, err, ErrInvalidDiskSize)
+
+	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{DiskSizeGb: 61})
 	assert.ErrorIs(t, err, ErrDiskSizeExceeded)
 
 	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{DiskSizeGb: 60})
@@ -124,10 +148,49 @@ func TestCreateBuilder_Quotas(t *testing.T) {
 	assert.ErrorIs(t, err, ErrQuotaExceeded)
 }
 
+func TestCreateBuilder_FailedDiskCleanupKeepsOwnershipMetadata(t *testing.T) {
+	p := paths.New(t.TempDir())
+	volumeMgr := volumes.NewManager(p, 0, nil)
+	wrapped := &createThenFailVolumeManager{
+		Manager:   volumeMgr,
+		createErr: errors.New("create result lost"),
+		deleteErr: errors.New("disk busy"),
+	}
+	instMgr := &mockInstanceChecker{instances: map[string]*instances.Instance{}}
+	managerInterface, err := NewManager(p, Config{}, wrapped, instMgr, slog.Default(), nil)
+	require.NoError(t, err)
+	mgr := managerInterface.(*manager)
+
+	id := "partial-create"
+	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{ID: &id})
+	require.ErrorContains(t, err, "create result lost")
+	require.ErrorContains(t, err, "disk busy")
+
+	builder, err := mgr.GetBuilder(context.Background(), id)
+	require.NoError(t, err)
+	assert.Equal(t, StatusError, builder.Status)
+	_, err = volumeMgr.GetVolume(context.Background(), builder.DiskVolumeID)
+	require.NoError(t, err, "partially-created disk remains owned by visible metadata")
+
+	_, err = mgr.CreateBuilder(context.Background(), CreateBuilderRequest{ID: &id})
+	assert.ErrorIs(t, err, ErrAlreadyExists)
+}
+
 func TestGetBuilder_NotFound(t *testing.T) {
 	mgr, _, _, _ := setupTestManager(t, Config{})
 	_, err := mgr.GetBuilder(context.Background(), "nope")
 	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestCorruptMetadataIsReported(t *testing.T) {
+	mgr, _, _, p := setupTestManager(t, Config{})
+	require.NoError(t, os.MkdirAll(p.BuilderDir("corrupt"), 0755))
+	require.NoError(t, os.WriteFile(p.BuilderMetadata("corrupt"), []byte("{"), 0644))
+
+	_, err := mgr.ListBuilders(context.Background())
+	require.ErrorContains(t, err, "load builder corrupt")
+	err = mgr.Start(context.Background())
+	require.ErrorContains(t, err, "load builder corrupt")
 }
 
 func TestListBuilders(t *testing.T) {
@@ -320,7 +383,9 @@ func TestResetDisk(t *testing.T) {
 	marker := p.VolumeDir(b.DiskVolumeID) + "/marker"
 	require.NoError(t, os.WriteFile(marker, []byte("x"), 0644))
 
-	require.NoError(t, mgr.ResetDisk(context.Background(), b.ID))
+	accepted, err := mgr.ResetDisk(context.Background(), b.ID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusPruning, accepted.Status)
 	waitForStatus(t, mgr, b.ID, StatusReady)
 
 	_, err = os.Stat(marker)
@@ -344,14 +409,16 @@ func TestResetDisk_InUse(t *testing.T) {
 
 	_, err = mgr.AcquireForBuild(context.Background(), b.ID, "build-1")
 	require.NoError(t, err)
-	assert.ErrorIs(t, mgr.ResetDisk(context.Background(), b.ID), ErrInUse)
+	_, err = mgr.ResetDisk(context.Background(), b.ID)
+	assert.ErrorIs(t, err, ErrInUse)
 	require.NoError(t, mgr.ReleaseBuild(context.Background(), b.ID, "build-1"))
 
 	err = volumeMgr.AttachVolume(context.Background(), b.DiskVolumeID, volumes.AttachVolumeRequest{
 		InstanceID: "inst-1", MountPath: "/var/lib/buildkit",
 	})
 	require.NoError(t, err)
-	assert.ErrorIs(t, mgr.ResetDisk(context.Background(), b.ID), ErrInUse)
+	_, err = mgr.ResetDisk(context.Background(), b.ID)
+	assert.ErrorIs(t, err, ErrInUse)
 }
 
 func TestReconcile_MissingDisk(t *testing.T) {
@@ -535,10 +602,11 @@ func TestIdleReaper_RetriesAfterDiskDeleteFailure(t *testing.T) {
 	m.reapIdle(context.Background())
 
 	got, err := m.GetBuilder(context.Background(), b.ID)
-	require.NoError(t, err, "a failed reap must not strand the builder in deleting")
-	assert.Equal(t, StatusReady, got.Status, "status must revert to ready so the next tick retries")
+	require.NoError(t, err)
+	assert.Equal(t, StatusDeleting, got.Status, "failed delete remains crash-recoverable")
 
-	// Once the disk is deletable again, the next tick finishes the reap.
+	// Once the disk is deletable again, the next tick resumes the shared
+	// delete path and finishes the reap.
 	delete(failing.fail, b.DiskVolumeID)
 	m.reapIdle(context.Background())
 	_, err = m.GetBuilder(context.Background(), b.ID)
@@ -584,7 +652,8 @@ func TestValidateBuilderID(t *testing.T) {
 
 func TestResetDisk_NotFound(t *testing.T) {
 	mgr, _, _, _ := setupTestManager(t, Config{})
-	assert.ErrorIs(t, mgr.ResetDisk(context.Background(), "nope"), ErrNotFound)
+	_, err := mgr.ResetDisk(context.Background(), "nope")
+	assert.ErrorIs(t, err, ErrNotFound)
 }
 
 func TestDeleteBuilder_ToleratesMissingDisk(t *testing.T) {

--- a/lib/builders/manager_test.go
+++ b/lib/builders/manager_test.go
@@ -501,6 +501,79 @@ func TestIdleReaper(t *testing.T) {
 	assert.NoError(t, err, "acquired builder must not be reaped")
 }
 
+// failDeleteVolumeManager fails DeleteVolume for the given volume IDs.
+type failDeleteVolumeManager struct {
+	volumes.Manager
+	fail map[string]error
+}
+
+func (f *failDeleteVolumeManager) DeleteVolume(ctx context.Context, id string) error {
+	if err, ok := f.fail[id]; ok {
+		return err
+	}
+	return f.Manager.DeleteVolume(ctx, id)
+}
+
+func TestIdleReaper_RetriesAfterDiskDeleteFailure(t *testing.T) {
+	m, volumeMgr, _, p := setupTestManager(t, Config{IdleTTL: time.Hour})
+
+	b, err := m.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+
+	meta, err := loadMetadata(p, b.ID)
+	require.NoError(t, err)
+	old := time.Now().Add(-2 * time.Hour)
+	meta.LastUsedAt = &old
+	require.NoError(t, saveMetadata(p, meta))
+
+	failing := &failDeleteVolumeManager{
+		Manager: volumeMgr,
+		fail:    map[string]error{b.DiskVolumeID: errors.New("disk busy")},
+	}
+	m.volumeManager = failing
+
+	m.reapIdle(context.Background())
+
+	got, err := m.GetBuilder(context.Background(), b.ID)
+	require.NoError(t, err, "a failed reap must not strand the builder in deleting")
+	assert.Equal(t, StatusReady, got.Status, "status must revert to ready so the next tick retries")
+
+	// Once the disk is deletable again, the next tick finishes the reap.
+	delete(failing.fail, b.DiskVolumeID)
+	m.reapIdle(context.Background())
+	_, err = m.GetBuilder(context.Background(), b.ID)
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
+	assert.ErrorIs(t, err, volumes.ErrNotFound)
+}
+
+func TestReleaseBuild_FailureKeepsHold(t *testing.T) {
+	m, _, _, p := setupTestManager(t, Config{})
+
+	b, err := m.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+	_, err = m.AcquireForBuild(context.Background(), b.ID, "build-1")
+	require.NoError(t, err)
+
+	// Make the metadata unpersistable: a directory occupying the temp path
+	// fails the atomic write even for a root test runner.
+	tmpPath := p.BuilderMetadata(b.ID) + ".tmp"
+	require.NoError(t, os.Mkdir(tmpPath, 0755))
+
+	require.Error(t, m.ReleaseBuild(context.Background(), b.ID, "build-1"))
+
+	// The hold must survive the failed release: the builder stays acquired
+	// and a retry after the failure clears.
+	_, err = m.AcquireForBuild(context.Background(), b.ID, "build-2")
+	assert.ErrorIs(t, err, ErrInUse, "failed release must leave the builder held")
+	require.NoError(t, os.Remove(tmpPath))
+	require.NoError(t, m.ReleaseBuild(context.Background(), b.ID, "build-1"), "retry after failure must succeed")
+
+	got, err := m.GetBuilder(context.Background(), b.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastUsedAt)
+}
+
 func TestValidateBuilderID(t *testing.T) {
 	assert.NoError(t, ValidateBuilderID("abc"))
 	assert.NoError(t, ValidateBuilderID("team-cache_1"))

--- a/lib/builders/manager_test.go
+++ b/lib/builders/manager_test.go
@@ -489,7 +489,15 @@ func TestReconcile_InterruptedDelete(t *testing.T) {
 	b, err := mgr.CreateBuilder(context.Background(), CreateBuilderRequest{})
 	require.NoError(t, err)
 
-	// Crash mid-delete: status persisted as deleting, disk and metadata remain.
+	// Crash mid-delete: status persisted as deleting, disk and metadata remain,
+	// and a stale VM still holds the disk.
+	instMgr.instances["inst-stale-delete"] = &instances.Instance{
+		StoredMetadata: instances.StoredMetadata{Id: "inst-stale-delete"},
+	}
+	require.NoError(t, volumeMgr.AttachVolume(context.Background(), b.DiskVolumeID, volumes.AttachVolumeRequest{
+		InstanceID: "inst-stale-delete",
+		MountPath:  "/var/lib/buildkit",
+	}))
 	meta, err := loadMetadata(p, b.ID)
 	require.NoError(t, err)
 	meta.Status = StatusDeleting
@@ -501,6 +509,7 @@ func TestReconcile_InterruptedDelete(t *testing.T) {
 
 	_, err = restarted.GetBuilder(context.Background(), b.ID)
 	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Contains(t, instMgr.deleted, "inst-stale-delete")
 	_, err = volumeMgr.GetVolume(context.Background(), b.DiskVolumeID)
 	assert.ErrorIs(t, err, volumes.ErrNotFound)
 }
@@ -530,7 +539,7 @@ func TestReconcile_InterruptedPrune(t *testing.T) {
 }
 
 func TestIdleReaper(t *testing.T) {
-	m, volumeMgr, _, p := setupTestManager(t, Config{IdleTTL: time.Hour})
+	m, volumeMgr, instMgr, p := setupTestManager(t, Config{IdleTTL: time.Hour})
 
 	b, err := m.CreateBuilder(context.Background(), CreateBuilderRequest{})
 	require.NoError(t, err)
@@ -566,6 +575,26 @@ func TestIdleReaper(t *testing.T) {
 	m.reapIdle(context.Background())
 	_, err = m.GetBuilder(context.Background(), b2.ID)
 	assert.NoError(t, err, "acquired builder must not be reaped")
+
+	// A stale VM attachment on an idle builder is cleared before deletion.
+	b3, err := m.CreateBuilder(context.Background(), CreateBuilderRequest{})
+	require.NoError(t, err)
+	instMgr.instances["inst-stale-reap"] = &instances.Instance{
+		StoredMetadata: instances.StoredMetadata{Id: "inst-stale-reap"},
+	}
+	require.NoError(t, volumeMgr.AttachVolume(context.Background(), b3.DiskVolumeID, volumes.AttachVolumeRequest{
+		InstanceID: "inst-stale-reap",
+		MountPath:  "/var/lib/buildkit",
+	}))
+	meta, err = loadMetadata(p, b3.ID)
+	require.NoError(t, err)
+	meta.LastUsedAt = &old
+	require.NoError(t, saveMetadata(p, meta))
+
+	m.reapIdle(context.Background())
+	_, err = m.GetBuilder(context.Background(), b3.ID)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Contains(t, instMgr.deleted, "inst-stale-reap")
 }
 
 // failDeleteVolumeManager fails DeleteVolume for the given volume IDs.

--- a/lib/builders/metrics.go
+++ b/lib/builders/metrics.go
@@ -1,0 +1,65 @@
+package builders
+
+import (
+	"context"
+	"time"
+
+	hypotel "github.com/kernel/hypeman/lib/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// Metrics holds the metrics instruments for builder operations.
+type Metrics struct {
+	createDuration metric.Float64Histogram
+}
+
+// newBuilderMetrics creates and registers all builder metrics.
+func newBuilderMetrics(meter metric.Meter, m *manager) (*Metrics, error) {
+	createDuration, err := meter.Float64Histogram(
+		"hypeman_builders_create_duration_seconds",
+		metric.WithDescription("Time to create a builder"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	buildersTotal, err := meter.Int64ObservableGauge(
+		"hypeman_builders_total",
+		metric.WithDescription("Total number of builders"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = meter.RegisterCallback(
+		func(ctx context.Context, o metric.Observer) error {
+			builders, err := m.ListBuilders(ctx)
+			if err != nil {
+				return nil
+			}
+			o.ObserveInt64(buildersTotal, int64(len(builders)))
+			return nil
+		},
+		buildersTotal,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Metrics{
+		createDuration: createDuration,
+	}, nil
+}
+
+// recordCreateDuration records the builder creation duration.
+func (m *manager) recordCreateDuration(ctx context.Context, start time.Time, status string) {
+	if m.metrics == nil {
+		return
+	}
+	duration := time.Since(start).Seconds()
+	m.metrics.createDuration.Record(ctx, duration,
+		metric.WithAttributes(attribute.String("status", status)))
+}

--- a/lib/builders/metrics.go
+++ b/lib/builders/metrics.go
@@ -40,7 +40,19 @@ func newBuilderMetrics(meter metric.Meter, m *manager) (*Metrics, error) {
 			if err != nil {
 				return nil
 			}
-			o.ObserveInt64(buildersTotal, int64(len(builders)))
+			counts := map[string]int64{
+				StatusReady:    0,
+				StatusPruning:  0,
+				StatusDeleting: 0,
+				StatusError:    0,
+			}
+			for _, builder := range builders {
+				counts[builder.Status]++
+			}
+			for status, count := range counts {
+				o.ObserveInt64(buildersTotal, count,
+					metric.WithAttributes(attribute.String("status", status)))
+			}
 			return nil
 		},
 		buildersTotal,

--- a/lib/builders/storage.go
+++ b/lib/builders/storage.go
@@ -1,0 +1,113 @@
+package builders
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/tags"
+)
+
+// Filesystem structure:
+// {dataDir}/builders/{builder-id}/
+//   metadata.json   # Builder metadata
+
+// storedMetadata represents builder metadata persisted to disk
+type storedMetadata struct {
+	ID           string     `json:"id"`
+	Name         string     `json:"name,omitempty"`
+	DiskSizeGb   int        `json:"disk_size_gb"`
+	Tags         tags.Tags  `json:"tags,omitempty"`
+	Status       string     `json:"status"`
+	CreatedAt    time.Time  `json:"created_at"`
+	LastUsedAt   *time.Time `json:"last_used_at,omitempty"`
+	DiskVolumeID string     `json:"disk_volume_id"`
+}
+
+// loadMetadata loads builder metadata from disk
+func loadMetadata(p *paths.Paths, id string) (*storedMetadata, error) {
+	data, err := os.ReadFile(p.BuilderMetadata(id))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("read metadata: %w", err)
+	}
+
+	var meta storedMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("unmarshal metadata: %w", err)
+	}
+
+	return &meta, nil
+}
+
+// saveMetadata writes builder metadata to disk atomically
+func saveMetadata(p *paths.Paths, meta *storedMetadata) error {
+	dir := p.BuilderDir(meta.ID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create builder directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal metadata: %w", err)
+	}
+
+	tempPath := p.BuilderMetadata(meta.ID) + ".tmp"
+	if err := os.WriteFile(tempPath, data, 0644); err != nil {
+		return fmt.Errorf("write temp metadata: %w", err)
+	}
+	if err := os.Rename(tempPath, p.BuilderMetadata(meta.ID)); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("rename metadata: %w", err)
+	}
+
+	return nil
+}
+
+// deleteBuilderData removes all builder data from disk
+func deleteBuilderData(p *paths.Paths, id string) error {
+	if err := os.RemoveAll(p.BuilderDir(id)); err != nil {
+		return fmt.Errorf("remove builder directory: %w", err)
+	}
+	return nil
+}
+
+// listBuilderIDs returns all builder IDs by scanning the builders directory
+func listBuilderIDs(p *paths.Paths) ([]string, error) {
+	entries, err := os.ReadDir(p.BuildersDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read builders directory: %w", err)
+	}
+
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(p.BuilderMetadata(entry.Name())); err == nil {
+			ids = append(ids, entry.Name())
+		}
+	}
+	return ids, nil
+}
+
+// toBuilder converts stored metadata to the public Builder type
+func (m *storedMetadata) toBuilder() *Builder {
+	return &Builder{
+		ID:           m.ID,
+		Name:         m.Name,
+		DiskSizeGb:   m.DiskSizeGb,
+		Tags:         tags.Clone(m.Tags),
+		Status:       m.Status,
+		CreatedAt:    m.CreatedAt,
+		LastUsedAt:   m.LastUsedAt,
+		DiskVolumeID: m.DiskVolumeID,
+	}
+}

--- a/lib/builders/storage.go
+++ b/lib/builders/storage.go
@@ -16,14 +16,13 @@ import (
 
 // storedMetadata represents builder metadata persisted to disk
 type storedMetadata struct {
-	ID           string     `json:"id"`
-	Name         string     `json:"name,omitempty"`
-	DiskSizeGb   int        `json:"disk_size_gb"`
-	Tags         tags.Tags  `json:"tags,omitempty"`
-	Status       string     `json:"status"`
-	CreatedAt    time.Time  `json:"created_at"`
-	LastUsedAt   *time.Time `json:"last_used_at,omitempty"`
-	DiskVolumeID string     `json:"disk_volume_id"`
+	ID         string     `json:"id"`
+	Name       string     `json:"name,omitempty"`
+	DiskSizeGb int        `json:"disk_size_gb"`
+	Tags       tags.Tags  `json:"tags,omitempty"`
+	Status     string     `json:"status"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
 }
 
 // loadMetadata loads builder metadata from disk
@@ -91,11 +90,19 @@ func listBuilderIDs(p *paths.Paths) ([]string, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		if _, err := os.Stat(p.BuilderMetadata(entry.Name())); err == nil {
-			ids = append(ids, entry.Name())
+		if _, err := os.Stat(p.BuilderMetadata(entry.Name())); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("stat builder metadata %s: %w", entry.Name(), err)
 		}
+		ids = append(ids, entry.Name())
 	}
 	return ids, nil
+}
+
+func (m *storedMetadata) diskVolumeID() string {
+	return DiskVolumeID(m.ID)
 }
 
 // toBuilder converts stored metadata to the public Builder type
@@ -108,6 +115,6 @@ func (m *storedMetadata) toBuilder() *Builder {
 		Status:       m.Status,
 		CreatedAt:    m.CreatedAt,
 		LastUsedAt:   m.LastUsedAt,
-		DiskVolumeID: m.DiskVolumeID,
+		DiskVolumeID: DiskVolumeID(m.ID),
 	}
 }

--- a/lib/builders/types.go
+++ b/lib/builders/types.go
@@ -1,0 +1,75 @@
+// Package builders implements the Builder resource: a named, persistent
+// BuildKit cache disk that disposable per-build VMs attach at
+// /var/lib/buildkit. A Builder is the unit of build-cache isolation; one
+// build at a time may run on a Builder.
+package builders
+
+import (
+	"time"
+
+	"github.com/kernel/hypeman/lib/tags"
+)
+
+// Builder status constants
+const (
+	StatusReady    = "ready"
+	StatusPruning  = "pruning"
+	StatusDeleting = "deleting"
+	StatusError    = "error"
+)
+
+const (
+	// DefaultDiskSizeGb is the disk size used when a create request does
+	// not specify one.
+	DefaultDiskSizeGb = 50
+
+	// diskVolumePrefix prefixes the deterministic volume ID of every
+	// builder disk. The prefix is reserved from public volume APIs.
+	diskVolumePrefix = "builder-disk-"
+
+	// managedByTagValue marks volumes created by the builders manager.
+	managedByTagValue = "builder"
+)
+
+// Builder is a first-class build-cache resource. Its disk is a persistent
+// ext4 sparse-file volume attached to builder VMs at /var/lib/buildkit.
+type Builder struct {
+	ID           string
+	Name         string // optional, non-unique metadata
+	DiskSizeGb   int
+	Tags         tags.Tags
+	Status       string
+	CreatedAt    time.Time
+	LastUsedAt   *time.Time
+	DiskVolumeID string
+}
+
+// CreateBuilderRequest is the domain request for creating a builder
+type CreateBuilderRequest struct {
+	ID         *string // optional caller-supplied ID for control-plane idempotency
+	Name       string
+	DiskSizeGb int // <= 0 uses the configured default; immutable after creation
+	Tags       tags.Tags
+}
+
+// Config holds configuration for the builders manager
+type Config struct {
+	// MaxCount caps the number of builders (0 = unlimited)
+	MaxCount int
+
+	// DefaultDiskSizeGb is the disk size for creates that omit it
+	// (<= 0 uses DefaultDiskSizeGb)
+	DefaultDiskSizeGb int
+
+	// MaxDiskSizeGb caps the requested disk size (0 = unlimited)
+	MaxDiskSizeGb int
+
+	// IdleTTL is how long a builder may go unused before it is deleted.
+	// Deletion is total and irreversible. 0 disables the reaper.
+	IdleTTL time.Duration
+}
+
+// DiskVolumeID returns the deterministic volume ID of a builder's disk.
+func DiskVolumeID(builderID string) string {
+	return diskVolumePrefix + builderID
+}

--- a/lib/builders/types.go
+++ b/lib/builders/types.go
@@ -1,7 +1,6 @@
-// Package builders implements the Builder resource: a named, persistent
-// BuildKit cache disk that disposable per-build VMs attach at
-// /var/lib/buildkit. A Builder is the unit of build-cache isolation; one
-// build at a time may run on a Builder.
+// Package builders implements persistent cache resources used by disposable
+// build VMs. A Builder is the unit of build-cache isolation; one build at a
+// time may run on a Builder.
 package builders
 
 import (
@@ -31,8 +30,7 @@ const (
 	managedByTagValue = "builder"
 )
 
-// Builder is a first-class build-cache resource. Its disk is a persistent
-// ext4 sparse-file volume attached to builder VMs at /var/lib/buildkit.
+// Builder is a first-class build-cache resource backed by a persistent disk.
 type Builder struct {
 	ID           string
 	Name         string // optional, non-unique metadata
@@ -46,9 +44,9 @@ type Builder struct {
 
 // CreateBuilderRequest is the domain request for creating a builder
 type CreateBuilderRequest struct {
-	ID         *string // optional caller-supplied ID for control-plane idempotency
+	ID         *string // optional caller-supplied ID
 	Name       string
-	DiskSizeGb int // <= 0 uses the configured default; immutable after creation
+	DiskSizeGb int // 0 uses the configured default; immutable after creation
 	Tags       tags.Tags
 }
 

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -32,6 +32,14 @@ const (
 	MaxVolumesPerInstance = 23
 )
 
+// allowedSystemMountPaths are exact paths exempt from the system directory
+// check for instances created with AllowSystemVolumeMounts: internal
+// services that own the path and require a volume mounted at a fixed
+// location under it.
+var allowedSystemMountPaths = []string{
+	"/var/lib/buildkit", // BuildKit root volume in builder VMs
+}
+
 // systemDirectories are paths that cannot be used as volume mount points
 var systemDirectories = []string{
 	"/",
@@ -641,8 +649,9 @@ func validateCreateRequest(req *CreateInstanceRequest) error {
 }
 
 // validateVolumeAttachments validates volume attachment requests.
-// allowSystemVolumes permits attaching volumes whose IDs carry a reserved
-// internal prefix and is only set for internally created instances.
+// allowSystemVolumes is only set for internally created instances: it
+// permits attaching volumes whose IDs carry a reserved internal prefix and
+// mounting them at the reserved paths in allowedSystemMountPaths.
 func validateVolumeAttachments(attachments []VolumeAttachment, allowSystemVolumes bool) error {
 	// Count total devices needed (each overlay volume needs 2 devices: base + overlay)
 	totalDevices := 0
@@ -667,7 +676,7 @@ func validateVolumeAttachments(attachments []VolumeAttachment, allowSystemVolume
 		cleanPath := filepath.Clean(vol.MountPath)
 
 		// Check for system directories
-		if isSystemDirectory(cleanPath) {
+		if isSystemDirectory(cleanPath) && !(allowSystemVolumes && isAllowedSystemMountPath(cleanPath)) {
 			return fmt.Errorf("volume %s: cannot mount to system directory %q", vol.VolumeID, cleanPath)
 		}
 
@@ -696,6 +705,17 @@ func validateVolumeAttachments(attachments []VolumeAttachment, allowSystemVolume
 	}
 
 	return nil
+}
+
+// isAllowedSystemMountPath reports whether path is an exact match for a
+// system path that an internal instance may mount a volume at.
+func isAllowedSystemMountPath(path string) bool {
+	for _, allowed := range allowedSystemMountPaths {
+		if path == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 // isSystemDirectory checks if a path is or is under a system directory

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -32,14 +32,6 @@ const (
 	MaxVolumesPerInstance = 23
 )
 
-// allowedSystemMountPaths are exact paths exempt from the system directory
-// check for instances created with AllowSystemVolumeMounts: internal
-// services that own the path and require a volume mounted at a fixed
-// location under it.
-var allowedSystemMountPaths = []string{
-	"/var/lib/buildkit", // BuildKit root volume in builder VMs
-}
-
 // systemDirectories are paths that cannot be used as volume mount points
 var systemDirectories = []string{
 	"/",
@@ -641,18 +633,22 @@ func validateCreateRequest(req *CreateInstanceRequest) error {
 	req.RestartPolicy = normalizedRestartPolicy
 
 	// Validate volume attachments
-	if err := validateVolumeAttachments(req.Volumes, req.AllowSystemVolumeMounts); err != nil {
+	if err := validateVolumeAttachmentsWithSystemPaths(req.Volumes, req.AllowSystemVolumeMounts, req.SystemVolumeMountPaths); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// validateVolumeAttachments validates volume attachment requests.
-// allowSystemVolumes is only set for internally created instances: it
-// permits attaching volumes whose IDs carry a reserved internal prefix and
-// mounting them at the reserved paths in allowedSystemMountPaths.
+// validateVolumeAttachments validates public volume attachment requests.
 func validateVolumeAttachments(attachments []VolumeAttachment, allowSystemVolumes bool) error {
+	return validateVolumeAttachmentsWithSystemPaths(attachments, allowSystemVolumes, nil)
+}
+
+// validateVolumeAttachmentsWithSystemPaths validates volume attachments for
+// internal callers that may attach reserved volumes at explicitly allowed
+// system paths.
+func validateVolumeAttachmentsWithSystemPaths(attachments []VolumeAttachment, allowSystemVolumes bool, allowedSystemMountPaths []string) error {
 	// Count total devices needed (each overlay volume needs 2 devices: base + overlay)
 	totalDevices := 0
 	for _, vol := range attachments {
@@ -676,7 +672,7 @@ func validateVolumeAttachments(attachments []VolumeAttachment, allowSystemVolume
 		cleanPath := filepath.Clean(vol.MountPath)
 
 		// Check for system directories
-		if isSystemDirectory(cleanPath) && !(allowSystemVolumes && isAllowedSystemMountPath(cleanPath)) {
+		if isSystemDirectory(cleanPath) && !(allowSystemVolumes && isAllowedSystemMountPath(cleanPath, allowedSystemMountPaths)) {
 			return fmt.Errorf("volume %s: cannot mount to system directory %q", vol.VolumeID, cleanPath)
 		}
 
@@ -709,7 +705,7 @@ func validateVolumeAttachments(attachments []VolumeAttachment, allowSystemVolume
 
 // isAllowedSystemMountPath reports whether path is an exact match for a
 // system path that an internal instance may mount a volume at.
-func isAllowedSystemMountPath(path string) bool {
+func isAllowedSystemMountPath(path string, allowedSystemMountPaths []string) bool {
 	for _, allowed := range allowedSystemMountPaths {
 		if path == allowed {
 			return true

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -633,18 +633,20 @@ func validateCreateRequest(req *CreateInstanceRequest) error {
 	req.RestartPolicy = normalizedRestartPolicy
 
 	// Validate volume attachments
-	if err := validateVolumeAttachments(req.Volumes); err != nil {
+	if err := validateVolumeAttachments(req.Volumes, req.AllowSystemVolumeMounts); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// validateVolumeAttachments validates volume attachment requests
-func validateVolumeAttachments(volumes []VolumeAttachment) error {
+// validateVolumeAttachments validates volume attachment requests.
+// allowSystemVolumes permits attaching volumes whose IDs carry a reserved
+// internal prefix and is only set for internally created instances.
+func validateVolumeAttachments(attachments []VolumeAttachment, allowSystemVolumes bool) error {
 	// Count total devices needed (each overlay volume needs 2 devices: base + overlay)
 	totalDevices := 0
-	for _, vol := range volumes {
+	for _, vol := range attachments {
 		totalDevices++
 		if vol.Overlay {
 			totalDevices++ // Overlay needs an additional device
@@ -655,7 +657,7 @@ func validateVolumeAttachments(volumes []VolumeAttachment) error {
 	}
 
 	seenPaths := make(map[string]bool)
-	for _, vol := range volumes {
+	for _, vol := range attachments {
 		// Validate mount path is absolute
 		if !filepath.IsAbs(vol.MountPath) {
 			return fmt.Errorf("volume %s: mount path %q must be absolute", vol.VolumeID, vol.MountPath)
@@ -667,6 +669,13 @@ func validateVolumeAttachments(volumes []VolumeAttachment) error {
 		// Check for system directories
 		if isSystemDirectory(cleanPath) {
 			return fmt.Errorf("volume %s: cannot mount to system directory %q", vol.VolumeID, cleanPath)
+		}
+
+		// Reserved internal volume IDs are attachable only by internal instances
+		if !allowSystemVolumes {
+			if prefix := volumes.ReservedVolumeIDPrefix(vol.VolumeID); prefix != "" {
+				return fmt.Errorf("volume %s: volume IDs with the prefix %q are reserved for internal use", vol.VolumeID, prefix)
+			}
 		}
 
 		// Check for duplicate mount paths

--- a/lib/instances/resource_limits_test.go
+++ b/lib/instances/resource_limits_test.go
@@ -27,7 +27,7 @@ func TestValidateVolumeAttachments_MaxVolumes(t *testing.T) {
 		}
 	}
 
-	err := validateVolumeAttachments(volumes)
+	err := validateVolumeAttachments(volumes, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot attach more than 23")
 }
@@ -39,7 +39,7 @@ func TestValidateVolumeAttachments_SystemDirectory(t *testing.T) {
 		MountPath: "/etc/secrets", // system directory
 	}}
 
-	err := validateVolumeAttachments(volumes)
+	err := validateVolumeAttachments(volumes, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "system directory")
 }
@@ -51,7 +51,7 @@ func TestValidateVolumeAttachments_DuplicatePaths(t *testing.T) {
 		{VolumeID: "vol-2", MountPath: "/mnt/data"}, // duplicate
 	}
 
-	err := validateVolumeAttachments(volumes)
+	err := validateVolumeAttachments(volumes, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate mount path")
 }
@@ -63,7 +63,7 @@ func TestValidateVolumeAttachments_RelativePath(t *testing.T) {
 		MountPath: "relative/path", // not absolute
 	}}
 
-	err := validateVolumeAttachments(volumes)
+	err := validateVolumeAttachments(volumes, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "must be absolute")
 }
@@ -75,16 +75,16 @@ func TestValidateVolumeAttachments_Valid(t *testing.T) {
 		{VolumeID: "vol-2", MountPath: "/mnt/logs"},
 	}
 
-	err := validateVolumeAttachments(volumes)
+	err := validateVolumeAttachments(volumes, false)
 	assert.NoError(t, err)
 }
 
 func TestValidateVolumeAttachments_Empty(t *testing.T) {
 	t.Parallel()
-	err := validateVolumeAttachments(nil)
+	err := validateVolumeAttachments(nil, false)
 	assert.NoError(t, err)
 
-	err = validateVolumeAttachments([]VolumeAttachment{})
+	err = validateVolumeAttachments([]VolumeAttachment{}, false)
 	assert.NoError(t, err)
 }
 
@@ -99,7 +99,7 @@ func TestValidateVolumeAttachments_OverlayRequiresReadonly(t *testing.T) {
 		OverlaySize: 100 * 1024 * 1024,
 	}}
 
-	err := validateVolumeAttachments(volumes)
+	err := validateVolumeAttachments(volumes, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "overlay mode requires readonly=true")
 }
@@ -115,7 +115,7 @@ func TestValidateVolumeAttachments_OverlayRequiresSize(t *testing.T) {
 		OverlaySize: 0, // Invalid: overlay requires size
 	}}
 
-	err := validateVolumeAttachments(volumes)
+	err := validateVolumeAttachments(volumes, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "overlay_size is required")
 }
@@ -131,7 +131,7 @@ func TestValidateVolumeAttachments_OverlayValid(t *testing.T) {
 		OverlaySize: 100 * 1024 * 1024, // 100MB
 	}}
 
-	err := validateVolumeAttachments(volumes)
+	err := validateVolumeAttachments(volumes, false)
 	assert.NoError(t, err)
 }
 
@@ -151,7 +151,7 @@ func TestValidateVolumeAttachments_OverlayCountsAsTwoDevices(t *testing.T) {
 		}
 	}
 
-	err := validateVolumeAttachments(volumes)
+	err := validateVolumeAttachments(volumes, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot attach more than 23")
 }
@@ -228,4 +228,27 @@ func cleanupTestProcesses(t *testing.T, mgr *manager) {
 			}
 		}
 	}
+}
+
+func TestValidateVolumeAttachments_ReservedVolumeID(t *testing.T) {
+	t.Parallel()
+	reserved := []VolumeAttachment{{
+		VolumeID:  "builder-disk-abc123",
+		MountPath: "/mnt/cache",
+	}}
+
+	err := validateVolumeAttachments(reserved, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved for internal use")
+
+	// Internal instances may attach reserved volumes.
+	err = validateVolumeAttachments(reserved, true)
+	assert.NoError(t, err)
+
+	// Ordinary volumes remain attachable without the internal opt-in.
+	err = validateVolumeAttachments([]VolumeAttachment{{
+		VolumeID:  "builder-disks",
+		MountPath: "/mnt/data",
+	}}, false)
+	assert.NoError(t, err)
 }

--- a/lib/instances/resource_limits_test.go
+++ b/lib/instances/resource_limits_test.go
@@ -252,3 +252,29 @@ func TestValidateVolumeAttachments_ReservedVolumeID(t *testing.T) {
 	}}, false)
 	assert.NoError(t, err)
 }
+
+func TestValidateVolumeAttachments_BuildkitRootSystemPath(t *testing.T) {
+	t.Parallel()
+	// The BuildKit root volume in builder VMs mounts at a fixed path under
+	// /var and is allowed only for internal instances that opt in.
+	buildkitRoot := []VolumeAttachment{{
+		VolumeID:  "builder-disk-abc123",
+		MountPath: "/var/lib/buildkit",
+	}}
+
+	err := validateVolumeAttachments(buildkitRoot, true)
+	assert.NoError(t, err)
+
+	err = validateVolumeAttachments(buildkitRoot, false)
+	assert.Error(t, err, "system mount path rejected without AllowSystemVolumeMounts")
+
+	// Parent paths and other /var subdirectories remain rejected even for
+	// internal instances.
+	for _, path := range []string{"/var", "/var/lib", "/var/lib/buildkit/nested", "/var/log"} {
+		err := validateVolumeAttachments([]VolumeAttachment{{
+			VolumeID:  "builder-disk-abc123",
+			MountPath: path,
+		}}, true)
+		assert.Error(t, err, "expected %q to be rejected", path)
+	}
+}

--- a/lib/instances/resource_limits_test.go
+++ b/lib/instances/resource_limits_test.go
@@ -253,28 +253,27 @@ func TestValidateVolumeAttachments_ReservedVolumeID(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestValidateVolumeAttachments_BuildkitRootSystemPath(t *testing.T) {
+func TestValidateVolumeAttachments_AllowedInternalSystemPath(t *testing.T) {
 	t.Parallel()
-	// The BuildKit root volume in builder VMs mounts at a fixed path under
-	// /var and is allowed only for internal instances that opt in.
-	buildkitRoot := []VolumeAttachment{{
+	allowedPath := "/var/lib/internal-cache"
+	internalVolume := []VolumeAttachment{{
 		VolumeID:  "builder-disk-abc123",
-		MountPath: "/var/lib/buildkit",
+		MountPath: allowedPath,
 	}}
 
-	err := validateVolumeAttachments(buildkitRoot, true)
+	err := validateVolumeAttachmentsWithSystemPaths(internalVolume, true, []string{allowedPath})
 	assert.NoError(t, err)
 
-	err = validateVolumeAttachments(buildkitRoot, false)
+	err = validateVolumeAttachmentsWithSystemPaths(internalVolume, false, []string{allowedPath})
 	assert.Error(t, err, "system mount path rejected without AllowSystemVolumeMounts")
 
 	// Parent paths and other /var subdirectories remain rejected even for
 	// internal instances.
-	for _, path := range []string{"/var", "/var/lib", "/var/lib/buildkit/nested", "/var/log"} {
-		err := validateVolumeAttachments([]VolumeAttachment{{
+	for _, path := range []string{"/var", "/var/lib", allowedPath + "/nested", "/var/log"} {
+		err := validateVolumeAttachmentsWithSystemPaths([]VolumeAttachment{{
 			VolumeID:  "builder-disk-abc123",
 			MountPath: path,
-		}}, true)
+		}}, true, []string{allowedPath})
 		assert.Error(t, err, "expected %q to be rejected", path)
 	}
 }

--- a/lib/instances/types.go
+++ b/lib/instances/types.go
@@ -274,6 +274,7 @@ type CreateInstanceRequest struct {
 	AutoStandby              *autostandby.Policy         // Optional automatic standby policy
 	HealthCheck              *healthcheck.Policy         // Optional workload health check policy
 	RestartPolicy            *restartpolicy.Policy       // Optional whole-instance restart policy
+	AllowSystemVolumeMounts  bool                        // Internal only: permits attaching reserved system volumes. Never populated from API requests.
 }
 
 // StartInstanceRequest is the domain request for starting a stopped instance

--- a/lib/instances/types.go
+++ b/lib/instances/types.go
@@ -275,6 +275,7 @@ type CreateInstanceRequest struct {
 	HealthCheck              *healthcheck.Policy         // Optional workload health check policy
 	RestartPolicy            *restartpolicy.Policy       // Optional whole-instance restart policy
 	AllowSystemVolumeMounts  bool                        // Internal only: permits attaching reserved system volumes. Never populated from API requests.
+	SystemVolumeMountPaths   []string                    // Internal only: exact system paths reserved volumes may mount at.
 }
 
 // StartInstanceRequest is the domain request for starting a stopped instance

--- a/lib/paths/paths.go
+++ b/lib/paths/paths.go
@@ -373,6 +373,23 @@ func (p *Paths) IngressMetadata(id string) string {
 	return filepath.Join(p.IngressesDir(), id+".json")
 }
 
+// Builder path methods
+
+// BuildersDir returns the root builders directory.
+func (p *Paths) BuildersDir() string {
+	return filepath.Join(p.dataDir, "builders")
+}
+
+// BuilderDir returns the directory for a specific builder.
+func (p *Paths) BuilderDir(id string) string {
+	return filepath.Join(p.BuildersDir(), id)
+}
+
+// BuilderMetadata returns the path to builder metadata.json.
+func (p *Paths) BuilderMetadata(id string) string {
+	return filepath.Join(p.BuilderDir(id), "metadata.json")
+}
+
 // Build path methods
 
 // BuildsDir returns the root builds directory.

--- a/lib/scopes/README.md
+++ b/lib/scopes/README.md
@@ -52,6 +52,14 @@ Scopes follow the pattern `resource:action`. Each resource type supports `read`,
 | `build:write` | Create builds |
 | `build:delete` | Cancel/delete builds |
 
+### Builders
+
+| Scope | Grants access to |
+|---|---|
+| `builder:read` | List builders, get builder details |
+| `builder:write` | Create builders, prune builder cache disks |
+| `builder:delete` | Delete builders |
+
 ### Devices
 
 | Scope | Grants access to |

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -43,6 +43,11 @@ const (
 	BuildWrite  Scope = "build:write"  // create
 	BuildDelete Scope = "build:delete" // cancel
 
+	// Builder scopes
+	BuilderRead   Scope = "builder:read"
+	BuilderWrite  Scope = "builder:write" // create, prune
+	BuilderDelete Scope = "builder:delete"
+
 	// Device scopes
 	DeviceRead   Scope = "device:read"
 	DeviceWrite  Scope = "device:write"  // register
@@ -68,6 +73,7 @@ var allScopes = []Scope{
 	VolumeRead, VolumeWrite, VolumeDelete,
 	SnapshotRead, SnapshotWrite, SnapshotDelete,
 	BuildRead, BuildWrite, BuildDelete,
+	BuilderRead, BuilderWrite, BuilderDelete,
 	DeviceRead, DeviceWrite, DeviceDelete,
 	IngressRead, IngressWrite, IngressDelete,
 	ResourceRead, ResourceWrite,

--- a/lib/volumes/reserved.go
+++ b/lib/volumes/reserved.go
@@ -1,0 +1,36 @@
+package volumes
+
+import "strings"
+
+// SystemTagNamespace prefixes tag keys reserved for internal use. Public
+// volume APIs reject caller-supplied tags in this namespace so callers
+// cannot spoof ownership markers that internal managers rely on.
+const SystemTagNamespace = "hypeman.system/"
+
+// reservedVolumeIDPrefixes are volume ID prefixes reserved for volumes that
+// internal managers create. Public volume APIs reject caller-supplied IDs
+// with these prefixes so a caller cannot squat on or tamper with an
+// internal volume.
+var reservedVolumeIDPrefixes = []string{
+	"builder-disk-",
+}
+
+// ReservedVolumeIDPrefix returns the reserved internal prefix id starts
+// with, or "" when id is usable by API callers.
+func ReservedVolumeIDPrefix(id string) string {
+	for _, p := range reservedVolumeIDPrefixes {
+		if strings.HasPrefix(id, p) {
+			return p
+		}
+	}
+	return ""
+}
+
+// ReservedTagNamespace returns the reserved internal namespace key starts
+// with, or "" when key is usable by API callers.
+func ReservedTagNamespace(key string) string {
+	if strings.HasPrefix(key, SystemTagNamespace) {
+		return SystemTagNamespace
+	}
+	return ""
+}


### PR DESCRIPTION
Introduce lib/builders: a Builder is a first-class resource and the unit
of build-cache isolation. Each builder owns one persistent ext4
sparse-file volume (builder-disk-<id>, tagged hypeman.system/managed-by=
builder) provisioned eagerly at create and later attached by disposable
builder VMs at /var/lib/buildkit.

The manager provides Create/Get/List/Delete, an internal
AcquireForBuild/ReleaseBuild seam (one build at a time per builder), and
ResetDisk for pruning. Status (ready, pruning, deleting, error) is
persisted before side effects so interrupted deletes and prunes are
resumed by startup reconciliation, which also recreates missing disks
(best-effort, empty) and clears stale disk attachments: records whose
instance is gone are detached, records backed by a surviving stale VM are
cleared by deleting that VM and re-fetching the volume. Delete and prune
return ErrInUse while a builder is acquired, attached, or mid-transition.
AcquireForBuild clears stale disk attachments itself: an attachment on an
unheld, ready builder can only be a leaked record or a stale VM from a
crashed build, so the next build self-heals instead of failing until a
restart runs reconciliation. Config covers max_count, default/max disk
size, and an idle TTL reaper that is destructive and disabled by default.

Public volume APIs now reject caller-supplied IDs with the reserved
builder-disk- prefix and tags in the hypeman.system/ namespace on both
create paths, reject deletion of reserved disks, and instance creation
rejects attaching reserved volumes unless the internal
AllowSystemVolumeMounts opt-in is set (never populated from API
requests). Add builder:read/write/delete scope constants and docs.

Tests cover CRUD, quotas and disk-size validation, failed-create cleanup,
restart loading, corrupt metadata reporting, exclusivity, last_used stamping,
lazy disk recreation, deterministic prune acceptance, reconciliation of
missing disks/orphan attachments/stale instances/interrupted transitions,
stale-attachment clearing at acquire (including loud failure), and the idle
reaper through the shared delete path.

### Follow-up (not blocking)

Individual create, acquire, delete, and reset transitions still hold the single manager mutex across volume I/O to avoid ownership races. Idle reaping no longer holds it across the full scan and delegates deletion to the shared crash-safe path. Follow-up: replace the global transition lock with per-builder locks if cross-builder disk I/O becomes a throughput bottleneck.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new domain with reconciliation that can delete stale instances and irreversibly reap idle builders; volume/instance guardrails reduce spoofing risk but internal attach paths must stay API-inaccessible.
> 
> **Overview**
> Introduces **Builder** as a first-class resource in `lib/builders`: each builder gets an eagerly provisioned persistent disk (`builder-disk-<id>`), CRUD plus **AcquireForBuild** / **ReleaseBuild** (one build at a time), **ResetDisk** (async prune), startup **reconciliation** for interrupted deletes/prunes/missing disks, stale attachment cleanup (including deleting stale builder VMs), and an optional **idle TTL reaper**. Status transitions are persisted before side effects so crashes are recoverable.
> 
> **Public API hardening:** volume create (including from archive) rejects reserved `builder-disk-` IDs and `hypeman.system/` tag keys; delete rejects reserved disks. Instance volume validation blocks attaching reserved volumes unless internal **AllowSystemVolumeMounts** / **SystemVolumeMountPaths** are set (not exposed on the API). Adds `builder:read|write|delete` scopes and builder metadata paths under `dataDir/builders/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae855e8b0e06bc0dd0043f64510717e22f4b1ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->