### PR TITLE
Profile OCI image conversion phases

### DIFF
--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -277,18 +278,23 @@ func (m *manager) createAndQueueImage(ref *ResolvedRef, req CreateImageRequest, 
 
 func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef) {
 	buildStart := time.Now()
+	buildStatus := "failed"
 	buildDir := m.paths.SystemBuild(ref.String())
 	tempDir := filepath.Join(buildDir, "rootfs")
+	defer func() {
+		m.recordBuildMetrics(ctx, buildStart, buildStatus)
+	}()
 
 	if err := os.MkdirAll(buildDir, 0755); err != nil {
 		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("create build dir: %w", err))
-		m.recordBuildMetrics(ctx, buildStart, "failed")
 		return
 	}
 
 	defer func() {
 		// Clean up build directory after completion
-		os.RemoveAll(buildDir)
+		start := time.Now()
+		err := os.RemoveAll(buildDir)
+		m.recordImageBuildPhase(ctx, ref.Digest(), "cleanup", time.Since(start), phaseStatus(err), "not_applicable")
 	}()
 
 	m.updateStatusByDigest(ref, StatusPulling, nil)
@@ -300,10 +306,10 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef) {
 	// digest is already pulled.
 	pullRef := ref.DigestRef()
 	result, err := m.ociClient.pullAndExport(ctx, pullRef, ref.Digest(), tempDir)
+	m.recordPullResultMetrics(ctx, ref.Digest(), result)
 	if err != nil {
 		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("pull and export: %w", err))
 		m.recordPullMetrics(ctx, "failed")
-		m.recordBuildMetrics(ctx, buildStart, "failed")
 		return
 	}
 	m.recordPullMetrics(ctx, "success")
@@ -315,6 +321,7 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef) {
 			if ref.Tag() != "" {
 				createTagSymlink(m.paths, ref.Repository(), ref.Tag(), ref.DigestHex())
 			}
+			buildStatus = "success"
 			return
 		}
 	}
@@ -323,16 +330,29 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef) {
 
 	diskPath := digestPath(m.paths, ref.Repository(), ref.DigestHex())
 	// Use default image format (erofs on Linux, ext4 on Darwin)
+	convertStart := time.Now()
 	diskSize, err := ExportRootfs(tempDir, diskPath, DefaultImageFormat)
+	m.recordImageBuildPhase(ctx, ref.Digest(), "filesystem_export", time.Since(convertStart), phaseStatus(err), "not_applicable")
 	if err != nil {
 		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("convert to %s: %w", DefaultImageFormat, err))
 		return
 	}
 
