### PR TITLE
Fix public test workflow coordination

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -9,7 +9,7 @@ permissions:
   checks: read
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   dispatch:
@@ -147,4 +147,5 @@ jobs:
             --field body="Test workflow dispatched for commit ${HEAD_SHA:0:12}. Results: https://github.com/$REPO/actions/workflows/test.yml" 2>&1)"; then
             echo "$response"
             echo "::warning::tests were dispatched, but the confirmation comment could not be posted"
+            echo "Tests were dispatched for commit ${HEAD_SHA:0:12}, but the confirmation comment could not be posted." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -9,7 +9,7 @@ permissions:
   checks: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   dispatch:
@@ -143,5 +143,8 @@ jobs:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
           set -euo pipefail
-          gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-            --field body="Test workflow dispatched for commit ${HEAD_SHA:0:12}. Results: https://github.com/$REPO/actions/workflows/test.yml"
+          if ! response="$(gh api --include "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --field body="Test workflow dispatched for commit ${HEAD_SHA:0:12}. Results: https://github.com/$REPO/actions/workflows/test.yml" 2>&1)"; then
+            echo "$response"
+            echo "::warning::tests were dispatched, but the confirmation comment could not be posted"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Check UFFD pager version
         run: |
-          git fetch "https://github.com/${{ github.repository }}.git" main:refs/remotes/upstream/main --depth=1
-          bash scripts/check-uffd-version.sh upstream/main
+          git fetch "https://github.com/${{ github.repository }}.git" main --depth=1
+          bash scripts/check-uffd-version.sh FETCH_HEAD
       
       - name: Install dependencies
         run: |
@@ -276,7 +276,7 @@ jobs:
   test-darwin:
     runs-on: [self-hosted, macos, arm64]
     concurrency:
-      group: macos-ci-test-${{ github.ref }}
+      group: macos-ci-test-${{ inputs.pr_head_sha || github.ref }}
       cancel-in-progress: true
     env:
       DATA_DIR: /tmp/hypeman-ci-${{ github.run_id }}
@@ -390,7 +390,7 @@ jobs:
     runs-on: [self-hosted, macos, arm64]
     needs: test-darwin
     concurrency:
-      group: macos-ci-e2e-${{ github.ref }}
+      group: macos-ci-e2e-${{ inputs.pr_head_sha || github.ref }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- fetch `main` into `FETCH_HEAD` so persistent self-hosted workspaces cannot reject the UFFD version check
- isolate macOS concurrency groups by the tested public commit so slash-command runs do not cancel normal branch CI
- allow the slash-command controller to comment on pull requests without marking a successful dispatch failed if GitHub rejects the confirmation comment

## Why

The first run after #405 merged failed because a persistent runner already had a divergent `upstream/main` ref from a prior fork test. The end-to-end slash-command run also dispatched successfully but was reported as failed when its confirmation comment received a 403.

## Testing

- parsed both workflow files as YAML
- ran actionlint (only the repository-specific `kvm` runner label warning remains)
- ran the UFFD version check against `FETCH_HEAD`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes with no application runtime impact; minor risk of overlapping macOS jobs if concurrency grouping behaves unexpectedly.
> 
> **Overview**
> **Hardens public `/test` dispatch and self-hosted CI** so fork/slash-command runs do not fight normal branch jobs or fail for benign GitHub API issues.
> 
> The Linux job’s UFFD version check now shallow-fetches upstream `main` into `FETCH_HEAD` and compares against that, avoiding stale or divergent `upstream/main` refs on persistent runners. macOS `test-darwin` and `e2e-install` concurrency groups key off `inputs.pr_head_sha` when present (else `github.ref`), so slash-command test runs no longer share a group with push CI and cancel each other.
> 
> The test-command **Report dispatch** step no longer fails the job when posting the confirmation PR comment fails (e.g. 403); it logs the API response, emits a workflow warning, and records the outcome in the job summary while leaving the successful dispatch intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf376a0bade2ba66931eb52df33b5b7d53408ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->