### PR TITLE
Validate filesystem-backed resource IDs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Submit reports through [Kernel's HackerOne vulnerability disclosure program](https://hackerone.com/6b6581d9-326f-492c-978a-4ccdb54863b9/embedded_submissions/new?locale=en). Additional reporting guidance is available in the [Kernel documentation](https://www.kernel.sh/docs/security-vulnerability-reporting).
+
+For questions about the program, contact [security@kernel.sh](mailto:security@kernel.sh).

--- a/cmd/api/api/volumes.go
+++ b/cmd/api/api/volumes.go
@@ -78,7 +78,7 @@ func (s *ApiService) CreateVolume(ctx context.Context, request oapi.CreateVolume
 				Message: "volume with this ID already exists",
 			}, nil
 		}
-		if errors.Is(err, tags.ErrInvalidTags) {
+		if errors.Is(err, tags.ErrInvalidTags) || errors.Is(err, volumes.ErrInvalidID) {
 			return oapi.CreateVolume400JSONResponse{
 				Code:    "invalid_request",
 				Message: err.Error(),
@@ -151,7 +151,7 @@ func (s *ApiService) CreateVolumeFromArchive(ctx context.Context, request oapi.C
 				Message: "volume with this ID already exists",
 			}, nil
 		}
-		if errors.Is(err, tags.ErrInvalidTags) {
+		if errors.Is(err, tags.ErrInvalidTags) || errors.Is(err, volumes.ErrInvalidID) {
 			return oapi.CreateVolumeFromArchive400JSONResponse{
 				Code:    "invalid_request",
 				Message: err.Error(),

--- a/cmd/api/api/volumes_test.go
+++ b/cmd/api/api/volumes_test.go
@@ -31,14 +31,14 @@ func TestGetVolume_NotFound(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestGetVolume_ByName(t *testing.T) {
+func TestGetVolume_ByPathLikeName(t *testing.T) {
 	t.Parallel()
 	svc := newTestService(t)
 
 	// Create a volume
 	createResp, err := svc.CreateVolume(ctx(), oapi.CreateVolumeRequestObject{
 		Body: &oapi.CreateVolumeRequest{
-			Name:   "my-data",
+			Name:   "team/data",
 			SizeGb: 1,
 		},
 	})
@@ -46,15 +46,15 @@ func TestGetVolume_ByName(t *testing.T) {
 	created := createResp.(oapi.CreateVolume201JSONResponse)
 
 	// Get by name (not ID) - use ctxWithVolume to simulate middleware
-	resp, err := svc.GetVolume(ctxWithVolume(svc, "my-data"), oapi.GetVolumeRequestObject{
-		Id: "my-data", // using name instead of ID
+	resp, err := svc.GetVolume(ctxWithVolume(svc, "team/data"), oapi.GetVolumeRequestObject{
+		Id: "team/data", // using name instead of ID
 	})
 	require.NoError(t, err)
 
 	vol, ok := resp.(oapi.GetVolume200JSONResponse)
 	require.True(t, ok, "expected 200 response")
 	assert.Equal(t, created.Id, vol.Id)
-	assert.Equal(t, "my-data", vol.Name)
+	assert.Equal(t, "team/data", vol.Name)
 }
 
 func TestDeleteVolume_ByName(t *testing.T) {
@@ -77,6 +77,24 @@ func TestDeleteVolume_ByName(t *testing.T) {
 	require.NoError(t, err)
 	_, ok := resp.(oapi.DeleteVolume204Response)
 	assert.True(t, ok, "expected 204 response")
+}
+
+func TestCreateVolume_InvalidID(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	id := "../outside"
+
+	resp, err := svc.CreateVolume(ctx(), oapi.CreateVolumeRequestObject{Body: &oapi.CreateVolumeRequest{Name: "invalid", SizeGb: 1, Id: &id}})
+	require.NoError(t, err)
+	_, ok := resp.(oapi.CreateVolume400JSONResponse)
+	require.True(t, ok, "expected 400 for invalid ID")
+
+	archiveResp, err := svc.CreateVolumeFromArchive(ctx(), oapi.CreateVolumeFromArchiveRequestObject{
+		Params: oapi.CreateVolumeFromArchiveParams{Name: "invalid", SizeGb: 1, Id: &id},
+	})
+	require.NoError(t, err)
+	_, ok = archiveResp.(oapi.CreateVolumeFromArchive400JSONResponse)
+	require.True(t, ok, "expected 400 for invalid archive volume ID")
 }
 
 func TestCreateVolume_ReservedIDPrefix(t *testing.T) {

--- a/lib/builders/manager.go
+++ b/lib/builders/manager.go
@@ -75,7 +75,7 @@ var builderIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`)
 
 // ValidateBuilderID validates a caller-supplied builder ID.
 func ValidateBuilderID(id string) error {
-	if !builderIDPattern.MatchString(id) {
+	if paths.ValidatePathComponent(id) != nil || !builderIDPattern.MatchString(id) {
 		return fmt.Errorf("%w: must match %s", ErrInvalidID, builderIDPattern)
 	}
 	return nil

--- a/lib/builders/manager_test.go
+++ b/lib/builders/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -691,6 +692,21 @@ func TestIdleReaper_SkipsQueuedBuilds(t *testing.T) {
 
 	_, err = m.GetBuilder(context.Background(), b.ID)
 	assert.NoError(t, err, "builder with a queued build must not be reaped")
+}
+
+func TestBuilderStorageRejectsPathTraversal(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "data")
+	p := paths.New(dataDir)
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "metadata.json"), []byte(`{"id":"outside"}`), 0644))
+	marker := filepath.Join(dataDir, "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))
+
+	_, err := loadMetadata(p, "..")
+	require.ErrorIs(t, err, ErrNotFound)
+	require.ErrorIs(t, saveMetadata(p, &storedMetadata{ID: ".."}), ErrInvalidID)
+	require.ErrorIs(t, deleteBuilderData(p, ".."), ErrNotFound)
+	require.FileExists(t, marker)
 }
 
 func TestValidateBuilderID(t *testing.T) {

--- a/lib/builders/storage.go
+++ b/lib/builders/storage.go
@@ -27,6 +27,9 @@ type storedMetadata struct {
 
 // loadMetadata loads builder metadata from disk
 func loadMetadata(p *paths.Paths, id string) (*storedMetadata, error) {
+	if err := ValidateBuilderID(id); err != nil {
+		return nil, ErrNotFound
+	}
 	data, err := os.ReadFile(p.BuilderMetadata(id))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -45,6 +48,9 @@ func loadMetadata(p *paths.Paths, id string) (*storedMetadata, error) {
 
 // saveMetadata writes builder metadata to disk atomically
 func saveMetadata(p *paths.Paths, meta *storedMetadata) error {
+	if err := ValidateBuilderID(meta.ID); err != nil {
+		return err
+	}
 	dir := p.BuilderDir(meta.ID)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create builder directory: %w", err)
@@ -69,6 +75,9 @@ func saveMetadata(p *paths.Paths, meta *storedMetadata) error {
 
 // deleteBuilderData removes all builder data from disk
 func deleteBuilderData(p *paths.Paths, id string) error {
+	if err := ValidateBuilderID(id); err != nil {
+		return ErrNotFound
+	}
 	if err := os.RemoveAll(p.BuilderDir(id)); err != nil {
 		return fmt.Errorf("remove builder directory: %w", err)
 	}

--- a/lib/builds/manager_test.go
+++ b/lib/builds/manager_test.go
@@ -292,8 +292,8 @@ func (m *mockVolumeManager) DetachVolume(ctx context.Context, volumeID string, i
 	return nil
 }
 
-func (m *mockVolumeManager) GetVolumePath(id string) string {
-	return "/tmp/volumes/" + id
+func (m *mockVolumeManager) GetVolumePath(id string) (string, error) {
+	return "/tmp/volumes/" + id, nil
 }
 
 func (m *mockVolumeManager) TotalVolumeBytes(ctx context.Context) (int64, error) {

--- a/lib/builds/storage.go
+++ b/lib/builds/storage.go
@@ -54,6 +54,9 @@ func (m *buildMetadata) toBuild() *Build {
 
 // writeMetadata writes build metadata to disk atomically
 func writeMetadata(p *paths.Paths, meta *buildMetadata) error {
+	if err := paths.ValidatePathComponent(meta.ID); err != nil {
+		return err
+	}
 	dir := p.BuildDir(meta.ID)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create build directory: %w", err)
@@ -81,6 +84,9 @@ func writeMetadata(p *paths.Paths, meta *buildMetadata) error {
 
 // readMetadata reads build metadata from disk
 func readMetadata(p *paths.Paths, id string) (*buildMetadata, error) {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return nil, ErrNotFound
+	}
 	path := p.BuildMetadata(id)
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -157,6 +163,9 @@ func listPendingBuilds(p *paths.Paths) ([]*buildMetadata, error) {
 
 // deleteBuild removes a build's data from disk
 func deleteBuild(p *paths.Paths, id string) error {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return ErrNotFound
+	}
 	dir := p.BuildDir(id)
 
 	// Check if exists
@@ -176,6 +185,9 @@ func deleteBuild(p *paths.Paths, id string) error {
 
 // ensureLogsDir ensures the logs directory exists for a build
 func ensureLogsDir(p *paths.Paths, id string) error {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return err
+	}
 	logsDir := p.BuildLogs(id)
 	return os.MkdirAll(logsDir, 0755)
 }
@@ -214,6 +226,9 @@ func writeLog(p *paths.Paths, id string, data []byte) error {
 
 // readLog reads the build log file
 func readLog(p *paths.Paths, id string) ([]byte, error) {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return nil, ErrNotFound
+	}
 	logPath := p.BuildLog(id)
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -227,6 +242,9 @@ func readLog(p *paths.Paths, id string) ([]byte, error) {
 
 // writeBuildConfig writes the build config for the builder VM
 func writeBuildConfig(p *paths.Paths, id string, config *BuildConfig) error {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return err
+	}
 	dir := p.BuildDir(id)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create build directory: %w", err)
@@ -247,6 +265,9 @@ func writeBuildConfig(p *paths.Paths, id string, config *BuildConfig) error {
 
 // readBuildConfig reads the build config for a build
 func readBuildConfig(p *paths.Paths, id string) (*BuildConfig, error) {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return nil, ErrNotFound
+	}
 	configPath := p.BuildConfig(id)
 	data, err := os.ReadFile(configPath)
 	if err != nil {

--- a/lib/builds/storage_test.go
+++ b/lib/builds/storage_test.go
@@ -18,10 +18,29 @@ func TestBuildStorageRejectsPathTraversal(t *testing.T) {
 	marker := filepath.Join(dataDir, "keep")
 	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))
 
-	_, err := readMetadata(p, "..")
-	require.ErrorIs(t, err, ErrNotFound)
-	require.ErrorIs(t, writeMetadata(p, &buildMetadata{ID: ".."}), paths.ErrInvalidPathComponent)
-	require.ErrorIs(t, deleteBuild(p, ".."), ErrNotFound)
+	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, "logs"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "logs", "build.log"), []byte("outside"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.json"), []byte(`{}`), 0644))
+
+	tests := []struct {
+		name string
+		run  func() error
+		want error
+	}{
+		{"read metadata", func() error { _, err := readMetadata(p, ".."); return err }, ErrNotFound},
+		{"write metadata", func() error { return writeMetadata(p, &buildMetadata{ID: ".."}) }, paths.ErrInvalidPathComponent},
+		{"delete build", func() error { return deleteBuild(p, "..") }, ErrNotFound},
+		{"append log", func() error { return appendLog(p, "..", []byte("data")) }, paths.ErrInvalidPathComponent},
+		{"write log", func() error { return writeLog(p, "..", []byte("data")) }, paths.ErrInvalidPathComponent},
+		{"read log", func() error { _, err := readLog(p, ".."); return err }, ErrNotFound},
+		{"write config", func() error { return writeBuildConfig(p, "..", &BuildConfig{}) }, paths.ErrInvalidPathComponent},
+		{"read config", func() error { _, err := readBuildConfig(p, ".."); return err }, ErrNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, tt.run(), tt.want)
+		})
+	}
 	require.FileExists(t, marker)
 }
 

--- a/lib/builds/storage_test.go
+++ b/lib/builds/storage_test.go
@@ -10,6 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBuildStorageRejectsPathTraversal(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "data")
+	p := paths.New(dataDir)
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "metadata.json"), []byte(`{"id":"outside"}`), 0644))
+	marker := filepath.Join(dataDir, "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))
+
+	_, err := readMetadata(p, "..")
+	require.ErrorIs(t, err, ErrNotFound)
+	require.ErrorIs(t, writeMetadata(p, &buildMetadata{ID: ".."}), paths.ErrInvalidPathComponent)
+	require.ErrorIs(t, deleteBuild(p, ".."), ErrNotFound)
+	require.FileExists(t, marker)
+}
+
 func TestBuildMetadataReadWrite_MetadataRoundTrip(t *testing.T) {
 	tempDir := t.TempDir()
 	p := paths.New(tempDir)

--- a/lib/devices/manager.go
+++ b/lib/devices/manager.go
@@ -265,6 +265,9 @@ func (m *manager) DeleteDevice(ctx context.Context, id string) error {
 	}
 
 	// Remove device directory
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return ErrNotFound
+	}
 	if err := os.RemoveAll(m.paths.DeviceDir(id)); err != nil {
 		return fmt.Errorf("remove device dir: %w", err)
 	}
@@ -721,6 +724,9 @@ func (m *manager) resetOrphanedDevice(ctx context.Context, device *Device, stats
 // Helper methods
 
 func (m *manager) loadDevice(id string) (*Device, error) {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return nil, ErrNotFound
+	}
 	data, err := os.ReadFile(m.paths.DeviceMetadata(id))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -738,6 +744,9 @@ func (m *manager) loadDevice(id string) (*Device, error) {
 }
 
 func (m *manager) saveDevice(device *Device) error {
+	if err := paths.ValidatePathComponent(device.Id); err != nil {
+		return err
+	}
 	data, err := json.MarshalIndent(device, "", "  ")
 	if err != nil {
 		return err

--- a/lib/devices/manager_test.go
+++ b/lib/devices/manager_test.go
@@ -1,7 +1,9 @@
 package devices
 
 import (
+	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -163,6 +165,21 @@ func TestErrors(t *testing.T) {
 		assert.Contains(t, ErrInUse.Error(), "in use")
 		assert.Contains(t, ErrInvalidName.Error(), "pattern")
 	})
+}
+
+func TestDeviceLookupAndDeleteRejectPathTraversal(t *testing.T) {
+	p := paths.New(filepath.Join(t.TempDir(), "data"))
+	require.NoError(t, os.MkdirAll(p.DataDir(), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(p.DataDir(), "metadata.json"), []byte(`{"id":"outside"}`), 0644))
+	marker := filepath.Join(p.DataDir(), "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))
+	mgr := &manager{paths: p, vfioBinder: NewVFIOBinder()}
+
+	_, err := mgr.GetDevice(context.Background(), "..")
+	require.ErrorIs(t, err, ErrNotFound)
+	require.ErrorIs(t, mgr.saveDevice(&Device{Id: ".."}), paths.ErrInvalidPathComponent)
+	require.ErrorIs(t, mgr.DeleteDevice(context.Background(), ".."), ErrNotFound)
+	require.FileExists(t, marker)
 }
 
 func TestSaveLoadDevice_MetadataRoundTrip(t *testing.T) {

--- a/lib/imagepush/manager.go
+++ b/lib/imagepush/manager.go
@@ -251,7 +251,7 @@ func (m *manager) executePush(ctx context.Context, meta *pushMetadata, provider 
 func (m *manager) persistTerminal(meta *pushMetadata) error {
 	if err := m.writeTerminal(meta); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: push %s to %s finished as %s but the job record could not be persisted: %v\n", meta.ID, meta.Target, strings.ToLower(meta.Status), err)
-		os.RemoveAll(m.paths.PushDir(meta.ID))
+		removePushData(m.paths, meta.ID)
 		persistErr := fmt.Errorf("job record could not be persisted: %w", err)
 		errorMsg := persistErr.Error()
 		meta.Status = StatusFailed
@@ -459,7 +459,7 @@ func (m *manager) failRecovered(meta *pushMetadata, reason string) {
 	meta.CompletedAt = &now
 	if err := m.writeTerminal(meta); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: dropping unrecoverable push record %s: %v\n", meta.ID, err)
-		os.RemoveAll(m.paths.PushDir(meta.ID))
+		removePushData(m.paths, meta.ID)
 	}
 	m.notify(meta.ID, StatusFailed, errors.New(reason))
 }

--- a/lib/imagepush/storage.go
+++ b/lib/imagepush/storage.go
@@ -47,6 +47,9 @@ func (m *pushMetadata) toPush() *Push {
 
 // writeMetadata writes push metadata to disk atomically.
 func writeMetadata(p *paths.Paths, meta *pushMetadata) error {
+	if err := paths.ValidatePathComponent(meta.ID); err != nil {
+		return err
+	}
 	dir := p.PushDir(meta.ID)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create push directory: %w", err)
@@ -98,6 +101,9 @@ func writeMetadata(p *paths.Paths, meta *pushMetadata) error {
 }
 
 func readMetadata(p *paths.Paths, id string) (*pushMetadata, error) {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return nil, ErrNotFound
+	}
 	data, err := os.ReadFile(p.PushMetadata(id))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -110,8 +116,18 @@ func readMetadata(p *paths.Paths, id string) (*pushMetadata, error) {
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return nil, fmt.Errorf("unmarshal metadata: %w", err)
 	}
+	if err := paths.ValidatePathComponent(meta.ID); err != nil {
+		return nil, fmt.Errorf("invalid push metadata id: %w", err)
+	}
 
 	return &meta, nil
+}
+
+func removePushData(p *paths.Paths, id string) error {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return ErrNotFound
+	}
+	return os.RemoveAll(p.PushDir(id))
 }
 
 // listAllPushes returns all pushes sorted by creation time (newest first).
@@ -169,7 +185,7 @@ func removeOrphanedPushDirs(p *paths.Paths) {
 		}
 		if _, err := os.Stat(p.PushMetadata(entry.Name())); errors.Is(err, os.ErrNotExist) {
 			fmt.Fprintf(os.Stderr, "Warning: removing orphaned push directory %s (no metadata.json)\n", entry.Name())
-			os.RemoveAll(p.PushDir(entry.Name()))
+			removePushData(p, entry.Name())
 		}
 	}
 }

--- a/lib/imagepush/storage_test.go
+++ b/lib/imagepush/storage_test.go
@@ -3,11 +3,28 @@ package imagepush
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/kernel/hypeman/lib/paths"
+	"github.com/stretchr/testify/require"
 )
+
+func TestPushStorageRejectsPathTraversal(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "data")
+	p := paths.New(dataDir)
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "metadata.json"), []byte(`{"id":"outside"}`), 0644))
+
+	marker := filepath.Join(dataDir, "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))
+	_, err := readMetadata(p, "..")
+	require.ErrorIs(t, err, ErrNotFound)
+	require.ErrorIs(t, writeMetadata(p, &pushMetadata{ID: ".."}), paths.ErrInvalidPathComponent)
+	require.ErrorIs(t, removePushData(p, ".."), ErrNotFound)
+	require.FileExists(t, marker)
+}
 
 func TestPushMetadataRoundTrip(t *testing.T) {
 	p := paths.New(t.TempDir())

--- a/lib/ingress/storage.go
+++ b/lib/ingress/storage.go
@@ -34,6 +34,9 @@ func ensureIngressDir(p *paths.Paths) error {
 
 // loadIngress loads ingress metadata from disk.
 func loadIngress(p *paths.Paths, id string) (*storedIngress, error) {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return nil, ErrNotFound
+	}
 	metaPath := p.IngressMetadata(id)
 
 	data, err := os.ReadFile(metaPath)
@@ -54,6 +57,9 @@ func loadIngress(p *paths.Paths, id string) (*storedIngress, error) {
 
 // saveIngress saves ingress metadata to disk.
 func saveIngress(p *paths.Paths, stored *storedIngress) error {
+	if err := paths.ValidatePathComponent(stored.ID); err != nil {
+		return err
+	}
 	if err := ensureIngressDir(p); err != nil {
 		return err
 	}
@@ -92,6 +98,9 @@ func saveIngress(p *paths.Paths, stored *storedIngress) error {
 
 // deleteIngressData removes ingress data from disk.
 func deleteIngressData(p *paths.Paths, id string) error {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return ErrNotFound
+	}
 	metaPath := p.IngressMetadata(id)
 
 	if err := os.Remove(metaPath); err != nil {

--- a/lib/ingress/storage_test.go
+++ b/lib/ingress/storage_test.go
@@ -1,0 +1,24 @@
+package ingress
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIngressStorageRejectsPathTraversal(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "data")
+	p := paths.New(dataDir)
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+	outside := filepath.Join(dataDir, "outside.json")
+	require.NoError(t, os.WriteFile(outside, []byte(`{"id":"outside"}`), 0644))
+
+	_, err := loadIngress(p, "../outside")
+	require.ErrorIs(t, err, ErrNotFound)
+	require.ErrorIs(t, saveIngress(p, &storedIngress{ID: "../outside"}), paths.ErrInvalidPathComponent)
+	require.ErrorIs(t, deleteIngressData(p, "../outside"), ErrNotFound)
+	require.FileExists(t, outside)
+}

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -839,7 +839,10 @@ func (m *manager) buildHypervisorConfig(ctx context.Context, inst *Instance, ima
 
 	// Add attached volumes as additional disks
 	for _, volAttach := range inst.Volumes {
-		volumePath := m.volumeManager.GetVolumePath(volAttach.VolumeID)
+		volumePath, err := m.volumeManager.GetVolumePath(volAttach.VolumeID)
+		if err != nil {
+			return hypervisor.VMConfig{}, fmt.Errorf("get volume path: %w", err)
+		}
 		if volAttach.Overlay {
 			// Base volume is always read-only when overlay is enabled
 			disks = append(disks, hypervisor.DiskConfig{

--- a/lib/instances/snapshot.go
+++ b/lib/instances/snapshot.go
@@ -37,7 +37,7 @@ func (m *manager) getSnapshot(ctx context.Context, snapshotID string) (*Snapshot
 	_ = ctx
 	snapshot, err := m.snapshotStore().Get(snapshotID)
 	if err != nil {
-		if errors.Is(err, snapshotstore.ErrNotFound) {
+		if errors.Is(err, snapshotstore.ErrNotFound) || errors.Is(err, snapshotstore.ErrInvalidID) {
 			return nil, ErrSnapshotNotFound
 		}
 		return nil, err
@@ -232,7 +232,7 @@ func (m *manager) deleteSnapshot(ctx context.Context, snapshotID string) error {
 		m.recordSnapshotCompressionPreemption(ctx, snapshotCompressionPreemptionDeleteSnapshot, target.Target)
 	}
 	if err := m.snapshotStore().Delete(snapshotID); err != nil {
-		if errors.Is(err, snapshotstore.ErrNotFound) {
+		if errors.Is(err, snapshotstore.ErrNotFound) || errors.Is(err, snapshotstore.ErrInvalidID) {
 			return ErrSnapshotNotFound
 		}
 		return err
@@ -637,7 +637,7 @@ func (m *manager) saveSnapshotRecord(rec *snapshotRecord) error {
 func (m *manager) loadSnapshotRecord(snapshotID string) (*snapshotRecord, error) {
 	record, err := snapshotstore.LoadTypedRecord[StoredMetadata](m.snapshotStore(), snapshotID)
 	if err != nil {
-		if errors.Is(err, snapshotstore.ErrNotFound) {
+		if errors.Is(err, snapshotstore.ErrNotFound) || errors.Is(err, snapshotstore.ErrInvalidID) {
 			return nil, ErrSnapshotNotFound
 		}
 		return nil, err

--- a/lib/instances/snapshot_test.go
+++ b/lib/instances/snapshot_test.go
@@ -61,6 +61,28 @@ func TestStoppedSnapshotLifecycleAndForkAfterSourceDeletion(t *testing.T) {
 	assert.ErrorIs(t, err, ErrSnapshotNotFound)
 }
 
+func TestSnapshotOperationsRejectPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := setupTestManager(t)
+	ctx := context.Background()
+	marker := filepath.Join(mgr.paths.DataDir(), "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))
+
+	_, err := mgr.GetSnapshot(ctx, "..")
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+
+	err = mgr.DeleteSnapshot(ctx, "..")
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+	require.FileExists(t, marker)
+
+	_, err = mgr.ForkSnapshot(ctx, "..", ForkSnapshotRequest{Name: "snapshot-fork"})
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+
+	_, err = mgr.RestoreSnapshot(ctx, "source", "..", RestoreSnapshotRequest{})
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+}
+
 func TestStoppedSnapshotRejectsInvalidQEMUMicroVMTargetBeforeMutation(t *testing.T) {
 	t.Parallel()
 	mgr, _ := setupTestManager(t)

--- a/lib/instances/storage.go
+++ b/lib/instances/storage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kernel/hypeman/lib/healthcheck"
 	"github.com/kernel/hypeman/lib/hypervisor"
 	"github.com/kernel/hypeman/lib/images"
+	"github.com/kernel/hypeman/lib/paths"
 )
 
 const (
@@ -62,6 +63,9 @@ func (m *manager) ensureDirectories(id string) error {
 
 // loadMetadata loads instance metadata from disk
 func (m *manager) loadMetadata(id string) (*metadata, error) {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return nil, ErrNotFound
+	}
 	unlockAliasReaders := hypervisor.LockSnapshotSourceAliasReaders()
 	defer unlockAliasReaders()
 
@@ -85,6 +89,9 @@ func (m *manager) loadMetadata(id string) (*metadata, error) {
 
 // saveMetadata saves instance metadata to disk
 func (m *manager) saveMetadata(meta *metadata) error {
+	if err := paths.ValidatePathComponent(meta.Id); err != nil {
+		return err
+	}
 	unlockAliasReaders := hypervisor.LockSnapshotSourceAliasReaders()
 	defer unlockAliasReaders()
 
@@ -146,6 +153,9 @@ func (m *manager) createVolumeOverlayDisk(instanceID, volumeID string, sizeBytes
 
 // deleteInstanceData removes all instance data from disk
 func (m *manager) deleteInstanceData(id string) error {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return ErrNotFound
+	}
 	instDir := m.paths.InstanceDir(id)
 
 	if err := removeAllWithRetry(instDir, os.RemoveAll, time.Sleep); err != nil {

--- a/lib/instances/storage_path_test.go
+++ b/lib/instances/storage_path_test.go
@@ -1,0 +1,26 @@
+package instances
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceStorageRejectsPathTraversal(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "data")
+	p := paths.New(dataDir)
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "metadata.json"), []byte(`{"id":"outside"}`), 0644))
+	marker := filepath.Join(dataDir, "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))
+	mgr := &manager{paths: p}
+
+	_, err := mgr.loadMetadata("..")
+	require.ErrorIs(t, err, ErrNotFound)
+	require.ErrorIs(t, mgr.saveMetadata(&metadata{StoredMetadata: StoredMetadata{Id: ".."}}), paths.ErrInvalidPathComponent)
+	require.ErrorIs(t, mgr.deleteInstanceData(".."), ErrNotFound)
+	require.FileExists(t, marker)
+}

--- a/lib/paths/paths.go
+++ b/lib/paths/paths.go
@@ -2,6 +2,7 @@
 package paths
 
 import (
+	"errors"
 	"path/filepath"
 	"runtime"
 )
@@ -14,6 +15,17 @@ type Paths struct {
 // New creates a new Paths instance for the given data directory.
 func New(dataDir string) *Paths {
 	return &Paths{dataDir: dataDir}
+}
+
+// ErrInvalidPathComponent is returned when a value cannot be safely joined as one path component.
+var ErrInvalidPathComponent = errors.New("invalid path component")
+
+// ValidatePathComponent rejects empty, nested, absolute, and traversing paths.
+func ValidatePathComponent(value string) error {
+	if value == "." || !filepath.IsLocal(value) || filepath.Base(value) != value {
+		return ErrInvalidPathComponent
+	}
+	return nil
 }
 
 // DataDir returns the root data directory.

--- a/lib/paths/validate_test.go
+++ b/lib/paths/validate_test.go
@@ -1,0 +1,16 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePathComponent(t *testing.T) {
+	for _, value := range []string{"snapshot-1", "team_cache"} {
+		require.NoError(t, ValidatePathComponent(value))
+	}
+	for _, value := range []string{"", ".", "..", "../outside", "nested/resource", "/absolute"} {
+		require.ErrorIs(t, ValidatePathComponent(value), ErrInvalidPathComponent)
+	}
+}

--- a/lib/snapshot/store.go
+++ b/lib/snapshot/store.go
@@ -14,6 +14,7 @@ import (
 var (
 	ErrNotFound   = errors.New("snapshot not found")
 	ErrNameExists = errors.New("snapshot name already exists")
+	ErrInvalidID  = errors.New("invalid snapshot id")
 )
 
 // Record is the persisted representation of a snapshot plus source metadata.
@@ -59,6 +60,9 @@ func (s *Store) SaveRecord(record *Record) error {
 	if record == nil {
 		return fmt.Errorf("nil snapshot record")
 	}
+	if err := validateSnapshotID(record.Snapshot.Id); err != nil {
+		return err
+	}
 	dir := s.paths.SnapshotDir(record.Snapshot.Id)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create snapshot directory: %w", err)
@@ -74,6 +78,9 @@ func (s *Store) SaveRecord(record *Record) error {
 }
 
 func (s *Store) LoadRecord(snapshotID string) (*Record, error) {
+	if err := validateSnapshotID(snapshotID); err != nil {
+		return nil, err
+	}
 	content, err := os.ReadFile(s.paths.SnapshotMetadata(snapshotID))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -117,6 +124,9 @@ func (s *Store) ListRecords() ([]Record, error) {
 }
 
 func (s *Store) Delete(snapshotID string) error {
+	if err := validateSnapshotID(snapshotID); err != nil {
+		return err
+	}
 	path := s.paths.SnapshotDir(snapshotID)
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -142,6 +152,13 @@ func (s *Store) EnsureNameAvailable(sourceInstanceID, snapshotName string) error
 		if record.Snapshot.SourceInstanceID == sourceInstanceID && record.Snapshot.Name == snapshotName {
 			return fmt.Errorf("%w: snapshot name %q already exists for source instance %s", ErrNameExists, snapshotName, sourceInstanceID)
 		}
+	}
+	return nil
+}
+
+func validateSnapshotID(snapshotID string) error {
+	if snapshotID == "." || !filepath.IsLocal(snapshotID) || filepath.Base(snapshotID) != snapshotID {
+		return fmt.Errorf("%w: must be a single local path component", ErrInvalidID)
 	}
 	return nil
 }

--- a/lib/snapshot/store.go
+++ b/lib/snapshot/store.go
@@ -157,8 +157,8 @@ func (s *Store) EnsureNameAvailable(sourceInstanceID, snapshotName string) error
 }
 
 func validateSnapshotID(snapshotID string) error {
-	if snapshotID == "." || !filepath.IsLocal(snapshotID) || filepath.Base(snapshotID) != snapshotID {
-		return fmt.Errorf("%w: must be a single local path component", ErrInvalidID)
+	if err := paths.ValidatePathComponent(snapshotID); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidID, err)
 	}
 	return nil
 }

--- a/lib/snapshot/store_test.go
+++ b/lib/snapshot/store_test.go
@@ -53,6 +53,33 @@ func TestStoreSaveLoadListDelete(t *testing.T) {
 	require.True(t, errors.Is(err, ErrNotFound))
 }
 
+func TestStoreRejectsSnapshotIDsOutsideStoreRoot(t *testing.T) {
+	t.Parallel()
+
+	dataDir := filepath.Join(t.TempDir(), "data")
+	p := paths.New(dataDir)
+	store := NewStore(p)
+
+	outsideDir := filepath.Join(dataDir, "outside")
+	require.NoError(t, os.MkdirAll(outsideDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "snapshot.json"), []byte(`{"snapshot":{"id":"outside"}}`), 0644))
+
+	for _, snapshotID := range []string{"", ".", "..", "../outside", "nested/snapshot", "/absolute"} {
+		t.Run(snapshotID, func(t *testing.T) {
+			_, err := store.LoadRecord(snapshotID)
+			require.ErrorIs(t, err, ErrInvalidID)
+
+			err = store.SaveRecord(&Record{Snapshot: Snapshot{Id: snapshotID}})
+			require.ErrorIs(t, err, ErrInvalidID)
+		})
+	}
+
+	marker := filepath.Join(dataDir, "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))
+	require.ErrorIs(t, store.Delete(".."), ErrInvalidID)
+	require.FileExists(t, marker)
+}
+
 func TestStoreEnsureNameAvailable(t *testing.T) {
 	t.Parallel()
 

--- a/lib/volumes/errors.go
+++ b/lib/volumes/errors.go
@@ -7,4 +7,5 @@ var (
 	ErrInUse         = errors.New("volume is in use")
 	ErrAlreadyExists = errors.New("volume already exists")
 	ErrAmbiguousName = errors.New("multiple volumes with the same name")
+	ErrInvalidID     = errors.New("invalid volume id")
 )

--- a/lib/volumes/manager.go
+++ b/lib/volumes/manager.go
@@ -33,7 +33,7 @@ type Manager interface {
 	DetachVolume(ctx context.Context, volumeID string, instanceID string) error
 
 	// GetVolumePath returns the path to the volume data file
-	GetVolumePath(id string) string
+	GetVolumePath(id string) (string, error)
 
 	// TotalVolumeBytes returns the total size of all volumes.
 	// Used by the resource manager for disk capacity tracking.
@@ -460,8 +460,11 @@ func (m *manager) DetachVolume(ctx context.Context, volumeID string, instanceID 
 }
 
 // GetVolumePath returns the path to the volume data file
-func (m *manager) GetVolumePath(id string) string {
-	return m.paths.VolumeData(id)
+func (m *manager) GetVolumePath(id string) (string, error) {
+	if err := validateVolumeID(id); err != nil {
+		return "", err
+	}
+	return m.paths.VolumeData(id), nil
 }
 
 // TotalVolumeBytes returns the total size of all volumes.

--- a/lib/volumes/manager.go
+++ b/lib/volumes/manager.go
@@ -166,6 +166,9 @@ func (m *manager) CreateVolume(ctx context.Context, req CreateVolumeRequest) (*V
 	if req.Id != nil && *req.Id != "" {
 		id = *req.Id
 	}
+	if err := validateVolumeID(id); err != nil {
+		return nil, err
+	}
 
 	// Check volume doesn't already exist
 	if _, err := loadMetadata(m.paths, id); err == nil {
@@ -233,6 +236,9 @@ func (m *manager) CreateVolumeFromArchive(ctx context.Context, req CreateVolumeF
 	id := cuid2.Generate()
 	if req.Id != nil && *req.Id != "" {
 		id = *req.Id
+	}
+	if err := validateVolumeID(id); err != nil {
+		return nil, err
 	}
 
 	// Check volume doesn't already exist

--- a/lib/volumes/manager_test.go
+++ b/lib/volumes/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kernel/hypeman/lib/paths"
@@ -30,6 +31,24 @@ func setupTestManager(t *testing.T) (Manager, *paths.Paths, func()) {
 	}
 
 	return manager, p, cleanup
+}
+
+func TestVolumeIDsRejectPathTraversal(t *testing.T) {
+	manager, p, cleanup := setupTestManager(t)
+	defer cleanup()
+	ctx := context.Background()
+	id := ".."
+
+	_, err := manager.CreateVolume(ctx, CreateVolumeRequest{Id: &id, SizeGb: 1})
+	require.ErrorIs(t, err, ErrInvalidID)
+	_, err = manager.CreateVolumeFromArchive(ctx, CreateVolumeFromArchiveRequest{Id: &id, SizeGb: 1}, nil)
+	require.ErrorIs(t, err, ErrInvalidID)
+	require.ErrorIs(t, saveMetadata(p, &storedMetadata{Id: id}), ErrInvalidID)
+
+	marker := filepath.Join(p.DataDir(), "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))
+	require.ErrorIs(t, manager.DeleteVolume(ctx, id), ErrNotFound)
+	require.FileExists(t, marker)
 }
 
 func TestMultiAttach_FirstAttachmentRW(t *testing.T) {

--- a/lib/volumes/manager_test.go
+++ b/lib/volumes/manager_test.go
@@ -44,6 +44,8 @@ func TestVolumeIDsRejectPathTraversal(t *testing.T) {
 	_, err = manager.CreateVolumeFromArchive(ctx, CreateVolumeFromArchiveRequest{Id: &id, SizeGb: 1}, nil)
 	require.ErrorIs(t, err, ErrInvalidID)
 	require.ErrorIs(t, saveMetadata(p, &storedMetadata{Id: id}), ErrInvalidID)
+	_, err = manager.GetVolumePath(id)
+	require.ErrorIs(t, err, ErrInvalidID)
 
 	marker := filepath.Join(p.DataDir(), "keep")
 	require.NoError(t, os.WriteFile(marker, []byte("keep"), 0644))

--- a/lib/volumes/storage.go
+++ b/lib/volumes/storage.go
@@ -33,6 +33,13 @@ type storedMetadata struct {
 	Attachments []storedAttachment `json:"attachments,omitempty"`
 }
 
+func validateVolumeID(id string) error {
+	if err := paths.ValidatePathComponent(id); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidID, err)
+	}
+	return nil
+}
+
 // ensureVolumeDir creates the volume directory
 func ensureVolumeDir(p *paths.Paths, id string) error {
 	dir := p.VolumeDir(id)
@@ -44,6 +51,9 @@ func ensureVolumeDir(p *paths.Paths, id string) error {
 
 // loadMetadata loads volume metadata from disk
 func loadMetadata(p *paths.Paths, id string) (*storedMetadata, error) {
+	if err := validateVolumeID(id); err != nil {
+		return nil, ErrNotFound
+	}
 	metaPath := p.VolumeMetadata(id)
 
 	data, err := os.ReadFile(metaPath)
@@ -64,6 +74,9 @@ func loadMetadata(p *paths.Paths, id string) (*storedMetadata, error) {
 
 // saveMetadata saves volume metadata to disk
 func saveMetadata(p *paths.Paths, meta *storedMetadata) error {
+	if err := validateVolumeID(meta.Id); err != nil {
+		return err
+	}
 	metaPath := p.VolumeMetadata(meta.Id)
 
 	data, err := json.MarshalIndent(meta, "", "  ")
@@ -87,6 +100,9 @@ func createVolumeDisk(p *paths.Paths, id string, sizeGb int) error {
 
 // deleteVolumeData removes all volume data from disk
 func deleteVolumeData(p *paths.Paths, id string) error {
+	if err := validateVolumeID(id); err != nil {
+		return ErrNotFound
+	}
 	volDir := p.VolumeDir(id)
 
 	if err := os.RemoveAll(volDir); err != nil {


### PR DESCRIPTION
## Summary

- add one shared single-path-component validator and enforce it at filesystem-backed snapshot, instance, volume, device, ingress, builder, build, and image-push storage boundaries
- validate persisted volume attachment IDs before constructing base-volume or overlay paths
- reject invalid custom volume IDs as `400`, while invalid lookup and deletion candidates remain `404`
- preserve ID-or-name behavior by allowing invalid direct-ID candidates to continue through safe name scans, including path-like volume names
- add a repository security policy linking to Kernel's HackerOne vulnerability disclosure program

## Tests

- `go test -race ./lib/paths ./lib/snapshot ./lib/volumes ./lib/devices ./lib/ingress ./lib/builders ./lib/builds ./lib/imagepush`
- `go test -race ./lib/volumes ./lib/builds -run '^(TestVolumeIDsRejectPathTraversal|TestBuildStorageRejectsPathTraversal)$' -count=1`
- `go test ./lib/instances -run '^(TestInstanceStorageRejectsPathTraversal|TestSnapshotOperationsRejectPathTraversal)$' -count=1`
- `go test ./cmd/api/api -run '^(TestCreateVolume_InvalidID|TestGetVolume_ByPathLikeName)$' -count=1`
- `go test ./lib/volumes ./lib/builds -count=1`
- `go test ./lib/instances ./cmd/api/api -run '^$' -count=1`
- `go vet ./lib/paths ./lib/snapshot ./lib/volumes ./lib/devices ./lib/ingress ./lib/builders ./lib/builds ./lib/imagepush ./lib/instances ./cmd/api/api`
- verified the HackerOne submission and security guidance links return HTTP 200
- `go test ./cmd/api/api -count=1` *(unrelated integration tests require `mkfs.erofs` and network privileges unavailable in this environment)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive path handling across many persistence layers; incorrect validation could break legitimate IDs or leave traversal gaps, though changes are defensive and heavily tested.
> 
> **Overview**
> Hardens filesystem-backed persistence by introducing **`paths.ValidatePathComponent`** (rejects empty, `.`, `..`, nested, and absolute segments) and calling it before read/write/delete paths for **volumes, instances, snapshots, devices, builders, builds, image pushes, and ingresses**.
> 
> **API behavior:** caller-supplied volume IDs that fail validation return **`400 invalid_request`** on create (including from-archive); the same checks on lookup/delete surface as **not found** rather than touching paths outside the data directory. **`GetVolumePath`** now returns **`(string, error)`** so instance VM config cannot use a bad volume ID silently.
> 
> **Builder IDs** also require passing `ValidatePathComponent` in addition to the existing regex. **Image push** cleanup routes through **`removePushData`**, which validates IDs before `RemoveAll`.
> 
> Adds **`SECURITY.md`** pointing reporters to Kernel's HackerOne program. Tests cover traversal rejection and path-like volume names (e.g. `team/data`) still resolving by name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0072e0c22ec3fe0ab6b515ea50001c6ba157903b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->