### PR TITLE
Ensure generated SDK changes reach release notes

### DIFF
--- a/.github/scripts/normalize-sdk-commit-message.sh
+++ b/.github/scripts/normalize-sdk-commit-message.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+normalize_sdk_commit_message() {
+  local msg=$1
+  local conventional='^(feat|fix|perf|revert)(\([^()]+\))?!?:[[:space:]]*'
+  local breaking='^[^()!:[:space:]]+(\([^()]+\))?!:[[:space:]]*'
+
+  if [[ "$msg" =~ $conventional ]]; then
+    printf '%s\n' "$msg"
+  elif [[ "$msg" =~ $breaking ]]; then
+    printf 'feat!: %s\n' "$msg"
+  else
+    printf 'feat: %s\n' "$msg"
+  fi
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  set -euo pipefail
+  normalize_sdk_commit_message "${1:?commit message required}"
+fi

--- a/.github/scripts/normalize-sdk-commit-message.test.sh
+++ b/.github/scripts/normalize-sdk-commit-message.test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/normalize-sdk-commit-message.sh"
+
+cases=(
+  'untyped|Add builders|feat: Add builders'
+  'unknown type|api: add builders|feat: api: add builders'
+  'scoped|fix(api): correct status|fix(api): correct status'
+  'no space|fix!:breaking endpoint removal|fix!:breaking endpoint removal'
+  'empty scope|feat(): add endpoint|feat: feat(): add endpoint'
+  'nested scope|feat(api(v2)): add endpoint|feat: feat(api(v2)): add endpoint'
+  'slash breaking type|api/v2!: remove endpoint|feat!: api/v2!: remove endpoint'
+  'dot breaking type|api.sdk!:remove endpoint|feat!: api.sdk!:remove endpoint'
+  'scoped breaking type|api(cache)!: replace cache|feat!: api(cache)!: replace cache'
+)
+
+for test_case in "${cases[@]}"; do
+  IFS='|' read -r name input expected <<< "$test_case"
+  actual=$(normalize_sdk_commit_message "$input")
+  if [[ "$actual" != "$expected" ]]; then
+    printf '%s: expected %q, got %q\n' "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+done

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -155,6 +155,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Test SDK commit message normalization
+        run: .github/scripts/normalize-sdk-commit-message.test.sh
+
       - name: Mint app token for the SDK repos
         # Workflows:write because the generated SDKs contain .github/workflows.
         # Pull-requests:write for the integration-test draft PRs (action inputs
@@ -200,15 +203,7 @@ jobs:
           set -euo pipefail
           msg=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].title // empty')
           [ -n "$msg" ] || msg=$(git log -1 --pretty=%s)
-          conventional='^(feat|fix|perf|revert)(\([^)]*\))?!?:[[:space:]]+'
-          breaking='^[[:alnum:]_-]+(\([^)]*\))?!:[[:space:]]+'
-          if [[ "$msg" =~ $conventional ]]; then
-            :
-          elif [[ "$msg" =~ $breaking ]]; then
-            msg="feat!: $msg"
-          else
-            msg="feat: $msg"
-          fi
+          msg=$(.github/scripts/normalize-sdk-commit-message.sh "$msg")
           eof="MSG_$(openssl rand -hex 8)"
           {
             echo "commit_msg<<$eof"

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -25,6 +25,7 @@ on:
       - "stainless/**"
       - ".github/workflows/stlc-generate.yml"
       - ".github/actions/setup-stlc/**"
+      - ".github/scripts/normalize-sdk-commit-message*.sh"
   push:
     branches: [main]
     paths:
@@ -33,6 +34,7 @@ on:
       - "stainless/**"
       - ".github/workflows/stlc-generate.yml"
       - ".github/actions/setup-stlc/**"
+      - ".github/scripts/normalize-sdk-commit-message*.sh"
   workflow_dispatch:
     inputs:
       integration_test:

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -201,7 +201,12 @@ jobs:
           msg=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].title // empty')
           [ -n "$msg" ] || msg=$(git log -1 --pretty=%s)
           conventional='^(feat|fix|perf|revert)(\([^)]*\))?!?:[[:space:]]+'
-          if [[ ! "$msg" =~ $conventional ]]; then
+          breaking='^[[:alnum:]_-]+(\([^)]*\))?!:[[:space:]]+'
+          if [[ "$msg" =~ $conventional ]]; then
+            :
+          elif [[ "$msg" =~ $breaking ]]; then
+            msg="feat!: $msg"
+          else
             msg="feat: $msg"
           fi
           eof="MSG_$(openssl rand -hex 8)"

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -187,8 +187,9 @@ jobs:
           gh auth setup-git
 
       - name: Resolve the SDK commit message
-        # The merged PR's title, which survives squash, merge, and rebase alike;
-        # release-please reads it to pick the version bump.
+        # Every generated SDK change must be releasable without depending on
+        # developers to use Conventional Commit prefixes. Preserve an explicit
+        # release type when supplied; otherwise classify the change as a feature.
         id: msg
         if: github.event_name != 'pull_request'
         env:
@@ -199,6 +200,10 @@ jobs:
           set -euo pipefail
           msg=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].title // empty')
           [ -n "$msg" ] || msg=$(git log -1 --pretty=%s)
+          conventional='^(feat|fix|perf|revert)(\([^)]*\))?!?:[[:space:]]+'
+          if [[ ! "$msg" =~ $conventional ]]; then
+            msg="feat: $msg"
+          fi
           eof="MSG_$(openssl rand -hex 8)"
           {
             echo "commit_msg<<$eof"

--- a/docs/runbooks/sdk-generation-stlc.md
+++ b/docs/runbooks/sdk-generation-stlc.md
@@ -21,6 +21,10 @@ Update `openapi.yaml` and `stainless.yaml`, then open a PR. Review the generated
 preview branches and manifest diagnostics before merging. Publishing still
 requires a manual promotion and a release-please PR merge.
 
+Every merged SDK-affecting PR becomes a releasable SDK commit automatically.
+Explicit `feat:`, `fix:`, `perf:`, and `revert:` titles are preserved; other
+titles are classified as features so release notes never silently omit them.
+
 ## Integration test
 
 Run the real generator from any branch without touching staging or production


### PR DESCRIPTION
## Summary

Automatically makes every generated SDK change releasable. Explicit `feat:`, `fix:`, `perf:`, and `revert:` commit types are preserved; all other SDK-affecting merges are classified as features instead of being silently omitted by release-please.

## Validation

- actionlint passed
- shell normalization checks cover untyped, `api:`, `fix:`, and breaking `feat!:` titles
- the PR workflow runs real generation and SDK validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI commit-message shaping for SDK staging pushes; wrong classification could affect semver/changelog but not application runtime.
> 
> **Overview**
> SDK pushes on **main** now run merged PR titles (or the commit subject) through **`normalize-sdk-commit-message.sh`** before `stlc build --commit`, so **release-please** always sees a conventional type instead of skipping untyped titles.
> 
> The normalizer **keeps** explicit `feat` / `fix` / `perf` / `revert` messages (including scoped and `!` breaking forms). **Non-matching** titles get a **`feat:`** prefix; titles that look like a custom breaking type (`type!:`) are rewritten to **`feat!:`** plus the original text.
> 
> **`stlc-generate.yml`** runs the shell test script in the generate job and watches the script paths on PR/push. The SDK generation runbook documents that every merged API/SDK PR is treated as releasable with this classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 295831b6568e6da110d08e36f37702224da75a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->