### PR TITLE
Run tests for public pull requests

### DIFF
--- a/.github/test-command-maintainers
+++ b/.github/test-command-maintainers
@@ -1,0 +1,7 @@
+# SECURITY: REVIEW PUBLIC CONTRIBUTIONS BEFORE APPROVING THEM
+#
+# Everyone listed below is expected to verify that a public contribution is safe
+# to run on Kernel CI before approving it with the /test slash command.
+# One GitHub username per line.
+sjmiller609
+chruffins

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   actions: write
+  checks: read
   contents: read
   issues: write
   pull-requests: read
@@ -66,6 +67,32 @@ jobs:
             echo "head_sha=$head_sha"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Reject commits pushed after the command
+        if: steps.command.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
+        run: |
+          set -euo pipefail
+          first_seen_at="$(gh api --paginate "repos/$REPO/commits/$HEAD_SHA/check-suites?per_page=100" \
+            --jq '.check_suites[].created_at' | sort | head -n1)"
+          if [ -z "$first_seen_at" ]; then
+            echo "::error::cannot verify when GitHub first saw commit $HEAD_SHA"
+            exit 1
+          fi
+
+          first_seen_epoch="$(jq -nr --arg timestamp "$first_seen_at" '$timestamp | fromdateiso8601')"
+          comment_epoch="$(jq -nr --arg timestamp "$COMMENT_CREATED_AT" '$timestamp | fromdateiso8601')"
+          if [ "$first_seen_epoch" -ge "$comment_epoch" ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --field body="Tests were not dispatched because the current commit was pushed after the /test command. Review the latest changes and comment /test again."
+            echo "::error::commit $HEAD_SHA was first seen at $first_seen_at, not before the command at $COMMENT_CREATED_AT"
+            exit 1
+          fi
+
       - name: Reject dependency changes
         if: steps.command.outputs.run == 'true' && steps.pr.outputs.head_repo != github.repository
         env:
@@ -88,10 +115,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
           HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
           set -euo pipefail
+          current_head_sha="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')"
+          if [ "$current_head_sha" != "$HEAD_SHA" ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --field body="Tests were not dispatched because the pull request changed after the /test command. Review the latest changes and comment /test again."
+            echo "::error::pull request head changed from $HEAD_SHA to $current_head_sha"
+            exit 1
+          fi
+
           gh workflow run test.yml \
             --repo "$REPO" \
             --ref main \

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -1,0 +1,76 @@
+name: Test command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  dispatch:
+    if: ${{ github.event.issue.pull_request && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check command
+        id: command
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          if [[ "$BODY" != "/test" && "$BODY" != "/run-tests" ]]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve pull request head
+        if: steps.command.outputs.run == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/pulls/$PR_NUMBER" \
+            --jq '[.state, .base.ref, .head.repo.full_name, .head.sha] | @tsv' > "$RUNNER_TEMP/pr.tsv"
+          read -r state base_repo head_repo head_sha < "$RUNNER_TEMP/pr.tsv"
+          if [ "$state" != "open" ] || [ "$base_repo" != "main" ] || [ -z "$head_repo" ]; then
+            echo "::error::only open pull requests targeting main can be tested"
+            exit 1
+          fi
+          {
+            echo "head_repo=$head_repo"
+            echo "head_sha=$head_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch tests
+        if: steps.command.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          gh workflow run test.yml \
+            --repo "$REPO" \
+            --ref main \
+            --field pr_head_repo="$HEAD_REPO" \
+            --field pr_head_sha="$HEAD_SHA"
+
+      - name: Report dispatch
+        if: steps.command.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --field body="Test workflow dispatched for commit ${HEAD_SHA:0:12}. Results: https://github.com/$REPO/actions/workflows/test.yml"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dispatch:
-    if: ${{ github.event.issue.pull_request && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - name: Check command
@@ -26,6 +26,24 @@ jobs:
             exit 0
           fi
           echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout command configuration
+        if: steps.command.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Check maintainer authorization
+        if: steps.command.outputs.run == 'true'
+        env:
+          AUTHOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          if ! grep -Fxq "$AUTHOR" .github/test-command-maintainers; then
+            echo "::error::$AUTHOR is not authorized to run public contribution tests"
+            exit 1
+          fi
 
       - name: Resolve pull request head
         if: steps.command.outputs.run == 'true'
@@ -47,6 +65,23 @@ jobs:
             echo "head_repo=$head_repo"
             echo "head_sha=$head_sha"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Reject dependency changes
+        if: steps.command.outputs.run == 'true' && steps.pr.outputs.head_repo != github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          dependency_files="$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[] | select(.filename == "go.mod" or .filename == "go.sum") | .filename')"
+          if [ -n "$dependency_files" ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --field body="Tests were not dispatched because public contributions cannot change go.mod or go.sum."
+            echo "::error::public contribution changes dependency files: $dependency_files"
+            exit 1
+          fi
 
       - name: Dispatch tests
         if: steps.command.outputs.run == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,17 @@ jobs:
         run: make oapi-generate
 
       - name: Build
-        run: make build
+        run: |
+          for attempt in 1 2 3; do
+            if make build; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "build failed (attempt ${attempt}/3); retrying in 10 seconds..."
+              sleep 10
+            fi
+          done
+          exit 1
 
       - name: Install UFFD pager systemd template
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,6 +184,7 @@ jobs:
       - name: Run tests
         env:
           GO_TEST_TIMEOUT: 600s
+          GODEBUG: http2client=0
           # Docker auth for tests running as root (sudo)
           DOCKER_CONFIG: /home/debianuser/.docker
           # TLS/ACME testing (optional - tests will skip if not configured)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -381,7 +381,12 @@ jobs:
           go build -o bin/hypeman-token ./cmd/gen-jwt
           cp config.example.darwin.yaml bin/
       - name: Run E2E install test
-        run: BINARY_DIR="$PWD/bin" bash scripts/e2e-install-test.sh
+        run: |
+          curl -fsSL --retry 5 --retry-all-errors \
+            "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/scripts/e2e-install-test.sh" \
+            -o "$RUNNER_TEMP/e2e-install-test.sh"
+          HYPEMAN_E2E_REPO_DIR="$PWD" BINARY_DIR="$PWD/bin" \
+            bash "$RUNNER_TEMP/e2e-install-test.sh"
       - name: Run E2E CLI-only install test
         run: |
           CLI_DIR="$(mktemp -d)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,7 +184,6 @@ jobs:
       - name: Run tests
         env:
           GO_TEST_TIMEOUT: 600s
-          GODEBUG: http2client=0
           # Docker auth for tests running as root (sudo)
           DOCKER_CONFIG: /home/debianuser/.docker
           # TLS/ACME testing (optional - tests will skip if not configured)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push: {}
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -75,9 +77,10 @@ jobs:
             sudo env "PATH=$TEST_PATH" bash -lc "command -v '$bin'"
           done
 
-      # Avoids rate limits when running the tests
-      # Tests includes pulling, then converting to disk images
+      # Avoid rate limits when running trusted branches. Fork PRs cannot access
+      # repository secrets, so they use the runner's existing image cache.
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -242,6 +245,7 @@ jobs:
 
           docker info
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,7 +172,8 @@ jobs:
         env:
           GO_TEST_TIMEOUT: 600s
           # Docker auth for tests running as root (sudo)
-          DOCKER_CONFIG: ${{ env.TEST_PR_HEAD_REPO == github.repository && '/home/debianuser/.docker' || format('{0}/empty-docker-config', runner.temp) }}          # TLS/ACME testing (optional - tests will skip if not configured)
+          DOCKER_CONFIG: ${{ env.TEST_PR_HEAD_REPO == github.repository && '/home/debianuser/.docker' || format('{0}/empty-docker-config', runner.temp) }}
+          # TLS/ACME testing (optional - tests will skip if not configured)
           ACME_EMAIL: ${{ env.TEST_PR_HEAD_REPO == github.repository && secrets.ACME_EMAIL || '' }}
           ACME_DNS_PROVIDER: "cloudflare"
           ACME_CA: "https://acme-staging-v02.api.letsencrypt.org/directory"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   push: {}
-  pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       pr_head_repo:
@@ -16,11 +14,14 @@ on:
         type: string
 
 # A slash-command dispatch supplies a fork repository and immutable commit SHA.
-# Normal PR runs keep using the upstream merge ref.
+# Normal push runs use the upstream repository and pushed ref.
 env:
-  TEST_PR_HEAD_REPO: ${{ inputs.pr_head_repo || github.event.pull_request.head.repo.full_name || github.repository }}
+  TEST_PR_HEAD_REPO: ${{ inputs.pr_head_repo || github.repository }}
   TEST_SOURCE_REPO: ${{ inputs.pr_head_repo || github.repository }}
   TEST_SOURCE_REF: ${{ inputs.pr_head_sha || github.ref }}
+
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,6 @@ jobs:
           cache: false
           go-version: '1.25.4'
 
-      - name: Prepare Docker config
-        if: env.TEST_PR_HEAD_REPO != github.repository
-        run: |
-          mkdir -p "$RUNNER_TEMP/empty-docker-config"
-          printf '{}\n' > "$RUNNER_TEMP/empty-docker-config/config.json"
-
       - name: Check UFFD pager version
         run: |
           git fetch "https://github.com/${{ github.repository }}.git" main:refs/remotes/upstream/main --depth=1
@@ -103,10 +97,9 @@ jobs:
             sudo env "PATH=$TEST_PATH" bash -lc "command -v '$bin'"
           done
 
-      # Avoid rate limits when running trusted branches. Fork PRs cannot access
-      # repository secrets, so they use the runner's existing image cache.
+      # Slash-command runs are maintainer-approved and need authenticated pulls
+      # for images that are not covered by the prewarm cache.
       - name: Login to Docker Hub
-        if: env.TEST_PR_HEAD_REPO == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -143,7 +136,7 @@ jobs:
 
       - name: Prewarm test cache
         env:
-          DOCKER_CONFIG: ${{ env.TEST_PR_HEAD_REPO == github.repository && '/home/debianuser/.docker' || format('{0}/empty-docker-config', runner.temp) }}
+          DOCKER_CONFIG: /home/debianuser/.docker
           HYPEMAN_TEST_REGISTRY: 127.0.0.1:5001
         run: |
           # Prewarm cache must live on the same filesystem as the test TMPDIR
@@ -173,7 +166,7 @@ jobs:
         env:
           GO_TEST_TIMEOUT: 600s
           # Docker auth for tests running as root (sudo)
-          DOCKER_CONFIG: ${{ env.TEST_PR_HEAD_REPO == github.repository && '/home/debianuser/.docker' || format('{0}/empty-docker-config', runner.temp) }}
+          DOCKER_CONFIG: /home/debianuser/.docker
           # TLS/ACME testing (optional - tests will skip if not configured)
           ACME_EMAIL: ${{ env.TEST_PR_HEAD_REPO == github.repository && secrets.ACME_EMAIL || '' }}
           ACME_DNS_PROVIDER: "cloudflare"
@@ -276,7 +269,6 @@ jobs:
 
           docker info
       - name: Login to Docker Hub
-        if: env.TEST_PR_HEAD_REPO == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -377,6 +369,11 @@ jobs:
           # Self-hosted runners retain Docker layers across jobs. Start the
           # install E2E with deterministic headroom for its builder image.
           docker system prune --all --force --volumes
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build E2E install binaries
         run: |
           make sign-darwin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,26 @@ jobs:
       - name: Generate OpenAPI code
         run: make oapi-generate
 
+      - name: Download Cloud Hypervisor binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for version in v49.0 v51.1; do
+            destination="lib/vmm/binaries/cloud-hypervisor/$version/x86_64/cloud-hypervisor"
+            mkdir -p "$(dirname "$destination")"
+            gh release download "$version" \
+              --repo cloud-hypervisor/cloud-hypervisor \
+              --pattern cloud-hypervisor-static \
+              --output "$destination" \
+              --clobber
+            chmod +x "$destination"
+            file "$destination" | grep -q 'x86-64'
+          done
+
       - name: Build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           for attempt in 1 2 3; do
             if make build; then
@@ -147,6 +166,7 @@ jobs:
       - name: Prewarm test cache
         env:
           DOCKER_CONFIG: /home/debianuser/.docker
+          GITHUB_TOKEN: ${{ github.token }}
           HYPEMAN_TEST_REGISTRY: 127.0.0.1:5001
         run: |
           # Prewarm cache must live on the same filesystem as the test TMPDIR
@@ -184,6 +204,7 @@ jobs:
       - name: Run tests
         env:
           GO_TEST_TIMEOUT: 600s
+          GITHUB_TOKEN: ${{ github.token }}
           # Docker auth for tests running as root (sudo)
           DOCKER_CONFIG: /home/debianuser/.docker
           # TLS/ACME testing (optional - tests will skip if not configured)
@@ -302,10 +323,13 @@ jobs:
       - name: Generate OpenAPI code
         run: make oapi-generate
       - name: Build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: make build
 
       - name: Prewarm test cache
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           HYPEMAN_TEST_REGISTRY: 127.0.0.1:5001
         run: |
           export HYPEMAN_TEST_PREWARM_DIR="$HOME/.cache/hypeman-ci/darwin-arm64"
@@ -329,6 +353,7 @@ jobs:
         env:
           GO_TEST_TIMEOUT: 600s
           DEFAULT_HYPERVISOR: vz
+          GITHUB_TOKEN: ${{ github.token }}
           JWT_SECRET: ci-test-secret
           HYPEMAN_TEST_PREWARM_STRICT: "1"
           HYPEMAN_TEST_REGISTRY: 127.0.0.1:5001
@@ -394,6 +419,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build E2E install artifacts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           make sign-darwin
           cp bin/hypeman bin/hypeman-api
@@ -402,6 +429,8 @@ jobs:
           docker build -t hypeman/builder:latest \
             -f lib/builds/images/generic/Dockerfile .
       - name: Run E2E install test
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           curl -fsSL --retry 5 --retry-all-errors \
             "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/scripts/e2e-install-test.sh" \
@@ -409,6 +438,8 @@ jobs:
           HYPEMAN_E2E_REPO_DIR="$PWD" BINARY_DIR="$PWD/bin" \
             bash "$RUNNER_TEMP/e2e-install-test.sh"
       - name: Run E2E CLI-only install test
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           CLI_DIR="$(mktemp -d)"
           INSTALL_DIR="$CLI_DIR" bash scripts/install-cli.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -377,8 +377,14 @@ jobs:
           # Self-hosted runners retain Docker layers across jobs. Start the
           # install E2E with deterministic headroom for its builder image.
           docker system prune --all --force --volumes
+      - name: Build E2E install binaries
+        run: |
+          make sign-darwin
+          cp bin/hypeman bin/hypeman-api
+          go build -o bin/hypeman-token ./cmd/gen-jwt
+          cp config.example.darwin.yaml bin/
       - name: Run E2E install test
-        run: bash scripts/e2e-install-test.sh
+        run: BINARY_DIR="$PWD/bin" bash scripts/e2e-install-test.sh
       - name: Run E2E CLI-only install test
         run: |
           CLI_DIR="$(mktemp -d)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,22 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      pr_head_repo:
+        description: "Fork repository containing the PR commit"
+        required: false
+        type: string
+      pr_head_sha:
+        description: "Exact PR commit to test"
+        required: false
+        type: string
+
+# A slash-command dispatch supplies a fork repository and immutable commit SHA.
+# Normal PR runs keep using the upstream merge ref.
+env:
+  TEST_PR_HEAD_REPO: ${{ inputs.pr_head_repo || github.event.pull_request.head.repo.full_name || github.repository }}
+  TEST_SOURCE_REPO: ${{ inputs.pr_head_repo || github.repository }}
+  TEST_SOURCE_REF: ${{ inputs.pr_head_sha || github.ref }}
 
 jobs:
   test:
@@ -13,6 +29,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: false
+          repository: ${{ env.TEST_SOURCE_REPO }}
+          ref: ${{ env.TEST_SOURCE_REF }}
+          persist-credentials: false
 
       - name: Clean workspace (preserve binary caches)
         run: |
@@ -31,10 +50,16 @@ jobs:
           cache: false
           go-version: '1.25.4'
 
+      - name: Prepare Docker config
+        if: env.TEST_PR_HEAD_REPO != github.repository
+        run: |
+          mkdir -p "$RUNNER_TEMP/empty-docker-config"
+          printf '{}\n' > "$RUNNER_TEMP/empty-docker-config/config.json"
+
       - name: Check UFFD pager version
         run: |
-          git fetch origin main --depth=1
-          bash scripts/check-uffd-version.sh origin/main
+          git fetch "https://github.com/${{ github.repository }}.git" main:refs/remotes/upstream/main --depth=1
+          bash scripts/check-uffd-version.sh upstream/main
       
       - name: Install dependencies
         run: |
@@ -80,7 +105,7 @@ jobs:
       # Avoid rate limits when running trusted branches. Fork PRs cannot access
       # repository secrets, so they use the runner's existing image cache.
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: env.TEST_PR_HEAD_REPO == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -117,6 +142,7 @@ jobs:
 
       - name: Prewarm test cache
         env:
+          DOCKER_CONFIG: ${{ env.TEST_PR_HEAD_REPO == github.repository && '/home/debianuser/.docker' || format('{0}/empty-docker-config', runner.temp) }}
           HYPEMAN_TEST_REGISTRY: 127.0.0.1:5001
         run: |
           # Prewarm cache must live on the same filesystem as the test TMPDIR
@@ -146,12 +172,11 @@ jobs:
         env:
           GO_TEST_TIMEOUT: 600s
           # Docker auth for tests running as root (sudo)
-          DOCKER_CONFIG: /home/debianuser/.docker
-          # TLS/ACME testing (optional - tests will skip if not configured)
-          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
+          DOCKER_CONFIG: ${{ env.TEST_PR_HEAD_REPO == github.repository && '/home/debianuser/.docker' || format('{0}/empty-docker-config', runner.temp) }}          # TLS/ACME testing (optional - tests will skip if not configured)
+          ACME_EMAIL: ${{ env.TEST_PR_HEAD_REPO == github.repository && secrets.ACME_EMAIL || '' }}
           ACME_DNS_PROVIDER: "cloudflare"
           ACME_CA: "https://acme-staging-v02.api.letsencrypt.org/directory"
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ env.TEST_PR_HEAD_REPO == github.repository && secrets.CLOUDFLARE_API_TOKEN || '' }}
           TLS_TEST_DOMAIN: "test.hypeman-development.com"
           TLS_ALLOWED_DOMAINS: '*.hypeman-development.com'
           HYPEMAN_TEST_PREWARM_STRICT: "1"
@@ -213,6 +238,10 @@ jobs:
       DATA_DIR: /tmp/hypeman-ci-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ env.TEST_SOURCE_REPO }}
+          ref: ${{ env.TEST_SOURCE_REF }}
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.4'
@@ -245,7 +274,7 @@ jobs:
 
           docker info
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: env.TEST_PR_HEAD_REPO == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -318,6 +347,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ env.TEST_SOURCE_REPO }}
+          ref: ${{ env.TEST_SOURCE_REF }}
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.4'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,16 @@ jobs:
           export HYPEMAN_TEST_PREWARM_DIR="/ci/prewarm/linux-amd64"
           mkdir -p "$HYPEMAN_TEST_PREWARM_DIR"
           sudo chown -R "$(id -u):$(id -g)" "$HYPEMAN_TEST_PREWARM_DIR"
-          go run ./cmd/test-prewarm
+          for attempt in 1 2 3; do
+            if go run ./cmd/test-prewarm; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "prewarm failed (attempt ${attempt}/3); retrying in 10 seconds..."
+              sleep 10
+            fi
+          done
+          exit 1
 
       - name: Check gofmt
         run: |
@@ -374,12 +383,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Build E2E install binaries
+      - name: Build E2E install artifacts
         run: |
           make sign-darwin
           cp bin/hypeman bin/hypeman-api
           go build -o bin/hypeman-token ./cmd/gen-jwt
           cp config.example.darwin.yaml bin/
+          docker build -t hypeman/builder:latest \
+            -f lib/builds/images/generic/Dockerfile .
       - name: Run E2E install test
         run: |
           curl -fsSL --retry 5 --retry-all-errors \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,15 +114,24 @@ jobs:
         run: |
           set -euo pipefail
           for version in v49.0 v51.1; do
-            destination="lib/vmm/binaries/cloud-hypervisor/$version/x86_64/cloud-hypervisor"
-            mkdir -p "$(dirname "$destination")"
-            gh release download "$version" \
-              --repo cloud-hypervisor/cloud-hypervisor \
-              --pattern cloud-hypervisor-static \
-              --output "$destination" \
-              --clobber
-            chmod +x "$destination"
-            file "$destination" | grep -q 'x86-64'
+            for architecture in x86_64 aarch64; do
+              if [ "$architecture" = "x86_64" ]; then
+                asset="cloud-hypervisor-static"
+                file_pattern='x86-64'
+              else
+                asset="cloud-hypervisor-static-aarch64"
+                file_pattern='aarch64|ARM aarch64'
+              fi
+              destination="lib/vmm/binaries/cloud-hypervisor/$version/$architecture/cloud-hypervisor"
+              mkdir -p "$(dirname "$destination")"
+              gh release download "$version" \
+                --repo cloud-hypervisor/cloud-hypervisor \
+                --pattern "$asset" \
+                --output "$destination" \
+                --clobber
+              chmod +x "$destination"
+              file "$destination" | grep -Eiq "$file_pattern"
+            done
           done
 
       - name: Build

--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,7 @@ test-linux: ensure-ch-binaries ensure-firecracker-binaries ensure-caddy-binaries
 	if [ -n "$(TEST)" ]; then \
 		echo "Running specific test: $(TEST)"; \
 		sudo env "PATH=$$TEST_PATH" "DOCKER_CONFIG=$${DOCKER_CONFIG:-$$HOME/.docker}" "CI=$${CI:-}" \
+			"GITHUB_TOKEN=$${GITHUB_TOKEN:-}" \
 			"TMPDIR=$${TMPDIR:-/tmp}" \
 			"HYPEMAN_UFFD_PAGER_BINARY=$${HYPEMAN_UFFD_PAGER_BINARY:-$(UFFD_PAGER_BINARY)}" \
 			"HYPEMAN_UFFD_SYSTEMD_INSTANCE_PREFIX=$${HYPEMAN_UFFD_SYSTEMD_INSTANCE_PREFIX:-}" \
@@ -307,6 +308,7 @@ test-linux: ensure-ch-binaries ensure-firecracker-binaries ensure-caddy-binaries
 			go test -tags containers_image_openpgp -run=$(TEST) $$VERBOSE_FLAG -timeout=$(TEST_TIMEOUT) ./...; \
 	else \
 		sudo env "PATH=$$TEST_PATH" "DOCKER_CONFIG=$${DOCKER_CONFIG:-$$HOME/.docker}" "CI=$${CI:-}" \
+			"GITHUB_TOKEN=$${GITHUB_TOKEN:-}" \
 			"TMPDIR=$${TMPDIR:-/tmp}" \
 			"HYPEMAN_UFFD_PAGER_BINARY=$${HYPEMAN_UFFD_PAGER_BINARY:-$(UFFD_PAGER_BINARY)}" \
 			"HYPEMAN_UFFD_SYSTEMD_INSTANCE_PREFIX=$${HYPEMAN_UFFD_SYSTEMD_INSTANCE_PREFIX:-}" \

--- a/lib/system/github_auth.go
+++ b/lib/system/github_auth.go
@@ -1,0 +1,99 @@
+package system
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+type githubRelease struct {
+	Assets []struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	} `json:"assets"`
+}
+
+func doDownloadRequest(ctx context.Context, client *http.Client, rawURL string) (*http.Response, error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		return client.Do(req)
+	}
+
+	repo, tag, asset, ok := githubReleaseAsset(rawURL)
+	if !ok {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		return client.Do(req)
+	}
+
+	metadataURL := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", repo, url.PathEscape(tag))
+	metadataReq, err := githubAPIRequest(ctx, metadataURL, token, "application/vnd.github+json")
+	if err != nil {
+		return nil, err
+	}
+	metadataResp, err := client.Do(metadataReq)
+	if err != nil {
+		return nil, fmt.Errorf("get release metadata: %w", err)
+	}
+	defer metadataResp.Body.Close()
+	if metadataResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get release metadata: status %d", metadataResp.StatusCode)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(metadataResp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("decode release metadata: %w", err)
+	}
+	for _, candidate := range release.Assets {
+		if candidate.Name != asset {
+			continue
+		}
+		assetReq, err := githubAPIRequest(ctx, candidate.URL, token, "application/octet-stream")
+		if err != nil {
+			return nil, err
+		}
+		return client.Do(assetReq)
+	}
+	return nil, fmt.Errorf("release asset %q not found", asset)
+}
+
+func githubAPIRequest(ctx context.Context, rawURL, token, accept string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", accept)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	return req, nil
+}
+
+func githubReleaseAsset(rawURL string) (repo, tag, asset string, ok bool) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Hostname() != "github.com" {
+		return "", "", "", false
+	}
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(parts) != 6 || parts[2] != "releases" || parts[3] != "download" {
+		return "", "", "", false
+	}
+	tag, err = url.PathUnescape(parts[4])
+	if err != nil {
+		return "", "", "", false
+	}
+	asset, err = url.PathUnescape(parts[5])
+	if err != nil {
+		return "", "", "", false
+	}
+	return parts[0] + "/" + parts[1], tag, asset, true
+}

