### PR TITLE
Serialize Hypeman host ownership

### DIFF
--- a/cmd/api/host_lock.go
+++ b/cmd/api/host_lock.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const hostLockFilename = ".hypeman.lock"
+
+func acquireHostLock(dataDir string) (*os.File, error) {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create data directory: %w", err)
+	}
+
+	path := filepath.Join(dataDir, hostLockFilename)
+	lock, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open host lock: %w", err)
+	}
+
+	slog.Info("waiting for host ownership", "path", path)
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		_ = lock.Close()
+		return nil, fmt.Errorf("acquire host lock: %w", err)
+	}
+	slog.Info("acquired host ownership", "path", path)
+	return lock, nil
+}
+
+func releaseHostLock(lock *os.File) error {
+	return errors.Join(
+		syscall.Flock(int(lock.Fd()), syscall.LOCK_UN),
+		lock.Close(),
+	)
+}

--- a/cmd/api/host_lock_test.go
+++ b/cmd/api/host_lock_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostLockPreventsConcurrentOwnership(t *testing.T) {
+	dataDir := t.TempDir()
+	first, err := acquireHostLock(dataDir)
+	require.NoError(t, err)
+
+	second, err := os.OpenFile(filepath.Join(dataDir, hostLockFilename), os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	defer second.Close()
+
+	err = syscall.Flock(int(second.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN))
+
+	require.NoError(t, releaseHostLock(first))
+	require.NoError(t, syscall.Flock(int(second.Fd()), syscall.LOCK_EX|syscall.LOCK_NB))
+	require.NoError(t, syscall.Flock(int(second.Fd()), syscall.LOCK_UN))
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -186,6 +186,16 @@ func run() error {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	hostLock, err := acquireHostLock(cfg.DataDir)
+	if err != nil {
+		return fmt.Errorf("acquire host ownership: %w", err)
+	}
+	defer func() {
+		if err := releaseHostLock(hostLock); err != nil {
+			slog.Warn("failed to release host ownership", "error", err)
+		}
+	}()
+
 	// Configure GPU profile cache TTL
 	devices.SetGPUProfileCacheTTL(cfg.GPU.ProfileCacheTTL)
 


### PR DESCRIPTION
## Summary

- serialize Hypeman processes that share a data directory with a host ownership lock
- acquire ownership before managers or controllers can mutate host state
- keep the standby blocked until the active process exits
- start the API only after normal initialization completes, so `/health` can gate proxy cutover

## Deployment flow

Start the next process against the same data directory, stop the current process, wait for the next process to return `200` from `/health`, then update the proxy.

## Testing

- `go test ./cmd/api`
- `go test -race ./cmd/api`