### PR TITLE
images: deduplicate failure messages

### DIFF
--- a/cmd/api/api/images.go
+++ b/cmd/api/api/images.go
@@ -70,7 +70,7 @@ func (s *ApiService) CreateImage(ctx context.Context, request oapi.CreateImageRe
 		case errors.Is(err, images.ErrRateLimited):
 			return oapi.CreateImage429JSONResponse{
 				Code:    "rate_limited",
-				Message: "registry rate limit exceeded; retry later or authenticate to the registry",
+				Message: images.RateLimitMessage,
 			}, nil
 		case errors.Is(err, images.ErrNotFound):
 			return oapi.CreateImage404JSONResponse{

--- a/cmd/api/api/instances.go
+++ b/cmd/api/api/instances.go
@@ -382,7 +382,7 @@ func (s *ApiService) CreateInstance(ctx context.Context, request oapi.CreateInst
 		case errors.Is(err, images.ErrRateLimited):
 			return oapi.CreateInstance429JSONResponse{
 				Code:    "rate_limited",
-				Message: "registry rate limit exceeded; retry later or authenticate to the registry",
+				Message: images.RateLimitMessage,
 			}, nil
 		case errors.Is(err, images.ErrNotFound):
 			return oapi.CreateInstance404JSONResponse{

--- a/lib/images/errors.go
+++ b/lib/images/errors.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 )
 
+// RateLimitMessage is the actionable response returned to API clients when a
+// registry rejects an image request because its rate limit was exceeded.
+const RateLimitMessage = "registry rate limit exceeded; retry later or authenticate to the registry"
+
 var (
 	ErrNotFound        = errors.New("image not found")
 	ErrInvalidName     = errors.New("invalid image name")

--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -2,6 +2,7 @@ package images
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -595,10 +596,7 @@ func (m *manager) WaitForReady(ctx context.Context, name string) error {
 	case StatusReady:
 		return nil
 	case StatusFailed:
-		if img.Error != nil {
-			return fmt.Errorf("image conversion failed: %s", *img.Error)
-		}
-		return fmt.Errorf("image conversion failed")
+		return conversionFailedErr(img.Error, nil)
 	}
 
 	digestHex := strings.TrimPrefix(img.Digest, "sha256:")
@@ -615,10 +613,7 @@ func (m *manager) WaitForReady(ctx context.Context, name string) error {
 		case StatusReady:
 			return nil
 		case StatusFailed:
-			if img.Error != nil {
-				return fmt.Errorf("image conversion failed: %s", *img.Error)
-			}
-			return fmt.Errorf("image conversion failed")
+			return conversionFailedErr(img.Error, nil)
 		}
 	}
 
@@ -628,13 +623,20 @@ func (m *manager) WaitForReady(ctx context.Context, name string) error {
 		if event.Status == StatusReady {
 			return nil
 		}
-		if event.Err != nil {
-			return fmt.Errorf("image conversion failed: %w", event.Err)
-		}
-		return fmt.Errorf("image conversion failed")
+		return conversionFailedErr(nil, event.Err)
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+func conversionFailedErr(message *string, cause error) error {
+	if cause != nil {
+		return fmt.Errorf("image conversion failed: %w", cause)
+	}
+	if message != nil {
+		return fmt.Errorf("image conversion failed: %s", *message)
+	}
+	return errors.New("image conversion failed")
 }
 
 // subscribeToReady registers a channel for terminal status notifications on a digest.

--- a/lib/images/manager_test.go
+++ b/lib/images/manager_test.go
@@ -3,6 +3,7 @@ package images
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConversionFailedErr(t *testing.T) {
+	t.Run("without detail", func(t *testing.T) {
+		assert.EqualError(t, conversionFailedErr(nil, nil), "image conversion failed")
+	})
+
+	t.Run("with stored message", func(t *testing.T) {
+		message := "converter exited"
+		assert.EqualError(t, conversionFailedErr(&message, nil), "image conversion failed: converter exited")
+	})
+
+	t.Run("with cause", func(t *testing.T) {
+		cause := errors.New("converter exited")
+		err := conversionFailedErr(nil, cause)
+		assert.EqualError(t, err, "image conversion failed: converter exited")
+		assert.ErrorIs(t, err, cause)
+	})
+}
 
 func TestCreateImage(t *testing.T) {
 	dataDir := t.TempDir()


### PR DESCRIPTION
## Summary

- route all `WaitForReady` conversion failures through one helper while preserving wrapped causes
- centralize the actionable registry rate-limit response message in `lib/images`
- cover generic, stored-message, and wrapped-cause conversion failures

## Validation

- `go test ./lib/images`
- Fable 5 review: no actionable findings

Refs #283

**Stack:** 2 of 3; depends on #369 → followed by #371

<sub>Stack created with <a href=\"https://github.com/github/gh-stack\">GitHub Stacks CLI</a></sub>