-	// Read current metadata to preserve request info
+	finalizeStart := time.Now()
+	err = m.finalizeImage(ref, result, diskSize)
+	m.recordImageBuildPhase(ctx, ref.Digest(), "finalize", time.Since(finalizeStart), phaseStatus(err), "not_applicable")
+	if err != nil {
+		m.updateStatusByDigest(ref, StatusFailed, err)
+		return
+	}
+
+	buildStatus = "success"
+}
+
+func (m *manager) finalizeImage(ref *ResolvedRef, result *pullResult, diskSize int64) error {
+	// Read current metadata to preserve request info.
 	meta, err := readMetadata(m.paths, ref.Repository(), ref.DigestHex())
 	if err != nil {
-		// Create new metadata if it doesn't exist
 		meta = &imageMetadata{
 			Name:      ref.String(),
 			Digest:    ref.Digest(),
@@ -340,21 +360,16 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef) {
 		}
 	}
 
-	// The pulled image config is the source of truth for the platform. Record
-	// it rather than the requested value so the boot guard trusts a real
-	// platform (WithPlatform is a no-op for single-manifest images, so a wrong
-	// request would otherwise be silently recorded).
+	// The pulled image config is the source of truth for the platform.
 	var requestedPlatform string
 	if meta.Request != nil {
 		requestedPlatform = meta.Request.Platform
 	}
 	actualPlatform, err := resolveManifestPlatform(result.Metadata, requestedPlatform)
 	if err != nil {
-		m.updateStatusByDigest(ref, StatusFailed, err)
-		return
+		return err
 	}
 
-	// Update with final status
 	meta.Status = StatusReady
 	meta.Error = nil
 	meta.Platform = actualPlatform.String()
@@ -366,25 +381,57 @@ func (m *manager) buildImage(ctx context.Context, ref *ResolvedRef) {
 	meta.WorkingDir = result.Metadata.WorkingDir
 
 	if err := writeMetadata(m.paths, ref.Repository(), ref.DigestHex(), meta); err != nil {
-		m.updateStatusByDigest(ref, StatusFailed, fmt.Errorf("write final metadata: %w", err))
-		return
+		return fmt.Errorf("write final metadata: %w", err)
 	}
 
-	// Notify subscribers that image is ready
 	m.notifyReady(ref.DigestHex(), StatusReady, nil)
-
-	// Only create/update tag symlink on successful completion; last-pull-wins
-	// repoints the tag regardless of platform.
 	if ref.Tag() != "" {
 		if err := createTagSymlink(m.paths, ref.Repository(), ref.Tag(), ref.DigestHex()); err != nil {
-			// Log error but don't fail the build
 			fmt.Fprintf(os.Stderr, "Warning: failed to create tag symlink: %v\n", err)
 		}
 	}
-
 	m.refreshDiskUsageTotals()
+	return nil
+}
 
-	m.recordBuildMetrics(ctx, buildStart, "success")
+func phaseStatus(err error) string {
+	if err != nil {
+		return "failed"
+	}
+	return "success"
+}
+
+func (m *manager) recordPullResultMetrics(ctx context.Context, digest string, result *pullResult) {
+	if result == nil {
+		return
+	}
+	cacheStatus := "miss"
+	if result.CacheHit {
+		cacheStatus = "hit"
+	}
+	for _, phase := range result.Phases {
+		m.recordImageBuildPhase(ctx, digest, phase.Phase, phase.Duration, phase.Status, cacheStatus)
+	}
+	if result.Metadata != nil {
+		m.recordOCIImageMetrics(ctx, result.LayerCount, result.CompressedBytes, cacheStatus)
+		slog.InfoContext(ctx, "OCI image inspected",
+			"digest", digest,
+			"cache_status", cacheStatus,
+			"layer_count", result.LayerCount,
+			"compressed_bytes", result.CompressedBytes,
+		)
+	}
+}
+
+func (m *manager) recordImageBuildPhase(ctx context.Context, digest, phase string, duration time.Duration, status, cacheStatus string) {
+	m.recordBuildPhaseMetrics(ctx, phase, duration, status, cacheStatus)
+	slog.InfoContext(ctx, "image build phase completed",
+		"digest", digest,
+		"phase", phase,
+		"status", status,
+		"cache_status", cacheStatus,
+		"duration_seconds", duration.Seconds(),
+	)
 }
 
 func (m *manager) updateStatusByDigest(ref *ResolvedRef, status string, err error) {

--- a/lib/images/metrics.go
+++ b/lib/images/metrics.go
@@ -11,8 +11,11 @@ import (
 
 // Metrics holds the metrics instruments for image operations.
 type Metrics struct {
-	buildDuration metric.Float64Histogram
-	pullsTotal    metric.Int64Counter
+	buildDuration      metric.Float64Histogram
+	buildPhaseDuration metric.Float64Histogram
+	ociLayerCount      metric.Int64Histogram
+	ociCompressedBytes metric.Int64Histogram
+	pullsTotal         metric.Int64Counter
 }
 
 // newMetrics creates and registers all image metrics.
@@ -22,6 +25,34 @@ func newMetrics(meter metric.Meter, m *manager) (*Metrics, error) {
 		metric.WithDescription("Time to build an image"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries(hypotel.BuildDurationHistogramBuckets()...),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	buildPhaseDuration, err := meter.Float64Histogram(
+		"hypeman_images_build_phase_duration_seconds",
+		metric.WithDescription("Time spent in each image build phase"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.BuildDurationHistogramBuckets()...),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ociLayerCount, err := meter.Int64Histogram(
+		"hypeman_images_oci_layer_count",
+		metric.WithDescription("Number of layers in an OCI image being converted"),
+		metric.WithUnit("{layer}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ociCompressedBytes, err := meter.Int64Histogram(
+		"hypeman_images_oci_compressed_bytes",
+		metric.WithDescription("Total compressed bytes in OCI image layers being converted"),
+		metric.WithUnit("By"),
 	)
 	if err != nil {
 		return nil, err
@@ -80,8 +111,11 @@ func newMetrics(meter metric.Meter, m *manager) (*Metrics, error) {
 	}
 
 	return &Metrics{
-		buildDuration: buildDuration,
-		pullsTotal:    pullsTotal,
+		buildDuration:      buildDuration,
+		buildPhaseDuration: buildPhaseDuration,
+		ociLayerCount:      ociLayerCount,
+		ociCompressedBytes: ociCompressedBytes,
+		pullsTotal:         pullsTotal,
 	}, nil
 }
 
@@ -102,4 +136,24 @@ func (m *manager) recordPullMetrics(ctx context.Context, status string) {
 	}
 	m.metrics.pullsTotal.Add(ctx, 1,
 		metric.WithAttributes(attribute.String("status", status)))
+}
+
+func (m *manager) recordBuildPhaseMetrics(ctx context.Context, phase string, duration time.Duration, status, cacheStatus string) {
+	if m.metrics == nil {
+		return
+	}
+	m.metrics.buildPhaseDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(
+		attribute.String("phase", phase),
+		attribute.String("status", status),
+		attribute.String("cache_status", cacheStatus),
+	))
+}
+
+func (m *manager) recordOCIImageMetrics(ctx context.Context, layerCount int, compressedBytes int64, cacheStatus string) {
+	if m.metrics == nil {
+		return
+	}
+	attrs := metric.WithAttributes(attribute.String("cache_status", cacheStatus))
+	m.metrics.ociLayerCount.Record(ctx, int64(layerCount), attrs)
+	m.metrics.ociCompressedBytes.Record(ctx, compressedBytes, attrs)
 }

--- a/lib/images/metrics.go
+++ b/lib/images/metrics.go
@@ -53,6 +53,18 @@ func newMetrics(meter metric.Meter, m *manager) (*Metrics, error) {
 		"hypeman_images_oci_compressed_bytes",
 		metric.WithDescription("Total compressed bytes in OCI image layers being converted"),
 		metric.WithUnit("By"),
+		metric.WithExplicitBucketBoundaries(
+			1<<20,
+			4<<20,
+			16<<20,
+			64<<20,
+			256<<20,
+			1<<30,
+			2<<30,
+			4<<30,
+			8<<30,
+			16<<30,
+		),
 	)
 	if err != nil {
 		return nil, err

--- a/lib/images/metrics_test.go
+++ b/lib/images/metrics_test.go
@@ -1,0 +1,87 @@
+package images
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestImageBuildPhaseMetrics(t *testing.T) {
+	reader := otelmetric.NewManualReader()
+	provider := otelmetric.NewMeterProvider(otelmetric.WithReader(reader))
+	m := &manager{
+		paths: paths.New(t.TempDir()),
+		queue: NewBuildQueue(1),
+	}
+
+	metrics, err := newMetrics(provider.Meter("test"), m)
+	require.NoError(t, err)
+	m.metrics = metrics
+
+	m.recordPullResultMetrics(t.Context(), "sha256:test", &pullResult{
+		Metadata:        &containerMetadata{},
+		CacheHit:        true,
+		LayerCount:      74,
+		CompressedBytes: 2_467_319_902,
+		Phases: []imageBuildPhaseMeasurement{{
+			Phase:    "layer_unpack",
+			Duration: 1500 * time.Millisecond,
+			Status:   "success",
+		}},
+	})
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	phase := findImageMetric(t, rm, "hypeman_images_build_phase_duration_seconds")
+	phaseHistogram, ok := phase.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, phaseHistogram.DataPoints, 1)
+	require.Equal(t, uint64(1), phaseHistogram.DataPoints[0].Count)
+	require.InDelta(t, 1.5, phaseHistogram.DataPoints[0].Sum, 0.001)
+	requireMetricAttributes(t, phaseHistogram.DataPoints[0].Attributes, map[string]string{
+		"phase":        "layer_unpack",
+		"status":       "success",
+		"cache_status": "hit",
+	})
+
+	layers := findImageMetric(t, rm, "hypeman_images_oci_layer_count")
+	layerHistogram, ok := layers.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Equal(t, int64(74), layerHistogram.DataPoints[0].Sum)
+	requireMetricAttributes(t, layerHistogram.DataPoints[0].Attributes, map[string]string{"cache_status": "hit"})
+
+	bytes := findImageMetric(t, rm, "hypeman_images_oci_compressed_bytes")
+	bytesHistogram, ok := bytes.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Equal(t, int64(2_467_319_902), bytesHistogram.DataPoints[0].Sum)
+	requireMetricAttributes(t, bytesHistogram.DataPoints[0].Attributes, map[string]string{"cache_status": "hit"})
+}
+
+func findImageMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) metricdata.Metrics {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == name {
+				return metric
+			}
+		}
+	}
+	t.Fatalf("metric %s not found", name)
+	return metricdata.Metrics{}
+}
+
+func requireMetricAttributes(t *testing.T, attrs attribute.Set, want map[string]string) {
+	t.Helper()
+	for key, value := range want {
+		got, ok := attrs.Value(attribute.Key(key))
+		require.True(t, ok, "attribute %s not found", key)
+		require.Equal(t, value, got.AsString())
+	}
+}

--- a/lib/images/metrics_test.go
+++ b/lib/images/metrics_test.go
@@ -61,6 +61,18 @@ func TestImageBuildPhaseMetrics(t *testing.T) {
 	bytesHistogram, ok := bytes.Data.(metricdata.Histogram[int64])
 	require.True(t, ok)
 	require.Equal(t, int64(2_467_319_902), bytesHistogram.DataPoints[0].Sum)
+	require.Equal(t, []float64{
+		1 << 20,
+		4 << 20,
+		16 << 20,
+		64 << 20,
+		256 << 20,
+		1 << 30,
+		2 << 30,
+		4 << 30,
+		8 << 30,
+		16 << 30,
+	}, bytesHistogram.DataPoints[0].Bounds)
 	requireMetricAttributes(t, bytesHistogram.DataPoints[0].Attributes, map[string]string{"cache_status": "hit"})
 }
 

--- a/lib/images/oci.go
+++ b/lib/images/oci.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -175,8 +176,33 @@ func (c *ociClient) inspectDigestPlatform(ctx context.Context, imageRef string, 
 
 // pullResult contains the metadata and digest from pulling an image
 type pullResult struct {
-	Metadata *containerMetadata
-	Digest   string // sha256:abc123...
+	Metadata        *containerMetadata
+	Digest          string // sha256:abc123...
+	CacheHit        bool
+	LayerCount      int
+	CompressedBytes int64
+	Phases          []imageBuildPhaseMeasurement
+}
+
+type imageBuildPhaseMeasurement struct {
+	Phase    string
+	Duration time.Duration
+	Status   string
+}
+
+func (r *pullResult) measure(phase string, operation func() error) error {
+	start := time.Now()
+	err := operation()
+	status := "success"
+	if err != nil {
+		status = "failed"
+	}
+	r.Phases = append(r.Phases, imageBuildPhaseMeasurement{
+		Phase:    phase,
+		Duration: time.Since(start),
+		Status:   status,
+	})
+	return err
 }
 
 func (c *ociClient) pullAndExport(ctx context.Context, imageRef, digest, exportDir string) (*pullResult, error) {
@@ -188,31 +214,50 @@ func (c *ociClient) pullAndExportWithPlatform(ctx context.Context, imageRef, dig
 	// The cacheDir itself is the OCI layout root with shared blobs/sha256/ directory
 	// The digest is ALWAYS known at this point (from inspectManifest or digest reference)
 	layoutTag := digestToLayoutTag(digest)
+	result := &pullResult{Digest: digest}
 
 	// Check if this digest is already cached
-	if !c.existsInLayout(layoutTag) {
+	cacheLookupStart := time.Now()
+	result.CacheHit = c.existsInLayout(layoutTag)
+	result.Phases = append(result.Phases, imageBuildPhaseMeasurement{
+		Phase:    "oci_cache_lookup",
+		Duration: time.Since(cacheLookupStart),
+		Status:   "success",
+	})
+	if !result.CacheHit {
 		// Not cached, pull it using digest-based tag
-		if err := c.pullToOCILayoutWithPlatform(ctx, imageRef, layoutTag, platform); err != nil {
-			return nil, fmt.Errorf("pull to oci layout: %w", err)
+		if err := result.measure("registry_pull", func() error {
+			return c.pullToOCILayoutWithPlatform(ctx, imageRef, layoutTag, platform)
+		}); err != nil {
+			return result, fmt.Errorf("pull to oci layout: %w", err)
 		}
 	}
 	// If cached, we skip the pull entirely
 
 	// Extract metadata (from cache or freshly pulled)
-	meta, err := c.extractOCIMetadata(layoutTag)
+	var meta *containerMetadata
+	var layerCount int
+	var compressedBytes int64
+	err := result.measure("metadata_extract", func() error {
+		var err error
+		meta, layerCount, compressedBytes, err = c.extractOCIImageDetails(layoutTag)
+		return err
+	})
 	if err != nil {
-		return nil, fmt.Errorf("extract metadata: %w", err)
+		return result, fmt.Errorf("extract metadata: %w", err)
 	}
+	result.Metadata = meta
+	result.LayerCount = layerCount
+	result.CompressedBytes = compressedBytes
 
 	// Unpack layers to the export directory
-	if err := c.unpackLayers(ctx, layoutTag, exportDir); err != nil {
-		return nil, fmt.Errorf("unpack layers: %w", err)
+	if err := result.measure("layer_unpack", func() error {
+		return c.unpackLayers(ctx, layoutTag, exportDir)
+	}); err != nil {
+		return result, fmt.Errorf("unpack layers: %w", err)
 	}
 
-	return &pullResult{
-		Metadata: meta,
-		Digest:   digest,
-	}, nil
+	return result, nil
 }
 
 func (c *ociClient) pullToOCILayout(ctx context.Context, imageRef, layoutTag string) error {
@@ -317,22 +362,36 @@ func imageByAnnotation(path layout.Path, layoutTag string) (gcr.Image, error) {
 // extractOCIMetadata reads metadata from OCI layout config.json
 // Uses go-containerregistry which handles both Docker v2 and OCI v1 manifests.
 func (c *ociClient) extractOCIMetadata(layoutTag string) (*containerMetadata, error) {
+	meta, _, _, err := c.extractOCIImageDetails(layoutTag)
+	return meta, err
+}
+
+func (c *ociClient) extractOCIImageDetails(layoutTag string) (*containerMetadata, int, int64, error) {
 	// Open OCI layout using go-containerregistry (handles Docker v2 and OCI v1)
 	path, err := layout.FromPath(c.cacheDir)
 	if err != nil {
-		return nil, fmt.Errorf("open oci layout: %w", err)
+		return nil, 0, 0, fmt.Errorf("open oci layout: %w", err)
 	}
 
 	// Get the image by annotation tag from the layout
 	img, err := imageByAnnotation(path, layoutTag)
 	if err != nil {
-		return nil, fmt.Errorf("find image by tag %s: %w", layoutTag, err)
+		return nil, 0, 0, fmt.Errorf("find image by tag %s: %w", layoutTag, err)
 	}
 
 	// Get config file (go-containerregistry handles manifest format automatically)
 	configFile, err := img.ConfigFile()
 	if err != nil {
-		return nil, fmt.Errorf("get config file: %w", err)
+		return nil, 0, 0, fmt.Errorf("get config file: %w", err)
+	}
+
+	manifest, err := img.Manifest()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("get manifest: %w", err)
+	}
+	var compressedBytes int64
+	for _, layer := range manifest.Layers {
+		compressedBytes += layer.Size
 	}
 
 	// Extract metadata from config. OS/Architecture/Variant come straight from
@@ -365,7 +424,7 @@ func (c *ociClient) extractOCIMetadata(layoutTag string) (*containerMetadata, er
 		meta.Labels[key] = value
 	}
 
-	return meta, nil
+	return meta, len(manifest.Layers), compressedBytes, nil
 }
 
 // unpackLayers unpacks all OCI layers to a target directory using umoci

--- a/lib/images/oci_test.go
+++ b/lib/images/oci_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -22,6 +23,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPullResultMeasureRecordsFailure(t *testing.T) {
+	result := &pullResult{}
+	wantErr := errors.New("boom")
+
+	err := result.measure("registry_pull", func() error { return wantErr })
+
+	require.ErrorIs(t, err, wantErr)
+	require.Len(t, result.Phases, 1)
+	assert.Equal(t, "registry_pull", result.Phases[0].Phase)
+	assert.Equal(t, "failed", result.Phases[0].Status)
+}
 
 const testImageKernelVersion = "ch-6.12.8-kernel-1.6-202603301"
 
@@ -402,6 +415,16 @@ func TestDockerSaveToOCILayoutCacheHit(t *testing.T) {
 	assert.Equal(t, "/app", result.Metadata.WorkingDir)
 	assert.Equal(t, digestStr, result.Digest)
 	assert.Equal(t, testImageKernelVersion, result.Metadata.Labels["io.kernel.kernel-version"])
+	assert.True(t, result.CacheHit)
+	assert.Positive(t, result.LayerCount)
+	assert.Positive(t, result.CompressedBytes)
+	require.Len(t, result.Phases, 3)
+	assert.Equal(t, "oci_cache_lookup", result.Phases[0].Phase)
+	assert.Equal(t, "metadata_extract", result.Phases[1].Phase)
+	assert.Equal(t, "layer_unpack", result.Phases[2].Phase)
+	for _, phase := range result.Phases {
+		assert.Equal(t, "success", phase.Status)
+	}
 
 	// Verify rootfs was unpacked (umoci extracts directly into exportDir)
 	agentPath := filepath.Join(exportDir, "usr", "local", "bin", "guest-agent")


### PR DESCRIPTION
## Why

Hypeship staging spends about 146 seconds per host converting each new agent image digest, but Hypeman currently exposes only one end-to-end image build duration. That cannot distinguish registry transfer, cached-layer unpacking, filesystem creation, or finalization, so the next optimization would be guesswork.

## What

- Record `hypeman_images_build_phase_duration_seconds` with bounded `phase`, `status`, and `cache_status` attributes.
- Separate `oci_cache_lookup`, `registry_pull`, `metadata_extract`, `layer_unpack`, `filesystem_export`, `finalize`, and `cleanup`.
- Record OCI layer count and compressed layer bytes so phase duration can be correlated with image shape.
- Emit structured per-digest phase logs without putting the digest in metric labels.
- Record total build duration consistently on conversion and finalization failures and after cleanup.

## How

The OCI pull result carries timings collected directly around each operation. The image manager publishes them through OpenTelemetry and adds its own filesystem/finalization/cleanup measurements. Cache hits omit the registry-pull phase, making cached unpack cost directly visible.

This does not change pulling, unpacking, conversion, image metadata, or VM launch behavior.

## Before / after

Before: one total build histogram and a pull counter; a 146-second conversion cannot be decomposed.

After: dashboards and logs can answer whether time is spent downloading layers, unpacking all cached layers, or rebuilding EROFS, separately for cache hits and misses.

## Verification

- `DOCKER_CONFIG=/private/tmp/hypeman-empty-docker-config GOCACHE=/private/tmp/hypeman-go-cache go test -tags containers_image_openpgp ./lib/images -count=1`
- `GOCACHE=/private/tmp/hypeman-go-cache go test ./lib/images -run TestImageBuildPhaseMetrics -race -count=1`
- `GOCACHE=/private/tmp/hypeman-go-cache go vet -tags containers_image_openpgp ./lib/images`
- `git diff --check`

The full CI-tagged image package passed against Docker Hub in 17.6 seconds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only refactor with a small `finalizeImage` extraction; no changes to pull, unpack, conversion, or VM launch paths.
> 
> **Overview**
> Adds **per-phase observability** for image builds so long conversions can be broken down instead of relying on a single end-to-end duration.
> 
> The OCI client now times **oci_cache_lookup**, **registry_pull** (skipped on cache hit), **metadata_extract**, and **layer_unpack**, and returns layer count plus compressed byte totals. The manager records **filesystem_export**, **finalize**, and **cleanup**, publishes `hypeman_images_build_phase_duration_seconds` (with `phase`, `status`, `cache_status`), and adds OCI layer-count / compressed-bytes histograms. **Structured slog** logs per digest/phase; digest stays out of metric labels.
> 
> **Total build duration** is recorded via a single deferred path on all exit paths (including after cleanup). Final metadata/tag symlink work is extracted into `finalizeImage` without changing pull/unpack/conversion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f4780465ccbc381220042466ae21d03f78e795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->