### PR TITLE
ci: allow manual test workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push: {}
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- add a `workflow_dispatch` trigger to the test workflow
- keep the existing push trigger unchanged

## Testing

- `git diff --check`
- verified the workflow trigger declaration locally