### PR TITLE
Avoid repeated sorting when tracking shared extents

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -269,12 +269,10 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("invalid metrics allocation reconcile interval %q: %w", app.Config.Metrics.AllocationReconcileInterval, err)
 	}
-	resourceMonitoringStarted := time.Now()
 	logger.Info("starting resource monitoring", "refresh_interval", resourceRefreshInterval)
 	if err := app.ResourceManager.StartMonitoring(ctx, otelProvider.Meter, resourceRefreshInterval); err != nil {
 		return fmt.Errorf("start resource monitoring: %w", err)
 	}
-	logger.Info("resource monitoring started", "duration", time.Since(resourceMonitoringStarted))
 	if reconciler, ok := app.InstanceManager.(interface {
 		StartAdmissionAllocationReconciler(context.Context, time.Duration)
 	}); ok {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -173,6 +173,9 @@ func configureUFFDGraduationController(cfg *config.Config, instanceManager insta
 }
 
 func run() error {
+	startupStarted := time.Now()
+	slog.Info("starting hypeman initialization")
+
 	// Load config early for OTel initialization
 	// Config path can be specified via CONFIG_PATH env var or defaults to platform-specific locations
 	configPath := os.Getenv("CONFIG_PATH")
@@ -202,10 +205,13 @@ func run() error {
 		Env:                      cfg.Env,
 	}
 
+	telemetryStarted := time.Now()
+	slog.Info("initializing OpenTelemetry")
 	otelProvider, otelShutdown, err := otel.Init(context.Background(), otelCfg)
 	if err != nil {
 		return fmt.Errorf("initialize telemetry: %w", err)
 	}
+	slog.Info("OpenTelemetry initialized", "duration", time.Since(telemetryStarted))
 	defer func() {
 		slog.Info("shutting down OpenTelemetry")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -234,10 +240,14 @@ func run() error {
 	}
 
 	// Initialize app with wire
+	appInitializationStarted := time.Now()
+	slog.Info("initializing application dependencies")
 	app, cleanup, err := initializeApp()
 	if err != nil {
 		return fmt.Errorf("initialize application: %w", err)
 	}
+	logger := app.Logger
+	logger.Info("application dependencies initialized", "duration", time.Since(appInitializationStarted))
 	defer func() {
 		slog.Info("cleaning up application resources")
 		cleanup()
@@ -251,8 +261,6 @@ func run() error {
 		slog.Info("signal handler stopped")
 	}()
 
-	logger := app.Logger
-
 	resourceRefreshInterval, err := time.ParseDuration(app.Config.Metrics.ResourceRefreshInterval)
 	if err != nil {
 		return fmt.Errorf("invalid metrics resource refresh interval %q: %w", app.Config.Metrics.ResourceRefreshInterval, err)
@@ -261,9 +269,12 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("invalid metrics allocation reconcile interval %q: %w", app.Config.Metrics.AllocationReconcileInterval, err)
 	}
+	resourceMonitoringStarted := time.Now()
+	logger.Info("starting resource monitoring", "refresh_interval", resourceRefreshInterval)
 	if err := app.ResourceManager.StartMonitoring(ctx, otelProvider.Meter, resourceRefreshInterval); err != nil {
 		return fmt.Errorf("start resource monitoring: %w", err)
 	}
+	logger.Info("resource monitoring started", "duration", time.Since(resourceMonitoringStarted))
 	if reconciler, ok := app.InstanceManager.(interface {
 		StartAdmissionAllocationReconciler(context.Context, time.Duration)
 	}); ok {
@@ -641,6 +652,8 @@ func run() error {
 			return restartController.StartRestartPolicyController(gctx)
 		})
 	}
+
+	logger.Info("hypeman initialization complete", "duration", time.Since(startupStarted))
 
 	// Run the server
 	grp.Go(func() error {

--- a/lib/diskutilization/diskutilization_reflink_linux.go
+++ b/lib/diskutilization/diskutilization_reflink_linux.go
@@ -140,35 +140,34 @@ func (t *sharedExtentTracker) add(start, length uint64) int64 {
 	}
 
 	end := start + length
+	first := sort.Search(len(t.ranges), func(i int) bool {
+		return t.ranges[i].end >= start
+	})
+	last := first
+	mergedStart := start
+	mergedEnd := end
 	added := length
-	for _, existing := range t.ranges {
-		if existing.end <= start || end <= existing.start {
-			continue
-		}
+	for last < len(t.ranges) && t.ranges[last].start <= mergedEnd {
+		existing := t.ranges[last]
 		overlapStart := max(start, existing.start)
 		overlapEnd := min(end, existing.end)
-		added -= overlapEnd - overlapStart
+		if overlapStart < overlapEnd {
+			added -= overlapEnd - overlapStart
+		}
+		mergedStart = min(mergedStart, existing.start)
+		mergedEnd = max(mergedEnd, existing.end)
+		last++
 	}
 
-	t.ranges = append(t.ranges, physicalRange{start: start, end: end})
-	t.compact()
+	merged := physicalRange{start: mergedStart, end: mergedEnd}
+	if first == last {
+		t.ranges = append(t.ranges, physicalRange{})
+		copy(t.ranges[first+1:], t.ranges[first:])
+		t.ranges[first] = merged
+	} else {
+		t.ranges[first] = merged
+		copy(t.ranges[first+1:], t.ranges[last:])
+		t.ranges = t.ranges[:len(t.ranges)-(last-first)+1]
+	}
 	return int64(added)
-}
-
-func (t *sharedExtentTracker) compact() {
-	sort.Slice(t.ranges, func(i, j int) bool {
-		return t.ranges[i].start < t.ranges[j].start
-	})
-
-	merged := t.ranges[:0]
-	for _, current := range t.ranges {
-		if len(merged) == 0 || merged[len(merged)-1].end < current.start {
-			merged = append(merged, current)
-			continue
-		}
-		if current.end > merged[len(merged)-1].end {
-			merged[len(merged)-1].end = current.end
-		}
-	}
-	t.ranges = merged
 }

--- a/lib/diskutilization/diskutilization_reflink_linux_test.go
+++ b/lib/diskutilization/diskutilization_reflink_linux_test.go
@@ -58,6 +58,28 @@ func TestSharedExtentTrackerAdd(t *testing.T) {
 	require.Equal(t, int64(50), tracker.add(1050, 100))
 	require.Equal(t, int64(100), tracker.add(1200, 100))
 	require.Equal(t, int64(100), tracker.add(900, 200))
+	require.Equal(t, int64(50), tracker.add(1150, 50))
+	require.Equal(t, []physicalRange{{start: 900, end: 1300}}, tracker.ranges)
+}
+
+func TestSharedExtentTrackerAddOutOfOrder(t *testing.T) {
+	tracker := newSharedExtentTracker()
+
+	require.Equal(t, int64(100), tracker.add(300, 100))
+	require.Equal(t, int64(100), tracker.add(100, 100))
+	require.Equal(t, int64(100), tracker.add(500, 100))
+	require.Equal(t, int64(100), tracker.add(200, 100))
+	require.Equal(t, int64(100), tracker.add(400, 100))
+	require.Equal(t, []physicalRange{{start: 100, end: 600}}, tracker.ranges)
+}
+
+func BenchmarkSharedExtentTrackerAdd(b *testing.B) {
+	for b.Loop() {
+		tracker := newSharedExtentTracker()
+		for i := range 10_000 {
+			tracker.add(uint64(i*8192), 4096)
+		}
+	}
 }
 
 func cloneTestFile(srcPath, dstPath string) (bool, error) {

--- a/lib/resources/monitoring.go
+++ b/lib/resources/monitoring.go
@@ -48,17 +48,6 @@ func (m *Manager) StartMonitoring(ctx context.Context, meter metric.Meter, refre
 		}
 		m.monitoring.metricsRegistered = true
 	}
-	m.monitoring.mu.Unlock()
-
-	if err := m.refreshMonitoringSnapshot(ctx); err != nil {
-		return err
-	}
-
-	m.monitoring.mu.Lock()
-	if m.monitoring.started {
-		m.monitoring.mu.Unlock()
-		return nil
-	}
 	m.monitoring.started = true
 	m.monitoring.mu.Unlock()
 
@@ -75,6 +64,13 @@ func (m *Manager) StartMonitoring(ctx context.Context, meter metric.Meter, refre
 				)
 			}
 		}()
+
+		initialRefreshStarted := time.Now()
+		if err := m.refreshMonitoringSnapshot(ctx); err != nil {
+			log.WarnContext(ctx, "initial resource monitoring snapshot failed", "error", err)
+		} else {
+			log.InfoContext(ctx, "initial resource monitoring snapshot complete", "duration", time.Since(initialRefreshStarted))
+		}
 
 		ticker := time.NewTicker(refreshInterval)
 		defer ticker.Stop()

--- a/lib/resources/monitoring_test.go
+++ b/lib/resources/monitoring_test.go
@@ -115,6 +115,14 @@ func monitoringTestManager(t *testing.T) (*Manager, *monitoringInstanceLister, *
 	return mgr, instanceLister, imageLister
 }
 
+func waitForMonitoringSnapshot(t *testing.T, mgr *Manager) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, ok := mgr.currentMonitoringSnapshot()
+		return ok
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
 func TestStartMonitoringPublishesCapacityMetrics(t *testing.T) {
 	mgr, _, _ := monitoringTestManager(t)
 
@@ -125,6 +133,7 @@ func TestStartMonitoringPublishesCapacityMetrics(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, mgr.StartMonitoring(ctx, provider.Meter("test"), time.Hour))
+	waitForMonitoringSnapshot(t, mgr)
 
 	status, err := mgr.GetFullStatus(context.Background())
 	require.NoError(t, err)
@@ -159,6 +168,7 @@ func TestStartMonitoringRefreshesSnapshot(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, mgr.StartMonitoring(ctx, provider.Meter("test"), 20*time.Millisecond))
+	waitForMonitoringSnapshot(t, mgr)
 
 	instanceLister.SetAllocations([]InstanceAllocation{
 		{
@@ -210,6 +220,7 @@ func TestStartMonitoringPublishesGPUMetrics(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, mgr.StartMonitoring(ctx, provider.Meter("test"), time.Hour))
+	waitForMonitoringSnapshot(t, mgr)
 
 	rm := collectMonitoringMetrics(t, reader)
 	require.Equal(t, int64(3), int64GaugeValue(t, rm, "hypeman_resources_gpu_slots", map[string]string{"kind": "used"}))
@@ -242,6 +253,7 @@ func TestStartMonitoringPublishesDiskUtilizationFromCachedSnapshot(t *testing.T)
 	defer cancel()
 
 	require.NoError(t, mgr.StartMonitoring(ctx, provider.Meter("test"), time.Hour))
+	waitForMonitoringSnapshot(t, mgr)
 
 	initialRM := collectMonitoringMetrics(t, reader)
 	initialVolumeBytes := int64GaugeValue(t, initialRM, "hypeman_disk_utilization_bytes", map[string]string{"component": "volumes"})


### PR DESCRIPTION
## Summary

- keep shared physical extents sorted and merged as each range is added
- use binary search to find only the ranges affected by an insertion
- remove the full-list sort previously performed for every shared extent
- cover out-of-order insertion and adjacency merging
- log startup phase boundaries and durations at info level
- run the initial resource-monitoring snapshot asynchronously so startup no longer blocks on the disk scan; the metrics callback already skips reporting until the first snapshot exists

Resource monitoring scans reflinked snapshot extents synchronously during startup. Re-sorting every accumulated range for every extent caused startup work to grow superlinearly as snapshot trees became larger and more fragmented.

## Performance

For 10,000 disjoint sequential extents on AMD EPYC:

- before: ~170 ms/op, 30,018 allocations
- after: ~0.5 ms/op, 20 allocations

## Tests

- `go test -race ./lib/diskutilization`
- `go vet ./lib/diskutilization`
- randomized reference comparison against byte-level coverage
- `go test ./...` attempted; unrelated packages could not complete because embedded binaries are absent from the checkout and Docker Hub rejected unauthenticated test pulls. The changed package passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The extent tracker algorithm changed on a hot path used during disk utilization collection; behavior is covered by new tests and benchmarks, but incorrect merging could skew shared/private byte accounting. Deferring the first monitoring refresh slightly delays metric population at startup.
> 
> **Overview**
> **Shared extent tracking** for Linux reflink/fiemap disk utilization no longer re-sorts and merges the full range list on every insertion. `sharedExtentTracker.add` uses binary search to locate affected intervals, merges overlaps in place, and keeps ranges sorted incrementally—cutting work during snapshot-tree scans that run as part of resource monitoring.
> 
> **Resource monitoring** no longer blocks `StartMonitoring` on the first `refreshMonitoringSnapshot` (which includes `diskutilization.Collect`). The initial snapshot runs inside the background loop with success/failure and duration logs; tests wait for a cached snapshot via `waitForMonitoringSnapshot`.
> 
> **API startup** adds info-level phase markers and elapsed times (overall init, OpenTelemetry, dependency wiring, resource monitoring kickoff, and total time before the HTTP server starts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51405c7de29dbc9ea259c0cbd978838394190d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->