### PR TITLE
Return invalid request for macOS vGPU

### DIFF
--- a/cmd/api/api/instances_test.go
+++ b/cmd/api/api/instances_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/kernel/hypeman/lib/autostandby"
+	"github.com/kernel/hypeman/lib/devices"
 	"github.com/kernel/hypeman/lib/healthcheck"
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/images"
@@ -636,7 +637,7 @@ func TestInstanceToOAPI_OmitsPlatformWhenUnset(t *testing.T) {
 }
 
 // errCreateInstanceManager is a fake whose CreateInstance always fails with a
-// preset error, used to assert the handler maps typed image errors to statuses.
+// preset error, used to assert the handler maps typed errors to statuses.
 type errCreateInstanceManager struct {
 	instances.Manager
 	err error
@@ -650,10 +651,11 @@ func TestCreateInstance_ErrorStatusMapping(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		err      error
-		wantType any
-		wantCode string
+		name        string
+		err         error
+		wantType    any
+		wantCode    string
+		wantMessage string
 	}{
 		{
 			name:     "platform not available -> 404",
@@ -679,6 +681,13 @@ func TestCreateInstance_ErrorStatusMapping(t *testing.T) {
 			wantType: oapi.CreateInstance400JSONResponse{},
 			wantCode: "invalid_platform",
 		},
+		{
+			name:        "macOS vGPU unsupported -> 400",
+			err:         fmt.Errorf("%w: %w", instances.ErrInvalidRequest, devices.ErrVGPUNotSupportedOnMacOS),
+			wantType:    oapi.CreateInstance400JSONResponse{},
+			wantCode:    "invalid_request",
+			wantMessage: "invalid request: vGPU (mdev) is not supported on macOS",
+		},
 	}
 
 	for _, tc := range cases {
@@ -696,6 +705,10 @@ func TestCreateInstance_ErrorStatusMapping(t *testing.T) {
 			require.NoError(t, err)
 			require.IsType(t, tc.wantType, resp)
 			require.Equal(t, tc.wantCode, createInstanceErrorCodeOf(resp))
+			if tc.wantMessage != "" {
+				response := resp.(oapi.CreateInstance400JSONResponse)
+				require.Equal(t, tc.wantMessage, response.Message)
+			}
 		})
 	}
 }

--- a/lib/devices/capabilities.go
+++ b/lib/devices/capabilities.go
@@ -1,0 +1,7 @@
+package devices
+
+// HostCapabilities describes optional device features supported by the host platform.
+type HostCapabilities struct {
+	// SupportsVGPU indicates whether the platform supports mediated vGPU operations.
+	SupportsVGPU bool
+}

--- a/lib/devices/capabilities_darwin.go
+++ b/lib/devices/capabilities_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package devices
+
+// Capabilities returns the device features supported on macOS.
+func Capabilities() HostCapabilities {
+	return HostCapabilities{SupportsVGPU: false}
+}

--- a/lib/devices/capabilities_darwin_test.go
+++ b/lib/devices/capabilities_darwin_test.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package devices
+
+import "testing"
+
+func TestCapabilitiesDoesNotSupportVGPU(t *testing.T) {
+	t.Parallel()
+
+	if Capabilities().SupportsVGPU {
+		t.Fatal("macOS should not report vGPU support")
+	}
+}

--- a/lib/devices/capabilities_linux.go
+++ b/lib/devices/capabilities_linux.go
@@ -1,0 +1,8 @@
+//go:build linux
+
+package devices
+
+// Capabilities returns the device features supported on Linux.
+func Capabilities() HostCapabilities {
+	return HostCapabilities{SupportsVGPU: true}
+}

--- a/lib/devices/capabilities_linux_test.go
+++ b/lib/devices/capabilities_linux_test.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package devices
+
+import "testing"
+
+func TestCapabilitiesSupportsVGPU(t *testing.T) {
+	t.Parallel()
+
+	if !Capabilities().SupportsVGPU {
+		t.Fatal("Linux should report vGPU support")
+	}
+}