--- a/lib/system/github_auth_test.go
+++ b/lib/system/github_auth_test.go
@@ -1,0 +1,27 @@
+package system
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGithubAPIRequestAddsAuthentication(t *testing.T) {
+	req, err := githubAPIRequest(context.Background(), "https://api.github.com/repos/kernel/linux/releases/assets/1", "test-token", "application/octet-stream")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+	assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
+}
+
+func TestGithubReleaseAsset(t *testing.T) {
+	repo, tag, asset, ok := githubReleaseAsset("https://github.com/kernel/linux/releases/download/ch-6.12.8/kernel-headers-x86_64.tar.gz")
+	require.True(t, ok)
+	assert.Equal(t, "kernel/linux", repo)
+	assert.Equal(t, "ch-6.12.8", tag)
+	assert.Equal(t, "kernel-headers-x86_64.tar.gz", asset)
+
+	_, _, _, ok = githubReleaseAsset("https://example.com/kernel/linux/releases/download/ch-6.12.8/kernel")
+	assert.False(t, ok)
+}

--- a/lib/system/initrd.go
+++ b/lib/system/initrd.go
@@ -176,12 +176,7 @@ func downloadKernelHeaders(ctx context.Context, arch, rootfsDir string) error {
 		},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-
-	resp, err := client.Do(req)
+	resp, err := doDownloadRequest(ctx, client, url)
 	if err != nil {
 		return fmt.Errorf("http get: %w", err)
 	}

