### PR TITLE
Collect disk utilization without blocking startup

### DIFF
--- a/lib/resources/monitoring.go
+++ b/lib/resources/monitoring.go
@@ -9,23 +9,32 @@ import (
 
 	"github.com/kernel/hypeman/lib/diskutilization"
 	"github.com/kernel/hypeman/lib/logger"
+	"github.com/kernel/hypeman/lib/paths"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
 type monitoringState struct {
-	mu                sync.RWMutex
-	started           bool
-	metricsRegistered bool
-	snapshot          monitoringSnapshot
-	hasSnapshot       bool
+	mu                     sync.RWMutex
+	started                bool
+	metricsRegistered      bool
+	collectDiskUtilization func(*paths.Paths) (diskutilization.Breakdown, error)
+	snapshot               monitoringSnapshot
+	hasSnapshot            bool
+}
+
+func newMonitoringState() *monitoringState {
+	return &monitoringState{
+		collectDiskUtilization: diskutilization.Collect,
+	}
 }
 
 type monitoringSnapshot struct {
-	status              FullResourceStatus
-	imageStorageCurrent int64
-	imageStorageMax     int64
-	diskUtilization     diskutilization.Breakdown
+	status                 FullResourceStatus
+	imageStorageCurrent    int64
+	imageStorageMax        int64
+	diskUtilization        diskutilization.Breakdown
+	hasDiskUtilizationData bool
 }
 
 func (m *Manager) StartMonitoring(ctx context.Context, meter metric.Meter, refreshInterval time.Duration) error {
@@ -76,6 +85,10 @@ func (m *Manager) StartMonitoring(ctx context.Context, meter metric.Meter, refre
 			}
 		}()
 
+		if err := m.refreshDiskUtilizationSnapshot(); err != nil {
+			log.WarnContext(ctx, "disk utilization snapshot refresh failed", "error", err)
+		}
+
 		ticker := time.NewTicker(refreshInterval)
 		defer ticker.Stop()
 
@@ -86,6 +99,10 @@ func (m *Manager) StartMonitoring(ctx context.Context, meter metric.Meter, refre
 			case <-ticker.C:
 				if err := m.refreshMonitoringSnapshot(ctx); err != nil {
 					log.WarnContext(ctx, "resource monitoring snapshot refresh failed", "error", err)
+					continue
+				}
+				if err := m.refreshDiskUtilizationSnapshot(); err != nil {
+					log.WarnContext(ctx, "disk utilization snapshot refresh failed", "error", err)
 				}
 			}
 		}
@@ -108,15 +125,25 @@ func (m *Manager) refreshMonitoringSnapshot(ctx context.Context) error {
 	}
 	snapshot.imageStorageMax = m.MaxImageStorageBytes()
 
