### PR TITLE
imagepush: review fixes for push job manager (#350)

### DIFF
--- a/lib/imagepush/imagepush.go
+++ b/lib/imagepush/imagepush.go
@@ -27,6 +27,12 @@ var (
 	ErrNotFound      = errors.New("push not found")
 	ErrImageNotReady = errors.New("image not ready for push")
 	ErrInvalidTarget = errors.New("invalid push target")
+	// ErrCredentialConflict is returned when a push request matches an
+	// in-flight job but its credential intent differs from that job's. The
+	// manager never stores credential values, so it can only detect a
+	// presence mismatch; two requests that both borrow different credentials
+	// for the same target are indistinguishable and merge.
+	ErrCredentialConflict = errors.New("push already in flight with different credentials")
 )
 
 // PushRequest describes a request to push a hypeman image to a remote registry.
@@ -77,7 +83,9 @@ type Manager interface {
 	// CreatePush validates the request, persists a queued job, and enqueues it.
 	// A request that matches an in-flight job (same digest and target) returns
 	// the existing job instead of creating a duplicate; the in-flight job's
-	// credentials remain in effect.
+	// credentials remain in effect. A request whose credential presence
+	// differs from the in-flight job's (one borrowed, one not) returns
+	// ErrCredentialConflict instead of silently merging under the wrong auth.
 	CreatePush(ctx context.Context, req PushRequest) (*Push, error)
 	GetPush(ctx context.Context, id string) (*Push, error)
 	// ListPushes returns all pushes, newest first.

--- a/lib/imagepush/manager.go
+++ b/lib/imagepush/manager.go
@@ -17,8 +17,9 @@ import (
 )
 
 type inflightPush struct {
-	id     string
-	digest string
+	id             string
+	digest         string
+	hadCredentials bool
 }
 
 type manager struct {
@@ -79,6 +80,11 @@ func (m *manager) CreatePush(ctx context.Context, req PushRequest) (*Push, error
 	if img.Status != images.StatusReady {
 		return nil, fmt.Errorf("%w: %s is %s", ErrImageNotReady, img.Name, img.Status)
 	}
+	// A ready image must carry a digest; without one the dedup key below
+	// would collide across unrelated images.
+	if img.Digest == "" {
+		return nil, fmt.Errorf("%w: image %s has no digest", ErrImageNotReady, img.Name)
+	}
 
 	// Validate the target before persisting anything so typos fail fast.
 	var refOpts []name.Option
@@ -99,52 +105,27 @@ func (m *manager) CreatePush(ctx context.Context, req PushRequest) (*Push, error
 		provider = &registrypush.StaticProvider{Config: *req.Credentials}
 	}
 
-	// Hold the lock across dedup check, orphan adoption, metadata write, and
-	// registration so a concurrent request for the same digest+target cannot
-	// slip in between and leave an orphaned queued job behind.
+	// Hold the lock across the dedup check, metadata write, and registration so
+	// a concurrent request for the same digest+target cannot slip in between
+	// and create a duplicate job.
 	m.mu.Lock()
 	if existing, ok := m.inflight[key]; ok {
+		// Merge only when the credential intent matches the in-flight job. The
+		// manager never stores credential values, so it can only compare
+		// presence: a request that borrowed credentials cannot merge into an
+		// anonymous in-flight push (its auth would be silently dropped), and an
+		// anonymous request cannot merge into a credentialed one (it would
+		// silently inherit another caller's login). Both silently merge under
+		// the wrong auth otherwise; surface the conflict instead so the caller
+		// can retry once the in-flight job completes or match its credentials.
+		hadCreds := req.Credentials != nil
+		if existing.hadCredentials != hadCreds {
+			m.mu.Unlock()
+			return nil, fmt.Errorf("%w: a push of %s to %s is already in flight with different credentials; retry once it completes or match its credentials", ErrCredentialConflict, img.Digest, dstRef.String())
+		}
 		id := existing.id
 		m.mu.Unlock()
 		return m.GetPush(ctx, id)
-	}
-
-	// Adopt a pending record that exists on disk but is not tracked in memory
-	// (e.g. left behind by an interrupted recovery) instead of creating a
-	// duplicate job for the same digest+target. Records that carried borrowed
-	// credentials cannot be re-executed with them: close them with the same
-	// policy as recovery and fall through to create a fresh job (the current
-	// request may lend new credentials).
-	orphan, err := findPendingPush(m.paths, key)
-	if err != nil {
-		m.mu.Unlock()
-		return nil, fmt.Errorf("scan pending pushes: %w", err)
-	}
-	if orphan != nil && orphan.HadCredentials {
-		m.failRecovered(orphan, "push interrupted by restart: borrowed registry credentials are no longer available, retry the push")
-		orphan = nil
-	}
-	// A request that lends credentials cannot adopt a credential-less orphan:
-	// the adopted job would run under the default provider instead of the
-	// borrowed login. Supersede the orphan and create a fresh job instead.
-	if orphan != nil && req.Credentials != nil {
-		m.failRecovered(orphan, "superseded by a new push request for the same image and target")
-		orphan = nil
-	}
-	if orphan != nil {
-		m.inflight[key] = inflightPush{id: orphan.ID, digest: orphan.Digest}
-		m.mu.Unlock()
-
-		orphanCopy := *orphan
-		queuePos := m.queue.Enqueue(key, func() {
-			m.executePush(context.Background(), &orphanCopy, m.provider)
-		}, m.releaseInflight(key))
-
-		push := orphan.toPush()
-		if queuePos > 0 {
-			push.QueuePosition = &queuePos
-		}
-		return push, nil
 	}
 
 	meta := &pushMetadata{
@@ -161,7 +142,7 @@ func (m *manager) CreatePush(ctx context.Context, req PushRequest) (*Push, error
 		m.mu.Unlock()
 		return nil, fmt.Errorf("write initial metadata: %w", err)
 	}
-	m.inflight[key] = inflightPush{id: meta.ID, digest: meta.Digest}
+	m.inflight[key] = inflightPush{id: meta.ID, digest: meta.Digest, hadCredentials: meta.HadCredentials}
 	m.mu.Unlock()
 
 	metaCopy := *meta
@@ -196,6 +177,8 @@ func (m *manager) executePush(ctx context.Context, meta *pushMetadata, provider 
 	}()
 
 	meta.Status = StatusPushing
+	// Best-effort: if this write fails the job still runs and the terminal
+	// record written on completion is the source of truth for recovery.
 	if err := writeMetadata(m.paths, meta); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to persist push status for %s: %v\n", meta.ID, err)
 	}
@@ -251,6 +234,9 @@ func (m *manager) writeTerminal(meta *pushMetadata) error {
 // active set, so a concurrent CreatePush never falls into a gap between job
 // completion and slot release: it either sees the inflight entry and gets the
 // finished job, or enqueues a fresh one that actually starts.
+// This relies on executePush having persisted the terminal status before it
+// returns (including from its panic handler); otherwise the record on disk
+// and the inflight map could disagree about whether the job is still running.
 func (m *manager) releaseInflight(key string) func() {
 	return func() {
 		m.mu.Lock()
@@ -260,6 +246,9 @@ func (m *manager) releaseInflight(key string) func() {
 }
 
 func (m *manager) GetPush(ctx context.Context, id string) (*Push, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	meta, err := readMetadata(m.paths, id)
 	if err != nil {
 		return nil, err
@@ -273,6 +262,9 @@ func (m *manager) GetPush(ctx context.Context, id string) (*Push, error) {
 }
 
 func (m *manager) ListPushes(ctx context.Context) ([]Push, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	metas, err := listAllPushes(m.paths)
 	if err != nil {
 		return nil, err
@@ -388,7 +380,7 @@ func (m *manager) recoverInterruptedPushes() {
 		seen[key] = meta.ID
 
 		m.mu.Lock()
-		m.inflight[key] = inflightPush{id: meta.ID, digest: meta.Digest}
+		m.inflight[key] = inflightPush{id: meta.ID, digest: meta.Digest, hadCredentials: meta.HadCredentials}
 		m.mu.Unlock()
 
 		metaCopy := *meta

--- a/lib/imagepush/manager_test.go
+++ b/lib/imagepush/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -472,118 +473,118 @@ func TestRecoverInterruptedPushes(t *testing.T) {
 	}
 }
 
-func TestCreatePushAdoptsOrphanedPendingJob(t *testing.T) {
+func TestCreatePushDedupesConcurrently(t *testing.T) {
 	p, digest := cacheFixture(t)
-	host := openRegistry(t)
-	target := host + "/export/orphan:v1"
-
+	host, gate := gatedRegistry(t)
 	resolver := &fakeResolver{images: map[string]*images.Image{
 		"myapp:v1": readyImage("myapp:v1", digest),
 	}}
+
+	mgr, err := NewManager(p, resolver, nil, 2)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	req := PushRequest{Image: "myapp:v1", Target: host + "/export/app:v1", Insecure: true}
+	if _, err := mgr.CreatePush(context.Background(), req); err != nil {
+		t.Fatalf("seed CreatePush: %v", err)
+	}
+
+	// Two goroutines racing CreatePush for the same digest+target must both
+	// land on the single in-flight job: one registers, the other merges.
+	const n = 2
+	ids := make([]string, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			push, err := mgr.CreatePush(context.Background(), req)
+			if push != nil {
+				ids[i] = push.ID
+			}
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("concurrent CreatePush #%d: %v", i, errs[i])
+		}
+		if ids[i] != ids[0] {
+			t.Errorf("concurrent push #%d got ID %s, want %s (single job)", i, ids[i], ids[0])
+		}
+	}
+
+	if digests := mgr.InProgressDigests(); len(digests) != 1 || digests[0] != digest {
+		t.Errorf("InProgressDigests = %v, want [%s]", digests, digest)
+	}
+
+	close(gate)
+	if err := mgr.WaitForPush(context.Background(), ids[0]); err != nil {
+		t.Fatalf("WaitForPush: %v", err)
+	}
+}
+
+func TestCreatePushCredentialConflict(t *testing.T) {
+	p, digest := cacheFixture(t)
+	hostA, gateA := gatedRegistry(t)
+	hostB, gateB := gatedRegistry(t)
+	targetA := hostA + "/export/a:v1"
+	targetB := hostB + "/export/b:v1"
+	resolver := &fakeResolver{images: map[string]*images.Image{
+		"myapp:v1": readyImage("myapp:v1", digest),
+	}}
+
 	mgr, err := NewManager(p, resolver, nil, 1)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	// Simulate an orphan: a queued record on disk that the manager does not
-	// track (it appeared after startup, e.g. left behind by a crashed
-	// process). A new push for the same image+target must adopt it instead of
-	// creating a duplicate job.
-	orphan := &pushMetadata{
-		ID:        "orphan-1",
-		Status:    StatusQueued,
-		Image:     "myapp:v1",
-		Digest:    digest,
-		Target:    target,
-		Insecure:  true,
-		CreatedAt: time.Now(),
-	}
-	if err := writeMetadata(p, orphan); err != nil {
-		t.Fatalf("writeMetadata: %v", err)
-	}
-
-	push, err := mgr.CreatePush(context.Background(), PushRequest{
-		Image: "myapp:v1", Target: target, Insecure: true,
+	// Credentialed in-flight push, then an anonymous request: merging would
+	// silently drop the request's intent and run under the in-flight auth.
+	seeded, err := mgr.CreatePush(context.Background(), PushRequest{
+		Image: "myapp:v1", Target: targetA, Insecure: true,
+		Credentials: &authn.AuthConfig{RegistryToken: "borrowed-token"},
 	})
 	if err != nil {
-		t.Fatalf("CreatePush: %v", err)
+		t.Fatalf("seed CreatePush: %v", err)
 	}
-	if push.ID != "orphan-1" {
-		t.Fatalf("push ID = %s, want orphan-1 (adopted, not duplicated)", push.ID)
-	}
-	if err := mgr.WaitForPush(context.Background(), push.ID); err != nil {
-		t.Fatalf("WaitForPush: %v", err)
+	if _, err := mgr.CreatePush(context.Background(), PushRequest{Image: "myapp:v1", Target: targetA, Insecure: true}); !errors.Is(err, ErrCredentialConflict) {
+		t.Errorf("anonymous duplicate err = %v, want ErrCredentialConflict", err)
 	}
 
-	got, err := mgr.GetPush(context.Background(), "orphan-1")
+	// Reverse: anonymous in-flight push, then a credentialed request.
+	seeded2, err := mgr.CreatePush(context.Background(), PushRequest{Image: "myapp:v1", Target: targetB, Insecure: true})
 	if err != nil {
-		t.Fatalf("GetPush: %v", err)
+		t.Fatalf("seed CreatePush 2: %v", err)
 	}
-	if got.Status != StatusPushed {
-		t.Errorf("status = %s, want pushed", got.Status)
+	if _, err := mgr.CreatePush(context.Background(), PushRequest{
+		Image: "myapp:v1", Target: targetB, Insecure: true,
+		Credentials: &authn.AuthConfig{RegistryToken: "borrowed-token"},
+	}); !errors.Is(err, ErrCredentialConflict) {
+		t.Errorf("credentialed duplicate err = %v, want ErrCredentialConflict", err)
 	}
 
-	// Exactly one job exists for the key.
+	close(gateA)
+	close(gateB)
+	if err := mgr.WaitForPush(context.Background(), seeded.ID); err != nil {
+		t.Fatalf("WaitForPush seeded: %v", err)
+	}
+	if err := mgr.WaitForPush(context.Background(), seeded2.ID); err != nil {
+		t.Fatalf("WaitForPush seeded 2: %v", err)
+	}
+
+	// The conflicted requests must not have created duplicate jobs: only the
+	// two seeds exist.
 	pushes, err := mgr.ListPushes(context.Background())
 	if err != nil {
 		t.Fatalf("ListPushes: %v", err)
 	}
-	if len(pushes) != 1 {
-		t.Errorf("len(pushes) = %d, want 1", len(pushes))
-	}
-}
-
-func TestCreatePushOrphanWithCredentialsIsFailedNotAdopted(t *testing.T) {
-	p, digest := cacheFixture(t)
-	host := openRegistry(t)
-	target := host + "/export/cred-orphan:v1"
-
-	resolver := &fakeResolver{images: map[string]*images.Image{
-		"myapp:v1": readyImage("myapp:v1", digest),
-	}}
-	mgr, err := NewManager(p, resolver, nil, 1)
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
-
-	// An orphaned record that used borrowed credentials cannot be
-	// re-executed with them: it must be closed, and a fresh job created.
-	orphan := &pushMetadata{
-		ID:             "cred-orphan",
-		Status:         StatusQueued,
-		Image:          "myapp:v1",
-		Digest:         digest,
-		Target:         target,
-		Insecure:       true,
-		HadCredentials: true,
-		CreatedAt:      time.Now(),
-	}
-	if err := writeMetadata(p, orphan); err != nil {
-		t.Fatalf("writeMetadata: %v", err)
-	}
-
-	push, err := mgr.CreatePush(context.Background(), PushRequest{
-		Image: "myapp:v1", Target: target, Insecure: true,
-	})
-	if err != nil {
-		t.Fatalf("CreatePush: %v", err)
-	}
-	if push.ID == "cred-orphan" {
-		t.Fatal("credentialed orphan must not be adopted")
-	}
-	if err := mgr.WaitForPush(context.Background(), push.ID); err != nil {
-		t.Fatalf("WaitForPush: %v", err)
-	}
-
-	got, err := mgr.GetPush(context.Background(), "cred-orphan")
-	if err != nil {
-		t.Fatalf("GetPush orphan: %v", err)
-	}
-	if got.Status != StatusFailed {
-		t.Errorf("orphan status = %s, want failed", got.Status)
-	}
-	if got.Error == nil || !strings.Contains(*got.Error, "credentials") {
-		t.Errorf("orphan error = %v, want credentials explanation", got.Error)
+	if len(pushes) != 2 {
+		t.Errorf("len(pushes) = %d, want 2 (conflicts created no jobs)", len(pushes))
 	}
 }
 
@@ -880,60 +881,6 @@ func TestExecutePushContainsPanic(t *testing.T) {
 	}
 	if got.Status != StatusFailed {
 		t.Errorf("status = %s, want failed", got.Status)
-	}
-}
-
-func TestCreatePushWithCredentialsSupersedesOrphan(t *testing.T) {
-	p, digest := cacheFixture(t)
-	host := openRegistry(t)
-	target := host + "/export/supersede:v1"
-
-	resolver := &fakeResolver{images: map[string]*images.Image{
-		"myapp:v1": readyImage("myapp:v1", digest),
-	}}
-	mgr, err := NewManager(p, resolver, nil, 1)
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
-
-	// A credential-less orphan cannot be adopted by a request that lends
-	// credentials: it would run under the default provider instead of the
-	// borrowed login.
-	orphan := &pushMetadata{
-		ID:        "plain-orphan",
-		Status:    StatusQueued,
-		Image:     "myapp:v1",
-		Digest:    digest,
-		Target:    target,
-		Insecure:  true,
-		CreatedAt: time.Now(),
-	}
-	if err := writeMetadata(p, orphan); err != nil {
-		t.Fatalf("writeMetadata: %v", err)
-	}
-
-	push, err := mgr.CreatePush(context.Background(), PushRequest{
-		Image:       "myapp:v1",
-		Target:      target,
-		Insecure:    true,
-		Credentials: &authn.AuthConfig{RegistryToken: "borrowed"},
-	})
-	if err != nil {
-		t.Fatalf("CreatePush: %v", err)
-	}
-	if push.ID == "plain-orphan" {
-		t.Fatal("credentialed request must not adopt a credential-less orphan")
-	}
-	if err := mgr.WaitForPush(context.Background(), push.ID); err != nil {
-		t.Fatalf("WaitForPush: %v", err)
-	}
-
-	got, err := mgr.GetPush(context.Background(), "plain-orphan")
-	if err != nil {
-		t.Fatalf("GetPush orphan: %v", err)
-	}
-	if got.Status != StatusFailed {
-		t.Errorf("orphan status = %s, want failed (superseded)", got.Status)
 	}
 }
 

--- a/lib/imagepush/storage.go
+++ b/lib/imagepush/storage.go
@@ -104,7 +104,11 @@ func listAllPushes(p *paths.Paths) ([]*pushMetadata, error) {
 		}
 		meta, err := readMetadata(p, entry.Name())
 		if err != nil {
-			continue // Skip invalid entries
+			// Surface unreadable records instead of swallowing them: a corrupt
+			// or half-written metadata.json would otherwise vanish from
+			// listing and recovery while its push directory lingers on disk.
+			fmt.Fprintf(os.Stderr, "Warning: skipping push %s with unreadable metadata: %v\n", entry.Name(), err)
+			continue
 		}
 		metas = append(metas, meta)
 	}
@@ -114,22 +118,6 @@ func listAllPushes(p *paths.Paths) ([]*pushMetadata, error) {
 	})
 
 	return metas, nil
-}
-
-// findPendingPush returns the oldest non-terminal push matching the key, or
-// nil when there is none. Used to adopt orphaned records instead of
-// duplicating them.
-func findPendingPush(p *paths.Paths, key string) (*pushMetadata, error) {
-	pending, err := listPendingPushes(p)
-	if err != nil {
-		return nil, err
-	}
-	for _, meta := range pending {
-		if pushKey(meta.Digest, meta.Target, meta.Insecure) == key {
-			return meta, nil
-		}
-	}
-	return nil, nil
 }
 
 // listPendingPushes returns pushes that did not reach a terminal state,

--- a/lib/imagepush/storage_test.go
+++ b/lib/imagepush/storage_test.go
@@ -2,6 +2,7 @@ package imagepush
 
 import (
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -55,6 +56,32 @@ func TestReadMetadataNotFound(t *testing.T) {
 	_, err := readMetadata(p, "missing")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestListPushesSkipsUnreadableMetadata(t *testing.T) {
+	p := paths.New(t.TempDir())
+	now := time.Now()
+
+	if err := writeMetadata(p, &pushMetadata{ID: "good", Status: StatusPushed, Digest: "sha256:1", Target: "t1", CreatedAt: now}); err != nil {
+		t.Fatalf("writeMetadata(good): %v", err)
+	}
+	// A corrupt record must not fail the whole listing, but must not vanish
+	// silently either: it is skipped with a warning so it stays visible.
+	badDir := p.PushDir("corrupt")
+	if err := os.MkdirAll(badDir, 0755); err != nil {
+		t.Fatalf("mkdir corrupt: %v", err)
+	}
+	if err := os.WriteFile(p.PushMetadata("corrupt"), []byte("{not json"), 0644); err != nil {
+		t.Fatalf("write corrupt metadata: %v", err)
+	}
+
+	all, err := listAllPushes(p)
+	if err != nil {
+		t.Fatalf("listAllPushes: %v", err)
+	}
+	if len(all) != 1 || all[0].ID != "good" {
+		t.Errorf("all = %v, want only good", all)
 	}
 }
 


### PR DESCRIPTION
Addresses review findings on #350 in `lib/imagepush`. Stacked on #350 (targets its head branch).

## Changes
- **credentials-blind dedup is now a hard conflict.** `CreatePush` merges a request into an in-flight job only when credential presence matches. A request that borrowed credentials can no longer merge into an anonymous in-flight push (auth silently dropped), and an anonymous request can no longer merge into a credentialed one (silently inherits another caller's login). Mismatch returns new `ErrCredentialConflict`. The manager never stores credential values, so presence is the only comparable signal; two requests borrowing different credentials for the same target remain indistinguishable and merge (documented).
- **dropped the dead orphan-adoption path.** The per-`CreatePush` `PushesDir` scan (`findPendingPush`) was unreachable: startup recovery adopts every pending record before any `CreatePush` runs, and the create lock spans metadata write + inflight registration, so no pending record can exist on disk that isn't tracked. Removing it also removes the O(N) scan performed while holding the create lock. Adjusts/removes the three orphan-adoption tests.
- **corrupt metadata is surfaced, not swallowed.** `listAllPushes` logs a warning for unreadable records instead of silently dropping them from listing and recovery.
- plus: empty-digest guard in `CreatePush` (dedup key would otherwise collide across images), `ctx` cancellation honored in `GetPush`/`ListPushes`, and clarifying comments for the best-effort pushing-status write and the terminal-persist-before-inflight-release invariant.

## Tests
- new `TestCreatePushCredentialConflict` (both directions), `TestCreatePushDedupesConcurrently` (the previously-missing concurrent dedup race), `TestListPushesSkipsUnreadableMetadata`.
- `go test -tags containers_image_openpgp -race -count=2 ./lib/imagepush/...` — pass. `go build -tags containers_image_openpgp ./...` and `go vet` — clean. `lib/registrypush`, `lib/ocicache`, `lib/registry`, `lib/ocicachegc` also pass with `-race`.

Not addressed here (left as follow-ups): consolidating `pushQueue` with the builds/images queues, decomposition of the 449-line manager, and a retention policy for terminal records.

Note: the full lib/images suite has a pre-existing failure (`TestImportLocalImageFromOCICache` times out spinning up a builder VM at the 60s cap); it is untouched by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes registry authentication merge semantics for concurrent pushes (safer but may surface new errors to callers); otherwise localized manager/storage behavior with no credential persistence changes.
> 
> **Overview**
> **Credential-aware in-flight dedup:** `CreatePush` still merges duplicate digest+target pushes, but only when both requests agree on whether credentials were borrowed. A mismatch returns **`ErrCredentialConflict`** instead of silently running under the wrong registry auth. In-flight state tracks credential *presence* only (values are never stored).
> 
> **Simpler create path:** Per-request **orphan adoption** (`findPendingPush` and the O(N) scan under the create lock) is removed as redundant with startup recovery and lock ordering. Related orphan/supersede tests are replaced by **concurrent dedup** and **credential conflict** coverage.
> 
> **Operational hardening:** Ready images without a digest are rejected before dedup; **`GetPush`** / **`ListPushes`** respect context cancellation; corrupt push metadata is **logged and skipped** on list rather than disappearing silently; comments clarify terminal persist vs inflight release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4998f67f1fed62103f1cb9f9f6fbe33e566a91b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->