### PR TITLE
Test fork binaries in install E2E

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -377,8 +377,14 @@ jobs:
           # Self-hosted runners retain Docker layers across jobs. Start the
           # install E2E with deterministic headroom for its builder image.
           docker system prune --all --force --volumes
+      - name: Build E2E install binaries
+        run: |
+          make sign-darwin
+          cp bin/hypeman bin/hypeman-api
+          go build -o bin/hypeman-token ./cmd/gen-jwt
+          cp config.example.darwin.yaml bin/
       - name: Run E2E install test
-        run: bash scripts/e2e-install-test.sh
+        run: BINARY_DIR="$PWD/bin" bash scripts/e2e-install-test.sh
       - name: Run E2E CLI-only install test
         run: |
           CLI_DIR="$(mktemp -d)"

--- a/scripts/e2e-install-test.sh
+++ b/scripts/e2e-install-test.sh
@@ -36,10 +36,14 @@ KEEP_DATA=false bash scripts/uninstall.sh 2>/dev/null || true
 # Phase 2: Install from source
 # =============================================================================
 info "Phase 2: Installing from source..."
-# Use the ref GitHub provides; on tag pushes rev-parse returns a detached "HEAD"
-BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
-# Build CLI from source too when CLI_BRANCH is set (e.g., for testing unreleased CLI features)
-BRANCH="$BRANCH" CLI_BRANCH="${CLI_BRANCH:-}" bash scripts/install.sh
+if [ -n "${BINARY_DIR:-}" ]; then
+    BINARY_DIR="$BINARY_DIR" CLI_BRANCH="${CLI_BRANCH:-}" bash scripts/install.sh
+else
+    # Use the ref GitHub provides; on tag pushes rev-parse returns a detached "HEAD"
+    BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+    # Build CLI from source too when CLI_BRANCH is set (e.g., for testing unreleased CLI features)
+    BRANCH="$BRANCH" CLI_BRANCH="${CLI_BRANCH:-}" bash scripts/install.sh
+fi
 
 # =============================================================================
 # Phase 3: Wait for service


### PR DESCRIPTION
## summary
- build and sign the install-test binaries from the workflow's checked-out source
- install those binaries directly during the E2E test instead of cloning the workflow ref from `kernel/hypeman`
- preserve branch-based installation for existing callers that do not provide `BINARY_DIR`

This ensures slash-command runs test the captured fork commit even though `workflow_dispatch` itself runs from `main`.

## testing
- `git diff --check`
- `bash -n scripts/e2e-install-test.sh scripts/install.sh`
- `actionlint` passed for the workflows, ignoring the repository-specific `kvm` runner label
- verified the E2E workflow constructs every artifact required by `install.sh` binary mode

The macOS install E2E is running in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI and E2E install scripting; production install paths are unchanged when `BINARY_DIR` is unset.
> 
> **Overview**
> **macOS install E2E** now builds signed `hypeman` / `hypeman-api`, `hypeman-token`, and Darwin example config in CI, then runs the install test with `BINARY_DIR` pointing at that `bin/` directory so the test installs the **checked-out commit** instead of re-cloning `kernel/hypeman` by branch/ref.
> 
> `scripts/e2e-install-test.sh` branches on `BINARY_DIR`: when set it delegates to `install.sh` binary mode; otherwise it keeps the existing `BRANCH` / `GITHUB_REF_NAME` source install path for local and other callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bc5299a04b5aa48a481673d952952e48dc28b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->