--- a/lib/devices/errors.go
+++ b/lib/devices/errors.go
@@ -35,4 +35,7 @@ var (
 
 	// ErrIOMMUGroupConflict is returned when not all devices in IOMMU group can be passed through
 	ErrIOMMUGroupConflict = errors.New("IOMMU group contains other devices that must also be passed through")
+
+	// ErrVGPUNotSupportedOnMacOS is returned for vGPU operations on macOS
+	ErrVGPUNotSupportedOnMacOS = errors.New("vGPU (mdev) is not supported on macOS")
 )

--- a/lib/devices/mdev_darwin.go
+++ b/lib/devices/mdev_darwin.go
@@ -2,13 +2,7 @@
 
 package devices
 
-import (
-	"context"
-	"fmt"
-)
-
-// ErrVGPUNotSupportedOnMacOS is returned for vGPU operations on macOS
-var ErrVGPUNotSupportedOnMacOS = fmt.Errorf("vGPU (mdev) is not supported on macOS")
+import "context"
 
 // SetGPUProfileCacheTTL is a no-op on macOS.
 func SetGPUProfileCacheTTL(ttl string) {

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -2,6 +2,7 @@ package instances
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -49,6 +50,13 @@ var systemDirectories = []string{
 	"/tmp",
 	"/usr",
 	"/var",
+}
+
+func wrapCreateMdevErr(profile string, err error) error {
+	if errors.Is(err, devices.ErrVGPUNotSupportedOnMacOS) {
+		return fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
+	return fmt.Errorf("create vGPU mdev for profile %s: %w", profile, err)
 }
 
 // generateVsockCID converts first 8 chars of instance ID to a unique CID
@@ -275,7 +283,7 @@ func (m *manager) createInstance(
 		mdev, err := devices.CreateMdev(ctx, req.GPU.Profile, id)
 		if err != nil {
 			log.ErrorContext(ctx, "failed to create mdev", "profile", req.GPU.Profile, "error", err)
-			return nil, fmt.Errorf("create vGPU mdev for profile %s: %w", req.GPU.Profile, err)
+			return nil, wrapCreateMdevErr(req.GPU.Profile, err)
 		}
 		gpuProfile = req.GPU.Profile
 		gpuMdevUUID = mdev.UUID

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -97,7 +96,7 @@ func (m *manager) createInstance(
 		log.ErrorContext(ctx, "invalid create request", "error", err)
 		return nil, err
 	}
-	if req.GPU != nil && req.GPU.Profile != "" && runtime.GOOS == "darwin" {
+	if req.GPU != nil && req.GPU.Profile != "" && !devices.Capabilities().SupportsVGPU {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidRequest, devices.ErrVGPUNotSupportedOnMacOS)
 	}
 	hvType := req.Hypervisor

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -95,6 +96,9 @@ func (m *manager) createInstance(
 	if err := validateCreateRequest(&req); err != nil {
 		log.ErrorContext(ctx, "invalid create request", "error", err)
 		return nil, err
+	}
+	if req.GPU != nil && req.GPU.Profile != "" && runtime.GOOS == "darwin" {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRequest, devices.ErrVGPUNotSupportedOnMacOS)
 	}
 	hvType := req.Hypervisor
 	if hvType == "" {

--- a/lib/instances/create_mdev_test.go
+++ b/lib/instances/create_mdev_test.go
@@ -1,12 +1,48 @@
 package instances
 
 import (
+	"context"
 	"errors"
+	"runtime"
 	"testing"
 
 	"github.com/kernel/hypeman/lib/devices"
 	"github.com/stretchr/testify/assert"
 )
+
+type recordingResourceValidator struct {
+	reserveCalls int
+}
+
+func (v *recordingResourceValidator) ValidateAllocation(context.Context, int, int64, int64, int64, int64, int64, bool) error {
+	return nil
+}
+
+func (v *recordingResourceValidator) ReserveAllocation(context.Context, string, int, int64, int64, int64, int64, int64, bool) error {
+	v.reserveCalls++
+	return nil
+}
+
+func (v *recordingResourceValidator) FinishAllocation(string) {}
+
+func TestCreateInstanceRejectsMacOSVGPUBeforeResourceReservation(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-specific validation")
+	}
+
+	validator := &recordingResourceValidator{}
+	m := &manager{resourceValidator: validator}
+
+	_, err := m.createInstance(context.Background(), CreateInstanceRequest{
+		Name:  "instance",
+		Image: "image",
+		GPU:   &GPUConfig{Profile: "profile"},
+	})
+
+	assert.ErrorIs(t, err, ErrInvalidRequest)
+	assert.ErrorIs(t, err, devices.ErrVGPUNotSupportedOnMacOS)
+	assert.Zero(t, validator.reserveCalls)
+}
 
 func TestWrapCreateMdevErr(t *testing.T) {
 	t.Parallel()

--- a/lib/instances/create_mdev_test.go
+++ b/lib/instances/create_mdev_test.go
@@ -3,7 +3,6 @@ package instances
 import (
 	"context"
 	"errors"
-	"runtime"
 	"testing"
 
 	"github.com/kernel/hypeman/lib/devices"
@@ -25,9 +24,11 @@ func (v *recordingResourceValidator) ReserveAllocation(context.Context, string, 
 
 func (v *recordingResourceValidator) FinishAllocation(string) {}
 
-func TestCreateInstanceRejectsMacOSVGPUBeforeResourceReservation(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("macOS-specific validation")
+func TestCreateInstanceRejectsUnsupportedVGPUBeforeResourceReservation(t *testing.T) {
+	t.Parallel()
+
+	if devices.Capabilities().SupportsVGPU {
+		t.Skip("host platform supports vGPU")
 	}
 
 	validator := &recordingResourceValidator{}

--- a/lib/instances/create_mdev_test.go
+++ b/lib/instances/create_mdev_test.go
@@ -1,0 +1,46 @@
+package instances
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kernel/hypeman/lib/devices"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapCreateMdevErr(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name               string
+		err                error
+		wantMessage        string
+		wantInvalidRequest bool
+	}{
+		{
+			name:               "macOS vGPU unsupported",
+			err:                devices.ErrVGPUNotSupportedOnMacOS,
+			wantMessage:        "invalid request: vGPU (mdev) is not supported on macOS",
+			wantInvalidRequest: true,
+		},
+		{
+			name:        "other mdev error",
+			err:         errors.New("boom"),
+			wantMessage: "create vGPU mdev for profile profile: boom",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := wrapCreateMdevErr("profile", tc.err)
+
+			assert.ErrorIs(t, err, tc.err)
+			if tc.wantInvalidRequest {
+				assert.ErrorIs(t, err, ErrInvalidRequest)
+			} else {
+				assert.NotErrorIs(t, err, ErrInvalidRequest)
+			}
+			assert.Equal(t, tc.wantMessage, err.Error())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- return HTTP 400 `invalid_request` when a macOS instance request includes a vGPU
- reject the request before checking GPU capacity, so it is not reported as insufficient resources
- leave other GPU creation errors unchanged

## Validation

- Linux and macOS tests pass in CI
- local build, vet, and focused error-response tests pass

## Scope

This only changes instance creation. Starting an existing instance is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to instance-create validation and error mapping on macOS; Linux vGPU behavior unchanged and existing start paths are untouched.
> 
> **Overview**
> **Instance create** now treats vGPU profile requests on hosts without mediated GPU support as a client error instead of a generic or capacity failure.
> 
> Adds `devices.Capabilities()` (Linux reports vGPU support; macOS does not) and moves `ErrVGPUNotSupportedOnMacOS` to a shared sentinel in `devices/errors.go`. **Create** rejects a non-empty GPU profile when `SupportsVGPU` is false **before** `ReserveAllocation`, so macOS no longer surfaces this as insufficient resources. If `CreateMdev` still returns the macOS unsupported error, `wrapCreateMdevErr` wraps it as `ErrInvalidRequest`, which the API maps to HTTP **400** with code `invalid_request` and the message `invalid request: vGPU (mdev) is not supported on macOS`.
> 
> Tests cover platform capabilities, early rejection (no reservation), error wrapping, and the create-instance error mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9034ff4c2ec3131505dac88ca3cdba5c6e496004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->