### PR TITLE
images: consolidate reference resolution

### DIFF
--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -183,7 +183,7 @@ func (m *manager) CreateImage(ctx context.Context, req CreateImageRequest) (*Ima
 	}
 
 	// Don't have this digest yet, queue the build
-	return m.createAndQueueImage(ref, req)
+	return m.createAndQueueImage(ref, req, platform)
 }
 
 // ImportLocalImage imports an image from the local OCI cache without resolving from a remote registry.
@@ -233,10 +233,10 @@ func (m *manager) ImportLocalImage(ctx context.Context, repo, reference, digest 
 	}
 
 	// Don't have this digest yet, queue the build
-	return m.createAndQueueImage(ref, CreateImageRequest{Name: imageRef})
+	return m.createAndQueueImage(ref, CreateImageRequest{Name: imageRef}, hostPlatform())
 }
 
-func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest) (*Image, error) {
+func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest, requestedPlatform Platform) (*Image, error) {
 	// Build one request value and reuse it for both the persisted metadata and
 	// the queue entry so they never diverge.
 	storedReq := CreateImageRequest{
@@ -246,14 +246,7 @@ func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest) 
 	}
 	// Record the requested platform optimistically while the build is pending;
 	// buildImage overwrites it with the authoritative manifest platform once the
-	// image config is pulled. resolveRequestPlatform already validated req, so
-	// the error here is unreachable in practice.
-	// TODO(followup) kernel/hypeman#283: pass the already-parsed platform from
-	// CreateImage instead of re-resolving here (also removes this dead error path).
-	requestedPlatform, err := resolveRequestPlatform(req.Platform)
-	if err != nil {
-		return nil, err
-	}
+	// image config is pulled.
 	meta := &imageMetadata{
 		Name:      ref.String(),
 		Digest:    ref.Digest(),
@@ -304,7 +297,7 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef) {
 	// non-host-arch image (tag preserved in ref.String()/ref.Tag() for symlinks)
 	// still pulls the architecture its digest identifies. Uses the cache if the
 	// digest is already pulled.
-	pullRef := ref.Repository() + "@" + ref.Digest()
+	pullRef := ref.DigestRef()
 	result, err := m.ociClient.pullAndExport(ctx, pullRef, ref.Digest(), tempDir)
 	if err != nil {
 		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("pull and export: %w", err))

--- a/lib/images/reference.go
+++ b/lib/images/reference.go
@@ -135,6 +135,11 @@ func (r *ResolvedRef) Digest() string {
 	return r.digest
 }
 
+// DigestRef returns the repository pinned to the resolved manifest digest.
+func (r *ResolvedRef) DigestRef() string {
+	return r.Repository() + "@" + r.Digest()
+}
+
 // DigestHex returns just the hex portion of the digest (without "sha256:" prefix).
 func (r *ResolvedRef) DigestHex() string {
 	// Strip "sha256:" prefix
@@ -148,22 +153,8 @@ func (r *ResolvedRef) DigestHex() string {
 // Resolve inspects the manifest to get the digest and returns a ResolvedRef.
 // This requires an ociClient interface for manifest inspection.
 type ManifestInspector interface {
-	inspectManifest(ctx context.Context, imageRef string) (string, error)
 	inspectManifestWithPlatform(ctx context.Context, imageRef string, platform gcr.Platform) (string, error)
 	inspectDigestPlatform(ctx context.Context, imageRef string, requested gcr.Platform) (Platform, string, error)
-}
-
-// Resolve returns a ResolvedRef by inspecting the manifest to get the authoritative digest.
-//
-// TODO(followup) kernel/hypeman#283: Resolve and ResolveForPlatform are
-// near-duplicates (platform-less vs platform-aware manifest inspection);
-// consider unifying them behind one path.
-func (r *NormalizedRef) Resolve(ctx context.Context, inspector ManifestInspector) (*ResolvedRef, error) {
-	digest, err := inspector.inspectManifest(ctx, r.String())
-	if err != nil {
-		return nil, err
-	}
-	return NewResolvedRef(r, digest), nil
 }
 
 // ResolveForPlatform returns a ResolvedRef for the manifest matching platform.

--- a/lib/images/reference_test.go
+++ b/lib/images/reference_test.go
@@ -11,18 +11,18 @@ import (
 // fakeInspector is a hermetic ManifestInspector for exercising the resolve seams
 // without a registry round-trip.
 type fakeInspector struct {
-	digestPlatform   Platform
-	digestResolved   string
-	digestErr        error
-	gotDigestRequest gcr.Platform
-}
-
-func (f *fakeInspector) inspectManifest(ctx context.Context, imageRef string) (string, error) {
-	return "", errors.New("not implemented")
+	manifestDigest     string
+	manifestErr        error
+	gotManifestRequest gcr.Platform
+	digestPlatform     Platform
+	digestResolved     string
+	digestErr          error
+	gotDigestRequest   gcr.Platform
 }
 
 func (f *fakeInspector) inspectManifestWithPlatform(ctx context.Context, imageRef string, platform gcr.Platform) (string, error) {
-	return "", errors.New("not implemented")
+	f.gotManifestRequest = platform
+	return f.manifestDigest, f.manifestErr
 }
 
 func (f *fakeInspector) inspectDigestPlatform(ctx context.Context, imageRef string, requested gcr.Platform) (Platform, string, error) {
@@ -31,6 +31,39 @@ func (f *fakeInspector) inspectDigestPlatform(ctx context.Context, imageRef stri
 		return Platform{}, "", f.digestErr
 	}
 	return f.digestPlatform, f.digestResolved, nil
+}
+
+func TestResolvedRefDigestRef(t *testing.T) {
+	normalized, err := ParseNormalizedRef("docker.io/library/alpine:latest")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	ref := NewResolvedRef(normalized, "sha256:abc123")
+	if got, want := ref.DigestRef(), "docker.io/library/alpine@sha256:abc123"; got != want {
+		t.Fatalf("DigestRef() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveForPlatform(t *testing.T) {
+	normalized, err := ParseNormalizedRef("docker.io/library/alpine:latest")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	fake := &fakeInspector{manifestDigest: "sha256:abc123"}
+	requested := gcr.Platform{OS: "linux", Architecture: "amd64"}
+	ref, err := normalized.ResolveForPlatform(context.Background(), fake, requested)
+	if err != nil {
+		t.Fatalf("ResolveForPlatform: %v", err)
+	}
+	if ref.Digest() != fake.manifestDigest {
+		t.Fatalf("ref digest = %q, want %q", ref.Digest(), fake.manifestDigest)
+	}
+	got := fake.gotManifestRequest
+	if got.OS != requested.OS || got.Architecture != requested.Architecture || got.Variant != requested.Variant {
+		t.Fatalf("requested platform = %+v, want %+v", got, requested)
+	}
 }
 
 func TestResolveDigest_RecordsResolvedChildDigest(t *testing.T) {


### PR DESCRIPTION
## Summary

- use the platform-aware resolver as the single `NormalizedRef` resolution path
- pass the already-validated platform into `createAndQueueImage`
- add `ResolvedRef.DigestRef()` for canonical `repo@digest` construction

## Validation

- `go test ./lib/images`
- Fable 5 review: no actionable findings after one cleanup pass

Refs #283

**Stack:** 1 of 3 → #370 → #371

<sub>Stack created with <a href=\"https://github.com/github/gh-stack\">GitHub Stacks CLI</a></sub>