### PR TITLE
Seal SDK release authentication

### DIFF
--- a/stainless/custom-code/go/2026-08-04T13-39-02-159Z-custom-code.json
+++ b/stainless/custom-code/go/2026-08-04T13-39-02-159Z-custom-code.json
@@ -1,6 +1,6 @@
 {
-  "base": "829e8d3bad603ee5cb08b245a0bddbf5a1e6c95e",
-  "integrated": "3d2b0a558b461ac7987d04c47f0df8456ff61141",
+  "base": "4e0fa62e697efc0c8a760021c6707b9dd3437656",
+  "integrated": "dbfca4d314b8de6004c75da801e233752d9d798b",
   "filename": "2026-08-04T13-39-02-159Z-custom-code.json",
   "branch": "main"
 }

--- a/stainless/custom-code/go/2026-08-04T16-07-52-061Z-custom-code.json
+++ b/stainless/custom-code/go/2026-08-04T16-07-52-061Z-custom-code.json
@@ -1,6 +1,0 @@
-{
-  "base": "fd2982c24122e486683d2720200c08b95696f44c",
-  "integrated": "b3b495d92f9c537c5f1a091d01bee0952ef9ad46",
-  "filename": "2026-08-04T16-07-52-061Z-custom-code.json",
-  "branch": "hypeship/stlc-sdk-generation"
-}

--- a/stainless/custom-code/typescript/2026-08-04T13-39-02-159Z-custom-code.json
+++ b/stainless/custom-code/typescript/2026-08-04T13-39-02-159Z-custom-code.json
@@ -1,6 +1,6 @@
 {
-  "base": "9be4218404d696ac3b3146273218d377967b2807",
-  "integrated": "ea0070252daa3e92800ee90f3747bc23658ae20a",
+  "base": "c1372f989d6a38351c2ba99950fc94dcafd0b5bb",
+  "integrated": "fee5343e8e492ff9c9618a47a92541c17940b9ec",
   "filename": "2026-08-04T13-39-02-159Z-custom-code.json",
   "branch": "main"
 }

--- a/stainless/custom-code/typescript/2026-08-04T16-07-56-748Z-custom-code.json
+++ b/stainless/custom-code/typescript/2026-08-04T16-07-56-748Z-custom-code.json
@@ -1,6 +1,0 @@
-{
-  "base": "46e488b7885197e25d9aa14d7319f5a44d630daa",
-  "integrated": "45eabf4951aa7035ee834428596e9375b84d3e00",
-  "filename": "2026-08-04T16-07-56-748Z-custom-code.json",
-  "branch": "hypeship/stlc-sdk-generation"
-}


### PR DESCRIPTION
## Summary

Updates Go and TypeScript custom-code tracking after the release workflows switched to short-lived `kernel-internal` GitHub App tokens and the production release commits were back-synced to staging.

## Validation

- Go bootstrap, lint, and tests passed
- TypeScript bootstrap, lint, build, and tests passed (377 passed, 88 skipped)
- both SDK worktrees were clean before the deterministic push build
- `v0.23.0` and `v0.5.1` release workflows completed successfully
- production and staging `main` match for both SDKs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only Stainless custom-code pointer updates with no runtime or auth logic changes in this diff.
> 
> **Overview**
> Repoints the **Go** and **TypeScript** `main` Stainless custom-code manifests to new `base` and `integrated` commit SHAs so custom-code integration state matches the latest production release back-sync.
> 
> Removes the obsolete **`hypeship/stlc-sdk-generation`** custom-code tracking files for both languages now that release workflows use short-lived `kernel-internal` app tokens and staging aligns with `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b5e98a1a3245efa8524990919c882462aa24b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->