### PR TITLE
Prune stale CI prewarm initrds

### DIFF
--- a/cmd/test-prewarm/main.go
+++ b/cmd/test-prewarm/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -23,8 +24,9 @@ import (
 )
 
 const (
-	defaultRegistry = "127.0.0.1:5001"
-	registryName    = "hypeman-ci-registry"
+	defaultRegistry      = "127.0.0.1:5001"
+	registryName         = "hypeman-ci-registry"
+	initrdBuildRetention = 2 * time.Hour
 )
 
 // prewarmImage is a source image to mirror into the local registry. Platform
@@ -154,6 +156,13 @@ func main() {
 	if err != nil {
 		fatalf("hash initrd: %v", err)
 	}
+	pruned, err := pruneOldInitrdBuilds(initrdPath, time.Now().Add(-initrdBuildRetention))
+	if err != nil {
+		fatalf("prune old initrd builds: %v", err)
+	}
+	if pruned > 0 {
+		fmt.Printf("pruned old initrd builds count=%d retention=%s\n", pruned, initrdBuildRetention)
+	}
 
 	manifest.System.KernelVersion = string(system.DefaultKernelVersion)
 	manifest.System.Arch = system.GetArch()
@@ -167,6 +176,44 @@ func main() {
 		fatalf("write manifest: %v", err)
 	}
 	fmt.Printf("prewarm complete manifest=%s\n", manifestPath)
+}
+
+func pruneOldInitrdBuilds(initrdPath string, cutoff time.Time) (int, error) {
+	currentBuild := filepath.Base(filepath.Dir(initrdPath))
+	initrdDir := filepath.Dir(filepath.Dir(initrdPath))
+	latestTarget, err := os.Readlink(filepath.Join(initrdDir, "latest"))
+	if err != nil {
+		return 0, fmt.Errorf("read latest initrd: %w", err)
+	}
+	latestBuild := filepath.Base(filepath.Clean(latestTarget))
+
+	entries, err := os.ReadDir(initrdDir)
+	if err != nil {
+		return 0, fmt.Errorf("read initrd builds: %w", err)
+	}
+
+	pruned := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || name == currentBuild || name == latestBuild {
+			continue
+		}
+		if _, err := strconv.ParseInt(name, 10, 64); err != nil {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return pruned, fmt.Errorf("stat initrd build %s: %w", name, err)
+		}
+		if !info.ModTime().Before(cutoff) {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(initrdDir, name)); err != nil {
+			return pruned, fmt.Errorf("remove initrd build %s: %w", name, err)
+		}
+		pruned++
+	}
+	return pruned, nil
 }
 
 func ensureMirroredImage(ctx context.Context, inspector *images.OCIClient, registry string, img prewarmImage) (manifestImage, error) {

--- a/cmd/test-prewarm/main_test.go
+++ b/cmd/test-prewarm/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPruneOldInitrdBuilds(t *testing.T) {
+	initrdDir := filepath.Join(t.TempDir(), "system", "initrd", "x86_64")
+	cutoff := time.Now().Add(-2 * time.Hour)
+
+	createBuild := func(name string, modTime time.Time) string {
+		t.Helper()
+		buildDir := filepath.Join(initrdDir, name)
+		if err := os.MkdirAll(buildDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		initrdPath := filepath.Join(buildDir, "initrd")
+		if err := os.WriteFile(initrdPath, []byte("initrd"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(buildDir, modTime, modTime); err != nil {
+			t.Fatal(err)
+		}
+		return initrdPath
+	}
+
+	oldBuild := createBuild("100", cutoff.Add(-time.Hour))
+	currentBuild := createBuild("200", cutoff.Add(-time.Hour))
+	latestBuild := createBuild("300", cutoff.Add(-time.Hour))
+	recentBuild := createBuild("400", cutoff.Add(time.Hour))
+	nonnumericBuild := createBuild("manual", cutoff.Add(-time.Hour))
+	if err := os.Symlink(filepath.Base(filepath.Dir(latestBuild)), filepath.Join(initrdDir, "latest")); err != nil {
+		t.Fatal(err)
+	}
+
+	pruned, err := pruneOldInitrdBuilds(currentBuild, cutoff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pruned != 1 {
+		t.Fatalf("pruned %d builds, want 1", pruned)
+	}
+	if _, err := os.Stat(oldBuild); !os.IsNotExist(err) {
+		t.Fatalf("old build still exists: %v", err)
+	}
+	for _, path := range []string{currentBuild, latestBuild, recentBuild, nonnumericBuild} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected %s to remain: %v", path, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- prune timestamped CI prewarm initrd builds older than two hours
- preserve the current build, the `latest` target, recent builds, and non-build directories
- cover the retention behavior with an isolated filesystem test

The shared prewarm cache retained every initrd variation indefinitely. Keeping a two-hour window protects active test runs while bounding persistent disk usage.

## Testing

- `go test -count=1 ./cmd/test-prewarm`
- `go vet ./cmd/test-prewarm`
- `go test ./lib/system` could not complete because Docker Hub rejected an unauthenticated Alpine pull with its rate limit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CI prewarm cache cleanup with explicit safeguards; no production runtime or auth paths touched.
> 
> **Overview**
> Adds **automatic cleanup** of timestamped initrd build directories in the shared CI prewarm cache so disk use does not grow without bound.
> 
> After system files are prepared, `test-prewarm` calls **`pruneOldInitrdBuilds`** with a **2-hour** retention window. It removes numeric build dirs older than the cutoff while **keeping** the build in use, the **`latest`** symlink target, builds newer than the cutoff, and non-numeric dirs (e.g. `manual`).
> 
> A filesystem unit test in **`main_test.go`** asserts only the expected stale build is deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c7ce840122d8f7b0eaf9a2831a4095b34d8d9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->