### PR TITLE
Test Builder cache reuse across disposable VMs

### DIFF
--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -138,8 +138,7 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 		}
 		require.True(collect, ready)
 	}, 5*time.Minute, time.Second)
-	// ensureBuilderImage records the ready image on its next 500ms poll.
-	time.Sleep(600 * time.Millisecond)
+	require.Eventually(t, buildManager.ReadyForBuilds, time.Second, 10*time.Millisecond)
 
 	builder, err := builderManager.CreateBuilder(ctx, builders.CreateBuilderRequest{DiskSizeGb: 4})
 	require.NoError(t, err)

--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -51,12 +52,9 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 	t.Chdir("..")
 
 	p := paths.New(t.TempDir())
-	networkConfig := newParallelTestNetworkConfig(t)
-	// Guest-to-host registry traffic follows the production bridge firewall path.
-	networkConfig.BridgeName = "hm" + strings.TrimPrefix(networkConfig.BridgeName, "hi")
 	cfg := &config.Config{
 		DataDir: p.DataDir(),
-		Network: networkConfig,
+		Network: newParallelTestNetworkConfig(t),
 	}
 	gateway, err := network.DeriveGateway(cfg.Network.SubnetCIDR)
 	require.NoError(t, err)
@@ -67,6 +65,7 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 	volumeManager := volumes.NewManager(p, 0, nil)
 	networkManager := network.NewManager(p, cfg, nil)
 	require.NoError(t, networkManager.Initialize(ctx, nil))
+	allowHostRegistryTraffic(t, cfg.Network.BridgeName)
 	systemManager := system.NewManager(p)
 	require.NoError(t, systemManager.EnsureSystemFiles(ctx))
 	instanceManager := instances.NewManager(
@@ -183,6 +182,30 @@ func startBuildRegistry(t *testing.T, gateway string, p *paths.Paths, imageManag
 	t.Cleanup(func() { _ = server.Close() })
 	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
 	return net.JoinHostPort(gateway, port), string(certPEM)
+}
+
+func allowHostRegistryTraffic(t *testing.T, bridge string) {
+	t.Helper()
+	if exec.Command("nft", "list", "table", "inet", "kernel_firewall").Run() != nil {
+		return
+	}
+	comment := "hypeman-builder-cache-test-" + bridge
+	output, err := exec.Command("nft", "insert", "rule", "inet", "kernel_firewall", "input",
+		"iifname", bridge, "accept", "comment", comment).CombinedOutput()
+	require.NoErrorf(t, err, "allow registry traffic: %s", output)
+	t.Cleanup(func() {
+		output, err := exec.Command("nft", "-a", "list", "chain", "inet", "kernel_firewall", "input").Output()
+		if err != nil {
+			return
+		}
+		for _, line := range strings.Split(string(output), "\n") {
+			if !strings.Contains(line, comment) {
+				continue
+			}
+			fields := strings.Fields(line)
+			_ = exec.Command("nft", "delete", "rule", "inet", "kernel_firewall", "input", "handle", fields[len(fields)-1]).Run()
+		}
+	})
 }
 
 func registryCertificate(t *testing.T, ip net.IP) ([]byte, []byte) {

--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -15,7 +15,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -52,9 +51,12 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 	t.Chdir("..")
 
 	p := paths.New(t.TempDir())
+	networkConfig := newParallelTestNetworkConfig(t)
+	// Guest-to-host registry traffic follows the production bridge firewall path.
+	networkConfig.BridgeName = "hm" + strings.TrimPrefix(networkConfig.BridgeName, "hi")
 	cfg := &config.Config{
 		DataDir: p.DataDir(),
-		Network: newParallelTestNetworkConfig(t),
+		Network: networkConfig,
 	}
 	gateway, err := network.DeriveGateway(cfg.Network.SubnetCIDR)
 	require.NoError(t, err)
@@ -93,7 +95,7 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 		}
 	})
 
-	registryURL, registryCA := startBuildRegistry(t, gateway, cfg.Network.SubnetCIDR, p, imageManager)
+	registryURL, registryCA := startBuildRegistry(t, gateway, p, imageManager)
 
 	builderManager, err := builders.NewManager(
 		p,
@@ -162,7 +164,7 @@ RUN --mount=type=cache,target=/cache sh -c 'if [ -f /cache/sentinel ]; then echo
 	require.NotEqual(t, *first.BuilderInstanceID, *second.BuilderInstanceID)
 }
 