-	diskUtilization, err := diskutilization.Collect(m.paths)
+	m.monitoring.mu.Lock()
+	snapshot.diskUtilization = m.monitoring.snapshot.diskUtilization
+	snapshot.hasDiskUtilizationData = m.monitoring.snapshot.hasDiskUtilizationData
+	m.monitoring.snapshot = snapshot
+	m.monitoring.hasSnapshot = true
+	m.monitoring.mu.Unlock()
+
+	return nil
+}
+
+func (m *Manager) refreshDiskUtilizationSnapshot() error {
+	diskUtilization, err := m.monitoring.collectDiskUtilization(m.paths)
 	if err != nil {
 		return err
 	}
-	snapshot.diskUtilization = diskUtilization
 
 	m.monitoring.mu.Lock()
-	m.monitoring.snapshot = snapshot
-	m.monitoring.hasSnapshot = true
+	m.monitoring.snapshot.diskUtilization = diskUtilization
+	m.monitoring.snapshot.hasDiskUtilizationData = true
 	m.monitoring.mu.Unlock()
 
 	return nil
@@ -238,8 +265,10 @@ func newMonitoringMetrics(meter metric.Meter, mgr *Manager) error {
 			o.ObserveInt64(imageStorage, snapshot.imageStorageCurrent, metric.WithAttributes(attribute.String("kind", "current")))
 		}
 
-		for component, value := range snapshot.diskUtilization.Components() {
-			o.ObserveInt64(diskUtilization, value, metric.WithAttributes(attribute.String("component", component)))
+		if snapshot.hasDiskUtilizationData {
+			for component, value := range snapshot.diskUtilization.Components() {
+				o.ObserveInt64(diskUtilization, value, metric.WithAttributes(attribute.String("component", component)))
+			}
 		}
 		o.ObserveInt64(imageStorage, snapshot.imageStorageMax, metric.WithAttributes(attribute.String("kind", "max")))
 

--- a/lib/resources/monitoring_test.go
+++ b/lib/resources/monitoring_test.go
@@ -141,12 +141,53 @@ func TestStartMonitoringPublishesCapacityMetrics(t *testing.T) {
 	require.Equal(t, status.DiskDetail.OCICache, int64GaugeValue(t, rm, "hypeman_resources_disk_breakdown_bytes", map[string]string{"component": "oci_cache"}))
 	require.Equal(t, status.DiskDetail.Volumes, int64GaugeValue(t, rm, "hypeman_resources_disk_breakdown_bytes", map[string]string{"component": "volumes"}))
 	require.Equal(t, status.DiskDetail.Overlays, int64GaugeValue(t, rm, "hypeman_resources_disk_breakdown_bytes", map[string]string{"component": "overlays"}))
-	require.Equal(t, int64(0), int64GaugeValue(t, rm, "hypeman_disk_utilization_bytes", map[string]string{"component": "images"}))
-	require.Equal(t, int64(0), int64GaugeValue(t, rm, "hypeman_disk_utilization_bytes", map[string]string{"component": "snapshot_other"}))
 
 	currentImageStorage := status.DiskDetail.Images + status.DiskDetail.OCICache
 	require.Equal(t, currentImageStorage, int64GaugeValue(t, rm, "hypeman_resources_image_storage_bytes", map[string]string{"kind": "current"}))
 	require.Equal(t, mgr.MaxImageStorageBytes(), int64GaugeValue(t, rm, "hypeman_resources_image_storage_bytes", map[string]string{"kind": "max"}))
+}
+
+func TestStartMonitoringDoesNotWaitForDiskUtilization(t *testing.T) {
+	mgr, _, _ := monitoringTestManager(t)
+
+	collectionStarted := make(chan struct{})
+	releaseCollection := make(chan struct{})
+	defer close(releaseCollection)
+	mgr.monitoring.collectDiskUtilization = func(*paths.Paths) (diskutilization.Breakdown, error) {
+		close(collectionStarted)
+		<-releaseCollection
+		return diskutilization.Breakdown{}, nil
+	}
+
+	reader := otelmetric.NewManualReader()
+	provider := otelmetric.NewMeterProvider(otelmetric.WithReader(reader))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	monitoringStarted := make(chan error, 1)
+	go func() {
+		monitoringStarted <- mgr.StartMonitoring(ctx, provider.Meter("test"), time.Hour)
+	}()
+
+	select {
+	case err := <-monitoringStarted:
+		require.NoError(t, err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("StartMonitoring blocked on disk utilization collection")
+	}
+
+	select {
+	case <-collectionStarted:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("disk utilization collection did not start")
+	}
+
+	rm := collectMonitoringMetrics(t, reader)
+	require.NotZero(t, int64GaugeValue(t, rm, "hypeman_resources_capacity", map[string]string{"resource": "cpu"}))
+	snapshot, ok := mgr.currentMonitoringSnapshot()
+	require.True(t, ok)
+	require.False(t, snapshot.hasDiskUtilizationData)
 }
 
 func TestStartMonitoringRefreshesSnapshot(t *testing.T) {
@@ -243,12 +284,17 @@ func TestStartMonitoringPublishesDiskUtilizationFromCachedSnapshot(t *testing.T)
 
 	require.NoError(t, mgr.StartMonitoring(ctx, provider.Meter("test"), time.Hour))
 
+	require.Eventually(t, func() bool {
+		snapshot, ok := mgr.currentMonitoringSnapshot()
+		return ok && snapshot.hasDiskUtilizationData
+	}, time.Second, 10*time.Millisecond)
+
 	initialRM := collectMonitoringMetrics(t, reader)
 	initialVolumeBytes := int64GaugeValue(t, initialRM, "hypeman_disk_utilization_bytes", map[string]string{"component": "volumes"})
 	initialCompressedSnapshotBytes := int64GaugeValue(t, initialRM, "hypeman_disk_utilization_bytes", map[string]string{"component": diskutilization.ComponentSnapshotCompressed})
 	require.Equal(t, allocatedBytesForMonitoringPath(volumePath), initialVolumeBytes)
-	require.Equal(t, int64(100*1024*1024*1024), int64GaugeValue(t, initialRM, "hypeman_resources_disk_breakdown_bytes", map[string]string{"component": "volumes"}))
 	require.Greater(t, initialCompressedSnapshotBytes, int64(0))
+	require.Equal(t, int64(100*1024*1024*1024), int64GaugeValue(t, initialRM, "hypeman_resources_disk_breakdown_bytes", map[string]string{"component": "volumes"}))
 
 	f, err := os.OpenFile(volumePath, os.O_WRONLY, 0)
 	require.NoError(t, err)
@@ -256,10 +302,11 @@ func TestStartMonitoringPublishesDiskUtilizationFromCachedSnapshot(t *testing.T)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
+	require.NoError(t, mgr.refreshMonitoringSnapshot(context.Background()))
 	cachedRM := collectMonitoringMetrics(t, reader)
 	require.Equal(t, initialVolumeBytes, int64GaugeValue(t, cachedRM, "hypeman_disk_utilization_bytes", map[string]string{"component": "volumes"}))
 
-	require.NoError(t, mgr.refreshMonitoringSnapshot(context.Background()))
+	require.NoError(t, mgr.refreshDiskUtilizationSnapshot())
 
 	refreshedRM := collectMonitoringMetrics(t, reader)
 	refreshedVolumeBytes := int64GaugeValue(t, refreshedRM, "hypeman_disk_utilization_bytes", map[string]string{"component": "volumes"})

--- a/lib/resources/resource.go
+++ b/lib/resources/resource.go
@@ -197,7 +197,7 @@ func NewManager(cfg *config.Config, p *paths.Paths) *Manager {
 		cfg:        cfg,
 		paths:      p,
 		resources:  make(map[ResourceType]Resource),
-		monitoring: &monitoringState{},
+		monitoring: newMonitoringState(),
 		pending:    make(map[string]pendingAllocation),
 	}
 }


### PR DESCRIPTION
## Summary

- publish the fast resource snapshot before collecting physical disk utilization
- run the filesystem scan in the background monitoring loop
- withhold physical disk utilization metrics until the first scan completes, while preserving the last completed scan across resource refreshes

## Testing

- `go test ./lib/resources`
- `go test -race ./lib/resources`
- `go vet ./lib/resources`

The full `go test ./...` suite could not complete in this checkout because required embedded binaries and `mkfs.erofs` are unavailable. It also encountered an unrelated socket cache key test failure.