### PR TITLE
Harden public test command approvals

### DIFF
--- a/.github/test-command-maintainers
+++ b/.github/test-command-maintainers
@@ -1,0 +1,7 @@
+# SECURITY: REVIEW PUBLIC CONTRIBUTIONS BEFORE APPROVING THEM
+#
+# Everyone listed below is expected to verify that a public contribution is safe
+# to run on Kernel CI before approving it with the /test slash command.
+# One GitHub username per line.
+sjmiller609
+chruffins

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dispatch:
-    if: ${{ github.event.issue.pull_request && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - name: Check command
@@ -26,6 +26,24 @@ jobs:
             exit 0
           fi
           echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout command configuration
+        if: steps.command.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Check maintainer authorization
+        if: steps.command.outputs.run == 'true'
+        env:
+          AUTHOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          if ! grep -Fxq "$AUTHOR" .github/test-command-maintainers; then
+            echo "::error::$AUTHOR is not authorized to run public contribution tests"
+            exit 1
+          fi
 
       - name: Resolve pull request head
         if: steps.command.outputs.run == 'true'
@@ -47,6 +65,23 @@ jobs:
             echo "head_repo=$head_repo"
             echo "head_sha=$head_sha"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Reject dependency changes
+        if: steps.command.outputs.run == 'true' && steps.pr.outputs.head_repo != github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          dependency_files="$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[] | select(.filename == "go.mod" or .filename == "go.sum") | .filename')"
+          if [ -n "$dependency_files" ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --field body="Tests were not dispatched because public contributions cannot change go.mod or go.sum."
+            echo "::error::public contribution changes dependency files: $dependency_files"
+            exit 1
+          fi
 
       - name: Dispatch tests
         if: steps.command.outputs.run == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   push: {}
-  pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       pr_head_repo:
@@ -16,11 +14,14 @@ on:
         type: string
 
 # A slash-command dispatch supplies a fork repository and immutable commit SHA.
-# Normal PR runs keep using the upstream merge ref.
+# Normal push runs use the upstream repository and pushed ref.
 env:
-  TEST_PR_HEAD_REPO: ${{ inputs.pr_head_repo || github.event.pull_request.head.repo.full_name || github.repository }}
+  TEST_PR_HEAD_REPO: ${{ inputs.pr_head_repo || github.repository }}
   TEST_SOURCE_REPO: ${{ inputs.pr_head_repo || github.repository }}
   TEST_SOURCE_REF: ${{ inputs.pr_head_sha || github.ref }}
+
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
## summary
- authorize `/test` using a dedicated maintainer allowlist with an explicit review-safety warning
- allow `sjmiller609` and `chruffins` to approve public contribution tests
- reject fork PRs that modify `go.mod` or `go.sum` before dispatching CI
- make slash-command dispatch the only way public PRs reach the self-hosted test workflow
- restrict the test workflow token to read-only repository contents

## testing
- `git diff --check`
- `actionlint` passed for the changed workflows, ignoring the repository-specific `kvm` runner label
- verified allowlist acceptance and rejection locally
- verified PR #405 passes the dependency-file gate

## dependency
This is a follow-up to #405 and targets its branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI security boundaries for self-hosted runners (who can trigger tests and what fork code runs); misconfiguration could block legitimate tests or leave a gap, but the intent is to reduce supply-chain exposure.
> 
> **Overview**
> **Tightens who can run untrusted code on self-hosted CI** by replacing the old GitHub `author_association` gate with an explicit maintainer allowlist in `.github/test-command-maintainers`, loaded from `main` before dispatch.
> 
> The `/test` workflow now **fails closed** for commenters not on that list and, for **fork PRs**, refuses dispatch when `go.mod` or `go.sum` changed (with an issue comment explaining why).
> 
> **Fork/public PR coverage is slash-command only:** `test.yml` no longer runs on `pull_request`, so self-hosted tests run on push to the upstream repo or via `workflow_dispatch` with pinned fork repo/SHA from the command handler. Checkout env vars no longer fall back to PR head metadata on ordinary runs.
> 
> The test workflow token is scoped to **`contents: read`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86bf90c0299a55420c26568108dad3687d6e02d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->