### PR TITLE
Authenticate public test image pulls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,6 @@ jobs:
           cache: false
           go-version: '1.25.4'
 
-      - name: Prepare Docker config
-        if: env.TEST_PR_HEAD_REPO != github.repository
-        run: |
-          mkdir -p "$RUNNER_TEMP/empty-docker-config"
-          printf '{}\n' > "$RUNNER_TEMP/empty-docker-config/config.json"
-
       - name: Check UFFD pager version
         run: |
           git fetch "https://github.com/${{ github.repository }}.git" main:refs/remotes/upstream/main --depth=1
@@ -103,10 +97,9 @@ jobs:
             sudo env "PATH=$TEST_PATH" bash -lc "command -v '$bin'"
           done
 
-      # Avoid rate limits when running trusted branches. Fork PRs cannot access
-      # repository secrets, so they use the runner's existing image cache.
+      # Slash-command runs are maintainer-approved and need authenticated pulls
+      # for images that are not covered by the prewarm cache.
       - name: Login to Docker Hub
-        if: env.TEST_PR_HEAD_REPO == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -143,7 +136,7 @@ jobs:
 
       - name: Prewarm test cache
         env:
-          DOCKER_CONFIG: ${{ env.TEST_PR_HEAD_REPO == github.repository && '/home/debianuser/.docker' || format('{0}/empty-docker-config', runner.temp) }}
+          DOCKER_CONFIG: /home/debianuser/.docker
           HYPEMAN_TEST_REGISTRY: 127.0.0.1:5001
         run: |
           # Prewarm cache must live on the same filesystem as the test TMPDIR
@@ -173,7 +166,7 @@ jobs:
         env:
           GO_TEST_TIMEOUT: 600s
           # Docker auth for tests running as root (sudo)
-          DOCKER_CONFIG: ${{ env.TEST_PR_HEAD_REPO == github.repository && '/home/debianuser/.docker' || format('{0}/empty-docker-config', runner.temp) }}
+          DOCKER_CONFIG: /home/debianuser/.docker
           # TLS/ACME testing (optional - tests will skip if not configured)
           ACME_EMAIL: ${{ env.TEST_PR_HEAD_REPO == github.repository && secrets.ACME_EMAIL || '' }}
           ACME_DNS_PROVIDER: "cloudflare"
@@ -276,7 +269,6 @@ jobs:
 
           docker info
       - name: Login to Docker Hub
-        if: env.TEST_PR_HEAD_REPO == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -377,6 +369,11 @@ jobs:
           # Self-hosted runners retain Docker layers across jobs. Start the
           # install E2E with deterministic headroom for its builder image.
           docker system prune --all --force --volumes
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build E2E install binaries
         run: |
           make sign-darwin


### PR DESCRIPTION
## summary
- authenticate Docker Hub pulls in maintainer-approved public contribution tests
- make the authenticated Docker config available to Linux tests running under sudo
- authenticate the macOS unit/integration and install E2E jobs
- continue withholding TLS and Cloudflare credentials from fork runs

The public-fork validation run failed because tests fetch images outside the prewarm set and hit Docker Hub's unauthenticated pull limit.

## testing
- `git diff --check`
- `actionlint` passed for the workflows, ignoring the repository-specific `kvm` runner label
- confirmed the failing run's Linux errors are Docker Hub `TOOMANYREQUESTS` responses for `alpine:3.22`

The configured Docker Hub token should be pull-only because approved contribution code can access the Docker config while tests run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Approved fork runs can use pull-only Docker Hub credentials via the shared runner config; TLS secrets remain gated, but CI secret exposure to external PR code is a deliberate tradeoff.
> 
> **Overview**
> **Fixes Docker Hub `TOOMANYREQUESTS` failures** when maintainer-approved fork/slash-command runs pull images outside the prewarm cache (e.g. `alpine:3.22`).
> 
> The Linux job **always** runs `docker/login-action` and points `DOCKER_CONFIG` at `/home/debianuser/.docker` for prewarm and test steps so **root/sudo** test processes use the same credentials. The previous **empty Docker config** workaround and **repo-only** login conditions are removed.
> 
> **macOS** `test-darwin` and **`e2e-install`** now log in to Docker Hub unconditionally as well (install E2E gains a dedicated login step after Docker is ready). **TLS/ACME and Cloudflare secrets** stay withheld when `TEST_PR_HEAD_REPO` is not the upstream repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383a6a56c79619d649b8e900585804eb3b7ff672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->