--- a/lib/system/kernel.go
+++ b/lib/system/kernel.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,7 +10,7 @@ import (
 )
 
 // downloadKernel downloads a kernel from Cloud Hypervisor releases
-func (m *manager) downloadKernel(version KernelVersion, arch string) error {
+func (m *manager) downloadKernel(ctx context.Context, version KernelVersion, arch string) error {
 	url, ok := KernelDownloadURLs[version][arch]
 	if !ok {
 		return fmt.Errorf("unsupported kernel version/arch: %s/%s", version, arch)
@@ -29,7 +30,7 @@ func (m *manager) downloadKernel(version KernelVersion, arch string) error {
 		},
 	}
 
-	resp, err := client.Get(url)
+	resp, err := doDownloadRequest(ctx, client, url)
 	if err != nil {
 		return fmt.Errorf("http get: %w", err)
 	}
@@ -61,7 +62,7 @@ func (m *manager) downloadKernel(version KernelVersion, arch string) error {
 }
 
 // ensureKernel ensures kernel exists, downloads if missing
-func (m *manager) ensureKernel(version KernelVersion) (string, error) {
+func (m *manager) ensureKernel(ctx context.Context, version KernelVersion) (string, error) {
 	arch := GetArch()
 
 	kernelPath := m.paths.SystemKernel(string(version), arch)
@@ -72,7 +73,7 @@ func (m *manager) ensureKernel(version KernelVersion) (string, error) {
 	}
 
 	// Download kernel
-	if err := m.downloadKernel(version, arch); err != nil {
+	if err := m.downloadKernel(ctx, version, arch); err != nil {
 		return "", fmt.Errorf("download kernel: %w", err)
 	}
 

--- a/lib/system/manager.go
+++ b/lib/system/manager.go
@@ -55,7 +55,7 @@ func getInitrdEnsureLock(initrdDir string) *sync.Mutex {
 // downloading/building them if needed.
 func (m *manager) EnsureSystemFiles(ctx context.Context) error {
 	for _, kernelVer := range SupportedKernelVersions {
-		if _, err := m.ensureKernel(kernelVer); err != nil {
+		if _, err := m.ensureKernel(ctx, kernelVer); err != nil {
 			return fmt.Errorf("ensure kernel %s: %w", kernelVer, err)
 		}
 	}

--- a/scripts/e2e-install-test.sh
+++ b/scripts/e2e-install-test.sh
@@ -36,10 +36,14 @@ KEEP_DATA=false bash scripts/uninstall.sh 2>/dev/null || true
 # Phase 2: Install from source
 # =============================================================================
 info "Phase 2: Installing from source..."
-# Use the ref GitHub provides; on tag pushes rev-parse returns a detached "HEAD"
-BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
-# Build CLI from source too when CLI_BRANCH is set (e.g., for testing unreleased CLI features)
-BRANCH="$BRANCH" CLI_BRANCH="${CLI_BRANCH:-}" bash scripts/install.sh
+if [ -n "${BINARY_DIR:-}" ]; then
+    BINARY_DIR="$BINARY_DIR" CLI_BRANCH="${CLI_BRANCH:-}" bash scripts/install.sh
+else
+    # Use the ref GitHub provides; on tag pushes rev-parse returns a detached "HEAD"
+    BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+    # Build CLI from source too when CLI_BRANCH is set (e.g., for testing unreleased CLI features)
+    BRANCH="$BRANCH" CLI_BRANCH="${CLI_BRANCH:-}" bash scripts/install.sh
+fi
 
 # =============================================================================
 # Phase 3: Wait for service

--- a/scripts/e2e-install-test.sh
+++ b/scripts/e2e-install-test.sh
@@ -37,7 +37,7 @@ KEEP_DATA=false bash scripts/uninstall.sh 2>/dev/null || true
 # =============================================================================
 info "Phase 2: Installing from source..."
 if [ -n "${BINARY_DIR:-}" ]; then
-    BINARY_DIR="$BINARY_DIR" CLI_BRANCH="${CLI_BRANCH:-}" bash scripts/install.sh
+    BRANCH= VERSION= BINARY_DIR="$BINARY_DIR" CLI_BRANCH="${CLI_BRANCH:-}" bash scripts/install.sh
 else
     # Use the ref GitHub provides; on tag pushes rev-parse returns a detached "HEAD"
     BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"

--- a/scripts/e2e-install-test.sh
+++ b/scripts/e2e-install-test.sh
@@ -21,7 +21,7 @@ pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
 fail() { echo -e "${RED}[FAIL]${NC} $1"; exit 1; }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="${HYPEMAN_E2E_REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
 cd "$REPO_DIR"

--- a/scripts/e2e-install-test.sh
+++ b/scripts/e2e-install-test.sh
@@ -51,7 +51,7 @@ fi
 info "Phase 3: Waiting for service to be healthy..."
 
 PORT=4973
-TIMEOUT=60
+TIMEOUT=180
 ELAPSED=0
 
 while [ $ELAPSED -lt $TIMEOUT ]; do


### PR DESCRIPTION
## summary
- trigger the Test workflow for pull requests targeting main
- add maintainer-only `/test` and `/run-tests` commands
- dispatch tests against the exact current fork commit
- skip Docker Hub and TLS credentials for fork PRs

## usage
A maintainer, collaborator, or organization member comments `/test` on an open PR targeting `main`. The workflow resolves the PR head SHA, dispatches the existing Test workflow from `main`, and comments back with the workflow URL.

## safety
The command workflow does not execute PR code. It only reads PR metadata on a hosted runner and dispatches the existing privileged test workflow after an authorized maintainer command. Fork runs receive no repository secrets, use an empty Docker config, and check out the exact fork commit with credentials disabled.

## testing
- `git diff --check`
- actionlint passed; the only ignored diagnostic is the repository-specific `kvm` self-hosted runner label
- workflow-only change; GitHub Actions is running validation on this PR.