### PR TITLE
Default to Firecracker

### DIFF
--- a/cmd/api/config/config.go
+++ b/cmd/api/config/config.go
@@ -449,7 +449,7 @@ func defaultConfig() *Config {
 		},
 
 		Hypervisor: HypervisorConfig{
-			Default:                          "cloud-hypervisor",
+			Default:                          "firecracker",
 			CloudHypervisorDefaultVersion:    "",
 			FirecrackerBinaryPath:            "",
 			FirecrackerSnapshotMemoryBackend: "file",


### PR DESCRIPTION
## summary
- change the default hypervisor from Cloud Hypervisor to Firecracker

## testing
- `GOCACHE=/tmp/hypeman-go-build go test ./cmd/api/config`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching the default hypervisor changes VM runtime behavior for new or minimally configured deployments; operators who expected Cloud Hypervisor must set `hypervisor.default` explicitly.
> 
> **Overview**
> **Changes the built-in default** for `hypervisor.default` from `cloud-hypervisor` to `firecracker` in `defaultConfig()` (`cmd/api/config/config.go`).
> 
> Hosts that rely on defaults (no YAML override and no `HYPERVISOR__DEFAULT` env) will now provision and run VMs with Firecracker instead of Cloud Hypervisor. Existing configs that set the hypervisor explicitly are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe268137b9e5f3719f54dc8f8f64a7320c18657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->