### PR TITLE
Reseal SDK custom code on main

### DIFF
--- a/stainless/custom-code/go/2026-08-04T13-39-02-159Z-custom-code.json
+++ b/stainless/custom-code/go/2026-08-04T13-39-02-159Z-custom-code.json
@@ -1,6 +1,6 @@
 {
-  "base": "4d050c6b6fbd764ae241634ab784151a6cb10e2b",
-  "integrated": "34781268d670e1d79fb67d053530c589e31bf9c4",
+  "base": "e0a0352673317e2c4504a6fa0a6a75c15cc30988",
+  "integrated": "3d2b0a558b461ac7987d04c47f0df8456ff61141",
   "filename": "2026-08-04T13-39-02-159Z-custom-code.json",
   "branch": "main"
 }

--- a/stainless/custom-code/typescript/2026-08-04T13-39-02-159Z-custom-code.json
+++ b/stainless/custom-code/typescript/2026-08-04T13-39-02-159Z-custom-code.json
@@ -1,6 +1,6 @@
 {
-  "base": "3811cb44ff34805a42a6d16f82eeefd359f62d11",
-  "integrated": "df8400653e115ff397d85ea32d8da3b3b7a13682",
+  "base": "d2ecdf86095c1f7e23314e276788dc2af6b1a472",
+  "integrated": "ea0070252daa3e92800ee90f3747bc23658ae20a",
   "filename": "2026-08-04T13-39-02-159Z-custom-code.json",
   "branch": "main"
 }


### PR DESCRIPTION
## Summary

Updates the Go and TypeScript custom-code tracking files after reconciling the new staging repositories with their sealed SDK histories.

## Validation

- real `stlc build --no-lint` completed for Go and TypeScript
- Go bootstrap, lint, and tests passed
- TypeScript bootstrap, lint, build, and tests passed (377 passed, 88 skipped)
- both SDK worktrees were clean before the deterministic push build
- TypeScript pushed successfully to staging `main`; the prior generation failure was caused by the initial staging-history reconciliation