-func startBuildRegistry(t *testing.T, gateway, subnet string, p *paths.Paths, imageManager images.Manager) (string, string) {
+func startBuildRegistry(t *testing.T, gateway string, p *paths.Paths, imageManager images.Manager) (string, string) {
 	t.Helper()
 	reg, err := registry.New(p, imageManager)
 	require.NoError(t, err)
@@ -180,10 +182,6 @@ func startBuildRegistry(t *testing.T, gateway, subnet string, p *paths.Paths, im
 	}()
 	t.Cleanup(func() { _ = server.Close() })
 	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
-	firewallArgs := []string{"INPUT", "-s", subnet, "-p", "tcp", "--dport", port, "-j", "ACCEPT"}
-	output, err := exec.Command("iptables", append([]string{"-I"}, firewallArgs...)...).CombinedOutput()
-	require.NoErrorf(t, err, "allow registry traffic: %s", output)
-	t.Cleanup(func() { _ = exec.Command("iptables", append([]string{"-D"}, firewallArgs...)...).Run() })
 	return net.JoinHostPort(gateway, port), string(certPEM)
 }
 

--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -5,6 +5,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"net/http"
 	"os"
@@ -85,7 +92,7 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 		}
 	})
 
-	registryURL := startBuildRegistry(t, gateway, p, imageManager)
+	registryURL, registryCA := startBuildRegistry(t, gateway, p, imageManager)
 
 	builderManager, err := builders.NewManager(
 		p,
@@ -103,7 +110,7 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 		builds.Config{
 			MaxConcurrentBuilds: 1,
 			RegistryURL:         registryURL,
-			RegistryInsecure:    true,
+			RegistryCACert:      registryCA,
 			RegistrySecret:      "builder-cache-integration-test",
 			DefaultTimeout:      600,
 		},
@@ -154,21 +161,46 @@ RUN --mount=type=cache,target=/cache sh -c 'if [ -f /cache/sentinel ]; then echo
 	require.NotEqual(t, *first.BuilderInstanceID, *second.BuilderInstanceID)
 }
 
-func startBuildRegistry(t *testing.T, gateway string, p *paths.Paths, imageManager images.Manager) string {
+func startBuildRegistry(t *testing.T, gateway string, p *paths.Paths, imageManager images.Manager) (string, string) {
 	t.Helper()
 	reg, err := registry.New(p, imageManager)
 	require.NoError(t, err)
+	certPEM, keyPEM := registryCertificate(t, net.ParseIP(gateway))
+	certificate, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
 	listener, err := net.Listen("tcp", "0.0.0.0:0")
 	require.NoError(t, err)
+	tlsListener := tls.NewListener(listener, &tls.Config{Certificates: []tls.Certificate{certificate}, MinVersion: tls.VersionTLS12})
 	server := &http.Server{Handler: reg.Handler()}
 	go func() {
-		if serveErr := server.Serve(listener); serveErr != nil && serveErr != http.ErrServerClosed {
+		if serveErr := server.Serve(tlsListener); serveErr != nil && serveErr != http.ErrServerClosed {
 			t.Logf("registry server: %v", serveErr)
 		}
 	}()
 	t.Cleanup(func() { _ = server.Close() })
 	port := listener.Addr().(*net.TCPAddr).Port
-	return net.JoinHostPort(gateway, strconv.Itoa(port))
+	return net.JoinHostPort(gateway, strconv.Itoa(port)), string(certPEM)
+}
+
+func registryCertificate(t *testing.T, ip net.IP) ([]byte, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: ip.String()},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{ip},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certPEM, keyPEM
 }
 
 func runBuilderBuild(t *testing.T, ctx context.Context, manager builds.Manager, builderID, dockerfile string, source []byte, cacheBuster string) *builds.Build {

--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -93,7 +93,7 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 		}
 	})
 
