### PR TITLE
Prevent systemd test VM leaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,40 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
+          set -euo pipefail
+
+          runner_cgroup="$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)"
+          guest_pids=()
+          if [ -n "$runner_cgroup" ] && [ "$runner_cgroup" != "/" ]; then
+            for proc in /proc/[0-9]*; do
+              process_cgroup="$(awk -F: '$1 == "0" { print $3 }' "$proc/cgroup" 2>/dev/null || true)"
+              if [ "$process_cgroup" != "$runner_cgroup" ]; then
+                continue
+              fi
+
+              comm="$(cat "$proc/comm" 2>/dev/null || true)"
+              cmdline="$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null || true)"
+              case "$comm" in
+                cloud-hypervis|firecracker|qemu-system-*)
+                  if [[ "$cmdline" == *"/ci/"* ]]; then
+                    guest_pids+=("${proc##*/}")
+                  fi
+                  ;;
+              esac
+            done
+          fi
+
+          if (( ${#guest_pids[@]} > 0 )); then
+            echo "Stopping leftover test VMs: ${guest_pids[*]}"
+            sudo kill -TERM "${guest_pids[@]}" 2>/dev/null || true
+            sleep 2
+            for pid in "${guest_pids[@]}"; do
+              if sudo kill -0 "$pid" 2>/dev/null; then
+                sudo kill -KILL "$pid" 2>/dev/null || true
+              fi
+            done
+          fi
+
           units="$(systemctl list-units --all --full --plain 'hypeman-uffd@ci-${{ github.run_id }}-${{ github.run_attempt }}-*.service' --no-legend | awk '{print $1}' || true)"
           if [ -n "$units" ]; then
             echo "$units" | xargs -r sudo systemctl stop || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,26 +170,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          runner_cgroup="$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup)"
+          run_prefix="ci-${{ github.run_id }}-${{ github.run_attempt }}"
           guest_pids=()
-          if [ -n "$runner_cgroup" ] && [ "$runner_cgroup" != "/" ]; then
-            for proc in /proc/[0-9]*; do
-              process_cgroup="$(awk -F: '$1 == "0" { print $3 }' "$proc/cgroup" 2>/dev/null || true)"
-              if [ "$process_cgroup" != "$runner_cgroup" ]; then
-                continue
-              fi
-
-              comm="$(cat "$proc/comm" 2>/dev/null || true)"
-              cmdline="$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null || true)"
-              case "$comm" in
-                cloud-hypervis|firecracker|qemu-system-*)
-                  if [[ "$cmdline" == *"/ci/"* ]]; then
-                    guest_pids+=("${proc##*/}")
-                  fi
-                  ;;
-              esac
-            done
-          fi
+          mapfile -t vmm_pids < <(pgrep -x 'cloud-hyperviso|firecracker|qemu-system-.*' || true)
+          for pid in "${vmm_pids[@]}"; do
+            proc="/proc/$pid"
+            cmdline="$(cat "$proc/cmdline" 2>/dev/null | tr '\0' ' ' || true)"
+            if [[ "$cmdline" == *"/ci/"* ]] && sudo grep -zFqx "HYPEMAN_UFFD_SYSTEMD_INSTANCE_PREFIX=$run_prefix" "$proc/environ" 2>/dev/null; then
+              guest_pids+=("$pid")
+            fi
+          done
 
           if (( ${#guest_pids[@]} > 0 )); then
             echo "Stopping leftover test VMs: ${guest_pids[*]}"

--- a/integration/systemd_test.go
+++ b/integration/systemd_test.go
@@ -72,11 +72,6 @@ func TestSystemdMode(t *testing.T) {
 
 	instanceManager := instances.NewManager(p, imageManager, systemManager, networkManager, deviceManager, volumeManager, limits, "", instances.SnapshotPolicy{}, nil, nil)
 
-	// Cleanup any orphaned instances
-	t.Cleanup(func() {
-		instanceManager.DeleteInstance(ctx, "systemd-test")
-	})
-
 	imageName := integrationTestImageRef(t, "docker.io/jrei/systemd-ubuntu:22.04")
 
 	// Pull the systemd image
@@ -121,6 +116,13 @@ func TestSystemdMode(t *testing.T) {
 		NetworkEnabled: false, // No network needed for this test
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		if err := instanceManager.DeleteInstance(cleanupCtx, inst.Id); err != nil {
+			t.Errorf("delete systemd test instance during cleanup: %v", err)
+		}
+	})
 	t.Logf("Instance created: %s", inst.Id)
 
 	// Wait for guest agent to be ready


### PR DESCRIPTION
## Summary

- register systemd VM cleanup only after instance creation, then delete the generated instance ID with a fresh bounded context
- report cleanup failures instead of silently ignoring them
- reap `/ci`-backed VMMs carrying the current workflow run's environment marker from the always-run cleanup step

The test cleanup previously used the test's canceled context and passed the instance name instead of its generated ID. The workflow fallback covers process-level `go test` timeouts, where `t.Cleanup` cannot run, while the exact run marker prevents cleanup from touching VMs owned by another job.

## Testing

- `GOCACHE=/tmp/go-build-cache go test -tags containers_image_openpgp ./integration -run '^$'`
- `GOCACHE=/tmp/go-build-cache go test -tags containers_image_openpgp ./integration -run '^TestSystemdMode$' -short`
- `GOCACHE=/tmp/go-build-cache go vet -tags containers_image_openpgp ./integration`
- `actionlint -ignore 'label "kvm" is unknown' .github/workflows/test.yml`
- extracted cleanup shell: `bash -n`
- GitHub Actions: Linux KVM tests, macOS tests, and install tests passed
- Cursor Bugbot passed on the latest commit
