### PR TITLE
Update CloudFormation quickstart to v0.3.0

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -42,7 +42,7 @@ curl -fsSL https://get.hypeman.sh/cli | bash
 
 mkdir -p ~/.config/hypeman
 cat > ~/.config/hypeman/cli.yaml <<EOF
-base_url: http://<public-ip>:8080
+base_url: http://<public-ip>:4973
 api_key: "<jwt-from-hypeman-create-token>"
 EOF
 
@@ -92,11 +92,11 @@ https://kernel-hypeman-cloudformation-prod.s3.us-east-1.amazonaws.com/v1/hypeman
 | --- | --- |
 | Region | `us-east-1` |
 | Instance type | `c8i.2xlarge` |
-| Hypeman API port | `8080` |
+| Hypeman API and internal registry port | `4973` |
 | Admin access | AWS Systems Manager Session Manager |
 | SSH | Disabled unless explicitly enabled |
 | Root volume | 30 GiB encrypted EBS |
 | Hypeman data volume | 100 GiB encrypted EBS, formatted XFS at `/var/lib/hypeman` |
-| Hypeman version | Latest release with a matching artifact |
+| Hypeman version | `v0.3.0` |
 
 The deployment expects an Intel C8i, M8i, or R8i instance type with EC2 nested virtualization support.

--- a/deploy/aws/cloudformation/template.yaml
+++ b/deploy/aws/cloudformation/template.yaml
@@ -94,10 +94,10 @@ Parameters:
     AllowedPattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/([0-9]|[1-2][0-9]|3[0-2])$"
   ApiPort:
     Type: Number
-    Default: 8080
+    Default: 4973
     MinValue: 1
     MaxValue: 65535
-    Description: Hypeman API port exposed to AllowedApiCidr.
+    Description: Hypeman API and internal registry port exposed to AllowedApiCidr.
   EnableHttpIngress:
     Type: String
     Default: "false"
@@ -151,7 +151,7 @@ Parameters:
     Description: Optional provisioned throughput in MiB/s for the Hypeman data gp3 EBS volume. When set, Hypeman disk I/O capacity is configured to the same value.
   HypemanVersion:
     Type: String
-    Default: latest
+    Default: v0.3.0
     Description: Hypeman API release tag, or latest. Ignored when HypemanBranch is set.
   HypemanBranch:
     Type: String
@@ -511,15 +511,17 @@ Resources:
           fi
           curl -fsSL https://raw.githubusercontent.com/kernel/hypeman/main/scripts/install.sh | bash
 
-          if [ -n "${DataVolumeThroughput}" ]; then
-            install -d -m 755 /etc/systemd/system/hypeman.service.d
-            cat >/etc/systemd/system/hypeman.service.d/disk-io-capacity.conf <<EOF
+          install -d -m 755 /etc/systemd/system/hypeman.service.d
+          cat >/etc/systemd/system/hypeman.service.d/cloudformation.conf <<EOF
           [Service]
-          Environment="CAPACITY__DISK_IO=${DataVolumeThroughput}MB/s"
+          Environment="PORT=${ApiPort}"
+          Environment="REGISTRY__URL=localhost:${ApiPort}"
           EOF
-            systemctl daemon-reload
-            systemctl restart hypeman
+          if [ -n "${DataVolumeThroughput}" ]; then
+            echo 'Environment="CAPACITY__DISK_IO=${DataVolumeThroughput}MB/s"' >>/etc/systemd/system/hypeman.service.d/cloudformation.conf
           fi
+          systemctl daemon-reload
+          systemctl restart hypeman
 
           install -d -m 755 /opt/hypeman/deploy
           cat >/usr/local/bin/hypeman-create-token <<'SCRIPT'