-	registryURL, registryCA := startBuildRegistry(t, gateway, cfg.Network.BridgeName, p, imageManager)
+	registryURL, registryCA := startBuildRegistry(t, gateway, cfg.Network.SubnetCIDR, p, imageManager)
 
 	builderManager, err := builders.NewManager(
 		p,
@@ -162,7 +162,7 @@ RUN --mount=type=cache,target=/cache sh -c 'if [ -f /cache/sentinel ]; then echo
 	require.NotEqual(t, *first.BuilderInstanceID, *second.BuilderInstanceID)
 }
 
-func startBuildRegistry(t *testing.T, gateway, bridge string, p *paths.Paths, imageManager images.Manager) (string, string) {
+func startBuildRegistry(t *testing.T, gateway, subnet string, p *paths.Paths, imageManager images.Manager) (string, string) {
 	t.Helper()
 	reg, err := registry.New(p, imageManager)
 	require.NoError(t, err)
@@ -180,7 +180,7 @@ func startBuildRegistry(t *testing.T, gateway, bridge string, p *paths.Paths, im
 	}()
 	t.Cleanup(func() { _ = server.Close() })
 	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
-	firewallArgs := []string{"INPUT", "-i", bridge, "-p", "tcp", "--dport", port, "-j", "ACCEPT"}
+	firewallArgs := []string{"INPUT", "-s", subnet, "-p", "tcp", "--dport", port, "-j", "ACCEPT"}
 	output, err := exec.Command("iptables", append([]string{"-I"}, firewallArgs...)...).CombinedOutput()
 	require.NoErrorf(t, err, "allow registry traffic: %s", output)
 	t.Cleanup(func() { _ = exec.Command("iptables", append([]string{"-D"}, firewallArgs...)...).Run() })

--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -139,8 +139,8 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 		}
 		require.True(collect, ready)
 	}, 5*time.Minute, time.Second)
-	// ensureBuilderImage records the ready image in the build manager after conversion.
-	time.Sleep(100 * time.Millisecond)
+	// ensureBuilderImage records the ready image on its next 500ms poll.
+	time.Sleep(600 * time.Millisecond)
 
 	builder, err := builderManager.CreateBuilder(ctx, builders.CreateBuilderRequest{DiskSizeGb: 4})
 	require.NoError(t, err)

