### PR TITLE
Fix persistent CI main ref fetch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Check UFFD pager version
         run: |
-          git fetch "https://github.com/${{ github.repository }}.git" main:refs/remotes/upstream/main --depth=1
+          git fetch "https://github.com/${{ github.repository }}.git" +main:refs/remotes/upstream/main --depth=1
           bash scripts/check-uffd-version.sh upstream/main
       
       - name: Install dependencies


### PR DESCRIPTION
## summary
- force-update the persistent upstream/main ref before checking the UFFD pager version
- prevent self-hosted runners from failing on stale remote-tracking refs

## testing
- git diff --check