### PR TITLE
Restore standby after failed Firecracker restore

### DIFF
--- a/lib/hypervisor/firecracker/process.go
+++ b/lib/hypervisor/firecracker/process.go
@@ -131,7 +131,7 @@ func (s *Starter) RestoreVM(ctx context.Context, p *paths.Paths, version string,
 	}
 
 	cu := cleanup.Make(func() {
-		_ = syscall.Kill(pid, syscall.SIGKILL)
+		cleanupFailedRestore(pid, socketPath)
 	})
 	defer cu.Clean()
 
@@ -198,6 +198,12 @@ func (s *Starter) RestoreVM(ctx context.Context, p *paths.Paths, version string,
 
 	cu.Release()
 	return pid, hv, nil
+}
+
+func cleanupFailedRestore(pid int, socketPath string) {
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	_, _ = syscall.Wait4(pid, nil, 0, nil)
+	_ = os.Remove(socketPath)
 }
 
 func withSnapshotSourceDirAlias(meta *restoreMetadata, targetDataDir string, run func() error) error {

--- a/lib/hypervisor/firecracker/process_test.go
+++ b/lib/hypervisor/firecracker/process_test.go
@@ -3,12 +3,30 @@ package firecracker
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCleanupFailedRestoreKillsProcessAndRemovesSocket(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	socketPath := filepath.Join(t.TempDir(), "fc.sock")
+	require.NoError(t, os.WriteFile(socketPath, nil, 0600))
+
+	cleanupFailedRestore(pid, socketPath)
+
+	_, err := os.Stat(socketPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	assert.ErrorIs(t, syscall.Kill(pid, 0), syscall.ESRCH)
+}
 
 func TestWithSnapshotSourceDirAlias_RestoresSourceDirOnSuccess(t *testing.T) {
 	tmp := t.TempDir()


### PR DESCRIPTION
## Summary

- reap Firecracker when a snapshot restore fails
- remove the stale API socket so the retained snapshot derives as Standby and can be retried
- cover failed-restore process and socket cleanup

## Testing

- `go test ./lib/hypervisor/firecracker`
- `go test -race ./lib/hypervisor/firecracker`
- `go vet ./...`
- `make build`

The broader `go test -race ./lib/instances` run was blocked by unauthenticated Docker Hub rate limits and existing asynchronous image-build race reports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM restore failure paths and process/socket lifecycle; behavior change is localized to failed restore cleanup with a direct test.
> 
> **Overview**
> When **Firecracker snapshot restore** fails partway through `RestoreVM`, the deferred cleanup now runs **`cleanupFailedRestore`** instead of only sending **SIGKILL** to the VMM.
> 
> That helper **reaps the process** with `Wait4`, **deletes the API socket** at `socketPath`, and is covered by a test that asserts the socket is gone and the process is no longer running. The intent is to avoid leaving a live VMM and a stale `fc.sock` so the retained snapshot can be treated as **Standby** and restore can be retried.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a0e7b78207144a4f2b4b157b62723a4ff6572b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->