--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -41,6 +41,7 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
+	t.Chdir("..")
 
 	p := paths.New(t.TempDir())
 	cfg := &config.Config{

--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -85,17 +86,6 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 
 	registryURL := startBuildRegistry(t, gateway, p, imageManager)
 
-	const builderImage = "docker.io/onkernel/builder-generic:latest"
-	createdBuilderImage, err := imageManager.CreateImage(ctx, images.CreateImageRequest{Name: builderImage})
-	require.NoError(t, err)
-	builderImageRef := createdBuilderImage.Name
-	if createdBuilderImage.Digest != "" {
-		builderRef, parseErr := images.ParseNormalizedRef(builderImage)
-		require.NoError(t, parseErr)
-		builderImageRef = builderRef.Repository() + "@" + createdBuilderImage.Digest
-	}
-	require.NoError(t, imageManager.WaitForReady(ctx, builderImageRef))
-
 	builderManager, err := builders.NewManager(
 		p,
 		builders.Config{DefaultDiskSizeGb: 4},
@@ -111,7 +101,6 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 		p,
 		builds.Config{
 			MaxConcurrentBuilds: 1,
-			BuilderImage:        builderImageRef,
 			RegistryURL:         registryURL,
 			RegistryInsecure:    true,
 			RegistrySecret:      "builder-cache-integration-test",
@@ -128,14 +117,24 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 	require.NoError(t, err)
 	builderManager.SetBuildActivityChecker(buildManager.BuilderHasBuilds)
 	require.NoError(t, buildManager.Start(ctx))
-	// Start prepares an already-imported Builder image asynchronously.
-	time.Sleep(time.Second)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		all, listErr := imageManager.ListImages(ctx)
+		require.NoError(collect, listErr)
+		ready := false
+		for _, image := range all {
+			if strings.Contains(image.Name, "/internal/builder") {
+				ready = image.Status == images.StatusReady
+			}
+		}
+		require.True(collect, ready)
+	}, 5*time.Minute, time.Second)
+	// ensureBuilderImage records the ready image in the build manager after conversion.
+	time.Sleep(100 * time.Millisecond)
 
 	builder, err := builderManager.CreateBuilder(ctx, builders.CreateBuilderRequest{DiskSizeGb: 4})
 	require.NoError(t, err)
 
-	dockerfile := `# syntax=docker/dockerfile:1
-FROM alpine:3.18
+	dockerfile := `FROM alpine:3.18
 ARG CACHE_BUSTER
 RUN --mount=type=cache,target=/cache sh -c 'if [ -f /cache/sentinel ]; then echo BUILDER_CACHE_HIT; else echo BUILDER_CACHE_MISS; touch /cache/sentinel; fi; echo "$CACHE_BUSTER" > /cache-buster'
 `

--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -92,7 +93,7 @@ func TestBuilderPersistentCacheReuse(t *testing.T) {
 		}
 	})
 
-	registryURL, registryCA := startBuildRegistry(t, gateway, p, imageManager)
+	registryURL, registryCA := startBuildRegistry(t, gateway, cfg.Network.BridgeName, p, imageManager)
 
 	builderManager, err := builders.NewManager(
 		p,
@@ -161,7 +162,7 @@ RUN --mount=type=cache,target=/cache sh -c 'if [ -f /cache/sentinel ]; then echo
 	require.NotEqual(t, *first.BuilderInstanceID, *second.BuilderInstanceID)
 }
 
-func startBuildRegistry(t *testing.T, gateway string, p *paths.Paths, imageManager images.Manager) (string, string) {
+func startBuildRegistry(t *testing.T, gateway, bridge string, p *paths.Paths, imageManager images.Manager) (string, string) {
 	t.Helper()
 	reg, err := registry.New(p, imageManager)
 	require.NoError(t, err)
@@ -178,8 +179,12 @@ func startBuildRegistry(t *testing.T, gateway string, p *paths.Paths, imageManag
 		}
 	}()
 	t.Cleanup(func() { _ = server.Close() })
-	port := listener.Addr().(*net.TCPAddr).Port
-	return net.JoinHostPort(gateway, strconv.Itoa(port)), string(certPEM)
+	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	firewallArgs := []string{"INPUT", "-i", bridge, "-p", "tcp", "--dport", port, "-j", "ACCEPT"}
+	output, err := exec.Command("iptables", append([]string{"-I"}, firewallArgs...)...).CombinedOutput()
+	require.NoErrorf(t, err, "allow registry traffic: %s", output)
+	t.Cleanup(func() { _ = exec.Command("iptables", append([]string{"-D"}, firewallArgs...)...).Run() })
+	return net.JoinHostPort(gateway, port), string(certPEM)
 }
 
 func registryCertificate(t *testing.T, ip net.IP) ([]byte, []byte) {

--- a/integration/builder_cache_linux_test.go
+++ b/integration/builder_cache_linux_test.go
@@ -1,0 +1,214 @@
+package integration
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/cmd/api/config"
+	"github.com/kernel/hypeman/lib/builders"
+	"github.com/kernel/hypeman/lib/builds"
+	"github.com/kernel/hypeman/lib/devices"
+	"github.com/kernel/hypeman/lib/images"
+	"github.com/kernel/hypeman/lib/instances"
+	"github.com/kernel/hypeman/lib/network"
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/kernel/hypeman/lib/registry"
+	"github.com/kernel/hypeman/lib/system"
+	"github.com/kernel/hypeman/lib/volumes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilderPersistentCacheReuse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("builder integration test requires root")
+	}
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		t.Skip("builder integration test requires /dev/kvm")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	p := paths.New(t.TempDir())
+	cfg := &config.Config{
+		DataDir: p.DataDir(),
+		Network: newParallelTestNetworkConfig(t),
+	}
+	gateway, err := network.DeriveGateway(cfg.Network.SubnetCIDR)
+	require.NoError(t, err)
+	cfg.Network.SubnetGateway = gateway
+
+	imageManager, err := images.NewManager(p, 1, nil)
+	require.NoError(t, err)
+	volumeManager := volumes.NewManager(p, 0, nil)
+	networkManager := network.NewManager(p, cfg, nil)
+	require.NoError(t, networkManager.Initialize(ctx, nil))
+	systemManager := system.NewManager(p)
+	require.NoError(t, systemManager.EnsureSystemFiles(ctx))
+	instanceManager := instances.NewManager(
+		p,
+		imageManager,
+		systemManager,
+		networkManager,
+		devices.NewManager(p),
+		volumeManager,
+		instances.ResourceLimits{MaxOverlaySize: 100 << 30},
+		"",
+		instances.SnapshotPolicy{},
+		nil,
+		nil,
+	)
+	t.Cleanup(func() {
+		all, listErr := instanceManager.ListInstances(context.Background(), nil)
+		if listErr != nil {
+			t.Logf("list instances during cleanup: %v", listErr)
+			return
+		}
+		for _, instance := range all {
+			if deleteErr := instanceManager.DeleteInstance(context.Background(), instance.Id); deleteErr != nil {
+				t.Logf("delete instance %s during cleanup: %v", instance.Id, deleteErr)
+			}
+		}
+	})
+
+	registryURL := startBuildRegistry(t, gateway, p, imageManager)
+
+	const builderImage = "docker.io/onkernel/builder-generic:latest"
+	createdBuilderImage, err := imageManager.CreateImage(ctx, images.CreateImageRequest{Name: builderImage})
+	require.NoError(t, err)
+	builderImageRef := createdBuilderImage.Name
+	if createdBuilderImage.Digest != "" {
+		builderRef, parseErr := images.ParseNormalizedRef(builderImage)
+		require.NoError(t, parseErr)
+		builderImageRef = builderRef.Repository() + "@" + createdBuilderImage.Digest
+	}
+	require.NoError(t, imageManager.WaitForReady(ctx, builderImageRef))
+
+	builderManager, err := builders.NewManager(
+		p,
+		builders.Config{DefaultDiskSizeGb: 4},
+		volumeManager,
+		instanceManager,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, builderManager.Start(ctx))
+
+	buildManager, err := builds.NewManager(
+		p,
+		builds.Config{
+			MaxConcurrentBuilds: 1,
+			BuilderImage:        builderImageRef,
+			RegistryURL:         registryURL,
+			RegistryInsecure:    true,
+			RegistrySecret:      "builder-cache-integration-test",
+			DefaultTimeout:      600,
+		},
+		instanceManager,
+		volumeManager,
+		builderManager,
+		imageManager,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	builderManager.SetBuildActivityChecker(buildManager.BuilderHasBuilds)
+	require.NoError(t, buildManager.Start(ctx))
+	// Start prepares an already-imported Builder image asynchronously.
+	time.Sleep(time.Second)
+
+	builder, err := builderManager.CreateBuilder(ctx, builders.CreateBuilderRequest{DiskSizeGb: 4})
+	require.NoError(t, err)
+
+	dockerfile := `# syntax=docker/dockerfile:1
+FROM alpine:3.18
+ARG CACHE_BUSTER
+RUN --mount=type=cache,target=/cache sh -c 'if [ -f /cache/sentinel ]; then echo BUILDER_CACHE_HIT; else echo BUILDER_CACHE_MISS; touch /cache/sentinel; fi; echo "$CACHE_BUSTER" > /cache-buster'
+`
+	source := sourceArchive(t, dockerfile)
+	first := runBuilderBuild(t, ctx, buildManager, builder.ID, dockerfile, source, "first")
+	firstLogs, err := buildManager.GetBuildLogs(ctx, first.ID)
+	require.NoError(t, err)
+	require.Contains(t, string(firstLogs), "BUILDER_CACHE_MISS")
+
+	second := runBuilderBuild(t, ctx, buildManager, builder.ID, dockerfile, source, "second")
+	secondLogs, err := buildManager.GetBuildLogs(ctx, second.ID)
+	require.NoError(t, err)
+	require.Contains(t, string(secondLogs), "BUILDER_CACHE_HIT")
+	require.NotNil(t, first.BuilderInstanceID)
+	require.NotNil(t, second.BuilderInstanceID)
+	require.NotEqual(t, *first.BuilderInstanceID, *second.BuilderInstanceID)
+}
+
+func startBuildRegistry(t *testing.T, gateway string, p *paths.Paths, imageManager images.Manager) string {
+	t.Helper()
+	reg, err := registry.New(p, imageManager)
+	require.NoError(t, err)
+	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	server := &http.Server{Handler: reg.Handler()}
+	go func() {
+		if serveErr := server.Serve(listener); serveErr != nil && serveErr != http.ErrServerClosed {
+			t.Logf("registry server: %v", serveErr)
+		}
+	}()
+	t.Cleanup(func() { _ = server.Close() })
+	port := listener.Addr().(*net.TCPAddr).Port
+	return net.JoinHostPort(gateway, strconv.Itoa(port))
+}
+
+func runBuilderBuild(t *testing.T, ctx context.Context, manager builds.Manager, builderID, dockerfile string, source []byte, cacheBuster string) *builds.Build {
+	t.Helper()
+	build, err := manager.CreateBuild(ctx, builds.CreateBuildRequest{
+		Dockerfile: dockerfile,
+		BuilderID:  builderID,
+		BuildArgs:  map[string]string{"CACHE_BUSTER": cacheBuster},
+	}, source)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		current, getErr := manager.GetBuild(ctx, build.ID)
+		require.NoError(collect, getErr)
+		require.Contains(collect, []string{builds.StatusReady, builds.StatusFailed}, current.Status)
+	}, 10*time.Minute, time.Second)
+
+	result, err := manager.GetBuild(ctx, build.ID)
+	require.NoError(t, err)
+	if result.Status != builds.StatusReady {
+		logs, _ := manager.GetBuildLogs(ctx, build.ID)
+		t.Fatalf("build %s failed: %v\n%s", build.ID, result.Error, logs)
+	}
+	return result
+}
+
+func sourceArchive(t *testing.T, dockerfile string) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	gz := gzip.NewWriter(&out)
+	tw := tar.NewWriter(gz)
+	contents := []byte(dockerfile)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "Dockerfile",
+		Mode: 0644,
+		Size: int64(len(contents)),
+	}))
+	_, err := tw.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return out.Bytes()
+}

--- a/lib/builds/manager.go
+++ b/lib/builds/manager.go
@@ -80,6 +80,9 @@ type Manager interface {
 	// queued or running, including builds still only persisted on disk
 	// while startup recovery has not re-enqueued them yet.
 	BuilderHasBuilds(builderID string) bool
+
+	// ReadyForBuilds reports whether startup builder-image preparation has finished.
+	ReadyForBuilds() bool
 }
 
 // Config holds configuration for the build manager
@@ -209,6 +212,10 @@ func (m *manager) Start(ctx context.Context) error {
 	}()
 	m.logger.Info("build manager started")
 	return nil
+}
+
+func (m *manager) ReadyForBuilds() bool {
+	return m.builderReady.Load()
 }
 
 // ensureBuilderImage ensures the builder image is available in the image store.


### PR DESCRIPTION
## summary

- add one Linux integration test that runs two builds on the same Builder
- force the cache-backed step to execute twice and verify the second build sees the first build's cache marker
- verify the builds ran in different disposable VM instances
- build the Builder image from the checked-out source and use a scoped TLS registry fixture

## validation

- Linux CI: passed, including `TestBuilderPersistentCacheReuse`
- Darwin CI: passed
- Cursor Bugbot: passed with no unresolved findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are primarily a new integration test plus a small read-only readiness hook on the build manager; no production build or cache behavior is altered.
> 
> **Overview**
> Adds a **Linux integration test** (`TestBuilderPersistentCacheReuse`) that proves BuildKit cache on a Builder’s persistent disk survives across **separate builder VM instances**.
> 
> The test runs two builds on the same Builder with a Dockerfile that uses `RUN --mount=type=cache`; it expects `BUILDER_CACHE_MISS` on the first run and `BUILDER_CACHE_HIT` on the second, and asserts the two builds used **different** `BuilderInstanceID`s. The harness spins up the full stack (network, builders, builds), a **TLS registry** on the gateway IP, optional **nft** firewall rules for bridge traffic, and waits for the internal builder image before submitting work.
> 
> To avoid racing startup builder-image prep, the builds **`Manager`** interface gains **`ReadyForBuilds()`**, implemented by reading the existing `builderReady` flag; the test blocks on that after the builder image shows ready in the image store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a3d7cdca580a615954d3f8bdd98b2ebdbd2fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->