### PR TITLE
Point at pending stlc seal-tracking PRs

### DIFF
--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -214,6 +214,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate and validate SDKs
+        id: build
         env:
           # A per-PR preview branch on pull_request, the integration-test branch
           # on an integration-test dispatch, the trunk otherwise.
@@ -249,6 +250,48 @@ jobs:
             --no-lint \
             --push \
             --targets all
+
+      - name: Report a pending seal-tracking PR on a custom-code conflict
+        # Keep one actionable comment while an open tracking PR may explain the
+        # conflict, and remove it once that condition no longer applies.
+        if: always()
+        env:
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          existing=""
+          if [ -n "$PR" ]; then
+            existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+              --jq '[.[] | select(.body | contains("<!-- stlc-seal-pending -->")) | .id][0] // empty')
+            existing=${existing%%$'\n'*}
+          fi
+
+          seal_pr=""
+          if [ "$BUILD_OUTCOME" = "failure" ]; then
+            status=$(cd "$STAINLESS_WORKSPACE" && stlc status 2>&1 || true)
+            if printf '%s\n' "$status" | grep -qi conflict; then
+              seal_pr=$(gh pr list --repo "$REPO" --head stlc/seal-tracking --state open --json url --jq '.[0].url // empty')
+            fi
+          fi
+
+          if [ -n "$seal_pr" ]; then
+            echo "::error::stlc encountered a custom-code conflict while a tracking-file sync PR is open: $seal_pr. Stale tracking files may be the cause. Merge that PR, update the affected branch from main, and let a new workflow run. If the conflict persists, use stlc status to resolve it as a legitimate custom-code conflict."
+            [ -n "$PR" ] || exit 0
+            body="<!-- stlc-seal-pending -->
+          This build encountered a custom-code conflict while a tracking-file sync PR is open: $seal_pr
+
+          Stale tracking files may be the cause. Merge the tracking PR, update this branch from \`main\`, and let a new workflow run. If the conflict persists, follow \`stlc status\` to resolve it as a legitimate custom-code conflict."
+            if [ -n "$existing" ]; then
+              gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body"
+            else
+              gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body"
+            fi
+          elif [ -n "$existing" ] && [ "$BUILD_OUTCOME" != "skipped" ]; then
+            gh api -X DELETE "repos/$REPO/issues/comments/$existing"
+          fi
 
       - name: Open or update draft PRs on the SDK repos
         # Integration-test runs only: a do-not-merge draft PR per SDK repo.


### PR DESCRIPTION
## Summary

When the stlc generate workflow encounters a custom-code conflict while a `stlc/seal-tracking` PR is open:

- emit a CI error annotation linking the tracking PR and explain that stale tracking files may be the cause
- upsert a marker-keyed PR comment instructing the author to merge the tracking PR, update their branch from `main`, and let a new workflow run
- direct the author to `stlc status` if the conflict persists
- remove the marker comment after a later build succeeds or the condition no longer applies

The SDK generation path is unchanged.

## Testing

- parsed the workflow as YAML
- validated the new shell step with `bash -n`
- verified the step matches the implementation in the API config repository
- exercised mocked success, custom-code conflict, unrelated failure, and skipped-build paths
- not exercised end-to-end because that requires a live conflict with an unmerged seal PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow shell and GitHub API comments; no changes to stlc build, auth, or SDK push logic.
> 
> **Overview**
> When **stlc generate** fails with a custom-code conflict and an open **`stlc/seal-tracking`** PR exists, the workflow now surfaces that situation instead of leaving authors to guess.
> 
> The **Generate and validate SDKs** step gets **`id: build`** so a follow-up step can read its outcome. A new **always** step runs after the build: on failure it checks **`stlc status`** for a conflict and looks up an open seal-tracking PR. If both apply, it emits a CI **`::error`** with the tracking PR link and remediation steps, and upserts a marker comment (`<!-- stlc-seal-pending -->`) on the PR. If the condition clears (build no longer skipped and conflict/tracking PR scenario gone), it deletes that comment.
> 
> SDK generation commands and push behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 441715faea2e450b7466e9dc5adf853010e09ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->