--- a/deploy/aws/cloudformation/template_test.go
+++ b/deploy/aws/cloudformation/template_test.go
@@ -15,7 +15,7 @@ func TestQuickstartParameters(t *testing.T) {
 	parameters := requireMapping(t, requireField(t, root, "Parameters"))
 	assertDefault(t, parameters, "InstanceType", "c8i.2xlarge")
 	assertDefault(t, parameters, "AllowedApiCidr", "127.0.0.1/32")
-	assertDefault(t, parameters, "ApiPort", "8080")
+	assertDefault(t, parameters, "ApiPort", "4973")
 	assertDefault(t, parameters, "EnableHttpIngress", "false")
 	assertDefault(t, parameters, "EnableHttpsIngress", "false")
 	assertDefault(t, parameters, "AllowedIngressCidr", "127.0.0.1/32")
@@ -25,7 +25,7 @@ func TestQuickstartParameters(t *testing.T) {
 	assertDefault(t, parameters, "DataVolumeSize", "100")
 	assertDefault(t, parameters, "DataVolumeIops", "")
 	assertDefault(t, parameters, "DataVolumeThroughput", "")
-	assertDefault(t, parameters, "HypemanVersion", "latest")
+	assertDefault(t, parameters, "HypemanVersion", "v0.3.0")
 	assertDefault(t, parameters, "HypemanCliVersion", "latest")
 
 	instanceType := requireMapping(t, parameters["InstanceType"])
@@ -53,6 +53,31 @@ func TestQuickstartParameters(t *testing.T) {
 			t.Fatalf("missing CloudFormation parameter group %q", name)
 		}
 	}
+}
+
+func TestApiPortContract(t *testing.T) {
+	template := loadTemplate(t)
+	root := requireMapping(t, template)
+	resources := requireMapping(t, requireField(t, root, "Resources"))
+
+	securityGroup := requireMapping(t, requireField(t, resources, "HypemanSecurityGroup"))
+	sgProperties := requireMapping(t, requireField(t, securityGroup, "Properties"))
+	apiIngress := requireMapping(t, requireSequence(t, requireField(t, sgProperties, "SecurityGroupIngress")).Content[0])
+	assertRef(t, requireField(t, apiIngress, "FromPort"), "ApiPort")
+	assertRef(t, requireField(t, apiIngress, "ToPort"), "ApiPort")
+
+	host := requireMapping(t, requireField(t, resources, "HypemanHost"))
+	userData := nodeText(requireField(t, requireMapping(t, requireField(t, host, "Properties")), "UserData"))
+	assertContains(t, userData, `Environment="PORT=${ApiPort}"`)
+	assertContains(t, userData, `Environment="REGISTRY__URL=localhost:${ApiPort}"`)
+	assertContains(t, userData, "base_url: http://localhost:${ApiPort}")
+	assertContains(t, userData, "http://127.0.0.1:${ApiPort}/health")
+
+	outputs := requireMapping(t, requireField(t, root, "Outputs"))
+	endpoint := requireMapping(t, requireField(t, outputs, "HypemanEndpoint"))
+	endpointSub := requireSequence(t, requireField(t, endpoint, "Value"))
+	endpointVariables := requireMapping(t, endpointSub.Content[1])
+	assertRef(t, requireField(t, endpointVariables, "Port"), "ApiPort")
 }
 
 func TestCloudFormationLaunchContract(t *testing.T) {


### PR DESCRIPTION
## Summary

- pin the AWS CloudFormation quickstart to Hypeman API v0.3.0
- use port 4973 for the API, internal registry, security group, CLI config, endpoint output, and health validation
- document and test the published quickstart defaults

## Tests

- `go test ./deploy/aws/cloudformation`
- `bash -n scripts/install.sh scripts/e2e-install-test.sh`
- `uvx cfn-lint deploy/aws/cloudformation/template.yaml`
- `git diff --check origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes published deployment defaults (port and release pin) and bootstrap systemd behavior; misconfiguration could break remote API/registry access for new stacks, but scope is limited to deploy assets and tests.
> 
> **Overview**
> Updates the **AWS CloudFormation quickstart** defaults for Hypeman **v0.3.0**, where the API and internal registry share **port 4973** instead of **8080**.
> 
> **`ApiPort`** defaults to **4973** everywhere it matters: security group ingress, **`HypemanEndpoint`**, local CLI config, health checks, and docs. **`HypemanVersion`** is pinned to **`v0.3.0`** instead of **`latest`**.
> 
> Instance bootstrap now **always** drops a **`cloudformation.conf`** systemd override setting **`PORT`** and **`REGISTRY__URL=localhost:${ApiPort}`**, optionally appends disk I/O capacity when throughput is set, then **reloads and restarts** Hypeman (previously the override and restart only ran when throughput was configured).
> 
> Tests add **`TestApiPortContract`** and refresh expected parameter defaults in **`deploy/README.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 310945cb2f86a7cbd5f7a1773a58a81e059900fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->