### PR TITLE
Remove the command-line fallback from socket owner resolution

### DIFF
--- a/lib/hypervisor/socket_pid_linux.go
+++ b/lib/hypervisor/socket_pid_linux.go
@@ -20,43 +20,31 @@ var procDir = "/proc"
 const soAcceptcon = 0x10000
 
 // ResolveProcessPID finds the process currently holding the listening Unix
-// socket for the given hypervisor control path. confirmed reports whether the
-// PID was found through socket ownership rather than its command line.
-func ResolveProcessPID(socketPath string) (pid int, confirmed bool, err error) {
+// socket for the given hypervisor control path, via the socket inode in
+// /proc/net/unix and each process's fd table. The fd scan requires the
+// caller to hold CAP_SYS_PTRACE (or run as root) so no live owner is missed;
+// an ErrNoOwningProcess result is proof the listener is gone.
+func ResolveProcessPID(socketPath string) (pid int, err error) {
 	return resolveProcessPID(socketPath, 0)
 }
 
 // ResolveProcessPIDForOwner resolves a socket while preferring an expected
 // owner when the socket descriptor is temporarily shared with a child process.
-func ResolveProcessPIDForOwner(socketPath string, ownerPID int) (pid int, confirmed bool, err error) {
+func ResolveProcessPIDForOwner(socketPath string, ownerPID int) (pid int, err error) {
 	return resolveProcessPID(socketPath, ownerPID)
 }
 
-func resolveProcessPID(socketPath string, ownerPID int) (pid int, confirmed bool, err error) {
-	socketRef, socketErr := socketRefForPath(socketPath)
-	var refErr error
-	if socketErr == nil {
-		// Confirm the expected owner first so a live stored PID does not
-		// require scanning every process fd.
-		if ownerPID > 0 && processHoldsSocketRef(ownerPID, socketRef) {
-			return ownerPID, true, nil
-		}
-		pid, refErr = pidBySocketRef(socketRef, ownerPID)
-		if refErr == nil {
-			return pid, true, nil
-		}
+func resolveProcessPID(socketPath string, ownerPID int) (pid int, err error) {
+	socketRef, err := socketRefForPath(socketPath)
+	if err != nil {
+		return 0, err
 	}
-
-	if pid, cmdErr := pidByCmdline(socketPath); cmdErr == nil {
-		return pid, false, nil
+	// Confirm the expected owner first so a live stored PID does not
+	// require scanning every process fd.
+	if ownerPID > 0 && processHoldsSocketRef(ownerPID, socketRef) {
+		return ownerPID, nil
 	}
-	if refErr != nil {
-		return 0, false, refErr
-	}
-	if socketErr != nil {
-		return 0, false, socketErr
-	}
-	return 0, false, fmt.Errorf("resolve process pid for socket %s: %w", socketPath, ErrNoOwningProcess)
+	return pidBySocketRef(socketRef, ownerPID)
 }
 
 func processHoldsSocketRef(pid int, socketRef string) bool {
@@ -137,47 +125,6 @@ func pidBySocketRef(socketRef string, ownerPID int) (int, error) {
 		return 0, fmt.Errorf("resolve process pid for %s: inspect process fds: %w", socketRef, scanErr)
 	}
 	return 0, fmt.Errorf("resolve process pid for %s: %w", socketRef, ErrNoOwningProcess)
-}
-
-func pidByCmdline(socketPath string) (int, error) {
-	procEntries, err := os.ReadDir(procDir)
-	if err != nil {
-		return 0, fmt.Errorf("read /proc: %w", err)
-	}
-
-	var scanErr error
-	for _, entry := range procEntries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		pid, err := strconv.Atoi(entry.Name())
-		if err != nil {
-			continue
-		}
-
-		cmdline, err := os.ReadFile(filepath.Join(procDir, entry.Name(), "cmdline"))
-		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ESRCH) {
-				continue
-			}
-			scanErr = err
-			continue
-		}
-		if len(cmdline) == 0 {
-			continue
-		}
-		for _, arg := range strings.Split(string(cmdline), "\x00") {
-			if arg == socketPath {
-				return pid, nil
-			}
-		}
-	}
-
-	if scanErr != nil {
-		return 0, fmt.Errorf("resolve process pid for socket %s: inspect process command lines: %w", socketPath, scanErr)
-	}
-	return 0, fmt.Errorf("resolve process pid for socket %s: no matching command line found: %w", socketPath, ErrNoOwningProcess)
 }
 
 func socketRefForPath(socketPath string) (string, error) {

--- a/lib/hypervisor/socket_pid_linux_test.go
+++ b/lib/hypervisor/socket_pid_linux_test.go
@@ -23,9 +23,8 @@ func TestResolveProcessPID(t *testing.T) {
 	require.NoError(t, err)
 	defer listener.Close()
 
-	pid, confirmed, err := ResolveProcessPID(socketPath)
+	pid, err := ResolveProcessPID(socketPath)
 	require.NoError(t, err)
-	require.True(t, confirmed)
 	require.Equal(t, os.Getpid(), pid)
 }
 
@@ -46,13 +45,12 @@ func TestResolveProcessPIDIgnoresConnectedSocketEntries(t *testing.T) {
 	require.NoError(t, err)
 	defer accepted.Close()
 
-	pid, confirmed, err := ResolveProcessPID(socketPath)
+	pid, err := ResolveProcessPID(socketPath)
 	require.NoError(t, err)
-	require.True(t, confirmed)
 	require.Equal(t, os.Getpid(), pid)
 }
 
-func TestResolveProcessPIDIsUnconfirmedForDuplicateSocketPaths(t *testing.T) {
+func TestResolveProcessPIDFailsForDuplicateSocketPaths(t *testing.T) {
 	oldProcDir := procDir
 	procDir = t.TempDir()
 	t.Cleanup(func() { procDir = oldProcDir })
@@ -63,9 +61,8 @@ func TestResolveProcessPIDIsUnconfirmedForDuplicateSocketPaths(t *testing.T) {
 		"00000000: 00000002 00000000 00010000 0001 01 12345 "+socketPath+"\n"+
 			"00000000: 00000002 00000000 00010000 0001 01 67890 "+socketPath+"\n"), 0o644))
 
-	_, confirmed, err := ResolveProcessPID(socketPath)
+	_, err := ResolveProcessPID(socketPath)
 	require.ErrorContains(t, err, "multiple socket inodes found")
-	require.False(t, confirmed)
 }
 
 func TestResolveProcessPIDToleratesExitedProcess(t *testing.T) {
@@ -81,9 +78,8 @@ func TestResolveProcessPIDToleratesExitedProcess(t *testing.T) {
 	require.NoError(t, os.MkdirAll(fdDir, 0o755))
 	require.NoError(t, os.Symlink("socket:[12345]", filepath.Join(fdDir, "3")))
 
-	pid, confirmed, err := ResolveProcessPID(socketPath)
+	pid, err := ResolveProcessPID(socketPath)
 	require.NoError(t, err)
-	require.True(t, confirmed)
 	require.Equal(t, 200, pid)
 }
 
@@ -101,13 +97,11 @@ func TestResolveProcessPIDForOwnerPrefersExpectedProcess(t *testing.T) {
 		require.NoError(t, os.Symlink("socket:[12345]", filepath.Join(fdDir, "3")))
 	}
 
-	_, confirmed, err := ResolveProcessPID(socketPath)
+	_, err := ResolveProcessPID(socketPath)
 	require.ErrorContains(t, err, "multiple owning processes found")
-	require.False(t, confirmed)
 
-	pid, confirmed, err := ResolveProcessPIDForOwner(socketPath, 101)
+	pid, err := ResolveProcessPIDForOwner(socketPath, 101)
 	require.NoError(t, err)
-	require.True(t, confirmed)
 	require.Equal(t, 101, pid)
 }
 
@@ -121,9 +115,8 @@ func TestResolveProcessPIDReportsNoOwnerAfterExitedProcesses(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "net", "unix"), []byte("00000000: 00000002 00000000 00010000 0001 01 12345 "+socketPath+"\n"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(procDir, "100"), 0o755))
 
-	_, confirmed, err := ResolveProcessPID(socketPath)
+	_, err := ResolveProcessPID(socketPath)
 	require.ErrorIs(t, err, ErrNoOwningProcess)
-	require.False(t, confirmed)
 	require.NotContains(t, err.Error(), "inspect process fds")
 }
 
@@ -135,9 +128,8 @@ func TestResolveProcessPIDReportsMissingSocket(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(procDir, "net"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "net", "unix"), nil, 0o644))
 
-	_, confirmed, err := ResolveProcessPID("/tmp/missing.sock")
+	_, err := ResolveProcessPID("/tmp/missing.sock")
 	require.ErrorIs(t, err, ErrNoOwningProcess)
-	require.False(t, confirmed)
 }
 
 func TestResolveProcessPIDFailsWhenFDIsUnreadable(t *testing.T) {
@@ -152,9 +144,8 @@ func TestResolveProcessPIDFailsWhenFDIsUnreadable(t *testing.T) {
 	require.NoError(t, os.MkdirAll(fdDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(fdDir, "3"), nil, 0o644))
 
-	_, confirmed, err := ResolveProcessPID(socketPath)
+	_, err := ResolveProcessPID(socketPath)
 	require.Error(t, err)
-	require.False(t, confirmed)
 	require.ErrorContains(t, err, "inspect process fds")
 	require.False(t, errors.Is(err, ErrNoOwningProcess))
 }
@@ -177,9 +168,8 @@ func TestResolveProcessPIDForOwnerConfirmsCandidateWithoutFullScan(t *testing.T)
 	require.NoError(t, os.MkdirAll(siblingFDDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(siblingFDDir, "3"), nil, 0o644))
 
-	pid, confirmed, err := ResolveProcessPIDForOwner(socketPath, 100)
+	pid, err := ResolveProcessPIDForOwner(socketPath, 100)
 	require.NoError(t, err)
-	require.True(t, confirmed)
 	require.Equal(t, 100, pid)
 }
 
@@ -199,9 +189,8 @@ func TestResolveProcessPIDForOwnerSkipsUnreadableCandidateFD(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(fdDir, "1"), nil, 0o644))
 	require.NoError(t, os.Symlink("socket:[12345]", filepath.Join(fdDir, "3")))
 
-	pid, confirmed, err := ResolveProcessPIDForOwner(socketPath, 100)
+	pid, err := ResolveProcessPIDForOwner(socketPath, 100)
 	require.NoError(t, err)
-	require.True(t, confirmed)
 	require.Equal(t, 100, pid)
 }
 
@@ -222,9 +211,8 @@ func TestResolveProcessPIDForOwnerFallsThroughWhenCandidateLacksSocket(t *testin
 	require.NoError(t, os.MkdirAll(ownerFDDir, 0o755))
 	require.NoError(t, os.Symlink("socket:[12345]", filepath.Join(ownerFDDir, "3")))
 
-	pid, confirmed, err := ResolveProcessPIDForOwner(socketPath, 999)
+	pid, err := ResolveProcessPIDForOwner(socketPath, 999)
 	require.NoError(t, err)
-	require.True(t, confirmed)
 	require.Equal(t, 200, pid)
 }
 
@@ -241,9 +229,8 @@ func TestResolveProcessPIDForOwnerFallsThroughWhenCandidateIsGone(t *testing.T) 
 	require.NoError(t, os.MkdirAll(ownerFDDir, 0o755))
 	require.NoError(t, os.Symlink("socket:[12345]", filepath.Join(ownerFDDir, "3")))
 
-	pid, confirmed, err := ResolveProcessPIDForOwner(socketPath, 999)
+	pid, err := ResolveProcessPIDForOwner(socketPath, 999)
 	require.NoError(t, err)
-	require.True(t, confirmed)
 	require.Equal(t, 200, pid)
 }
 
@@ -255,9 +242,8 @@ func TestResolveProcessPIDForOwnerReportsMissingSocket(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(procDir, "net"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "net", "unix"), []byte("00000000: 00000002 00000000 00010000 0001 01 12345 /tmp/other.sock\n"), 0o644))
 
-	_, confirmed, err := ResolveProcessPIDForOwner("/tmp/missing.sock", 100)
+	_, err := ResolveProcessPIDForOwner("/tmp/missing.sock", 100)
 	require.ErrorIs(t, err, ErrNoOwningProcess)
-	require.False(t, confirmed)
 }
 
 func TestResolveProcessPIDForOwnerReportsMissingSocketWithHeaderOnlyUnixTable(t *testing.T) {
@@ -268,9 +254,8 @@ func TestResolveProcessPIDForOwnerReportsMissingSocketWithHeaderOnlyUnixTable(t 
 	require.NoError(t, os.MkdirAll(filepath.Join(procDir, "net"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "net", "unix"), []byte("Num       RefCount Protocol Flags    Type St Inode Path\n"), 0o644))
 
-	_, confirmed, err := ResolveProcessPIDForOwner("/tmp/missing.sock", 100)
+	_, err := ResolveProcessPIDForOwner("/tmp/missing.sock", 100)
 	require.ErrorIs(t, err, ErrNoOwningProcess)
-	require.False(t, confirmed)
 }
 
 func TestResolveProcessPIDForOwnerReportsDuplicateSocketInodes(t *testing.T) {
@@ -288,9 +273,8 @@ func TestResolveProcessPIDForOwnerReportsDuplicateSocketInodes(t *testing.T) {
 	require.NoError(t, os.MkdirAll(fdDir, 0o755))
 	require.NoError(t, os.Symlink("socket:[12345]", filepath.Join(fdDir, "3")))
 
-	_, confirmed, err := ResolveProcessPIDForOwner(socketPath, 100)
+	_, err := ResolveProcessPIDForOwner(socketPath, 100)
 	require.ErrorContains(t, err, "multiple socket inodes found")
-	require.False(t, confirmed)
 }
 
 func TestResolveProcessPIDForOwnerConfirmsLiveListener(t *testing.T) {
@@ -301,10 +285,27 @@ func TestResolveProcessPIDForOwnerConfirmsLiveListener(t *testing.T) {
 	require.NoError(t, err)
 	defer listener.Close()
 
-	pid, confirmed, err := ResolveProcessPIDForOwner(socketPath, os.Getpid())
+	pid, err := ResolveProcessPIDForOwner(socketPath, os.Getpid())
 	require.NoError(t, err)
-	require.True(t, confirmed)
 	require.Equal(t, os.Getpid(), pid)
+}
+
+func TestResolveProcessPIDIgnoresCommandLineBystander(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "test.sock")
+	require.NoError(t, os.WriteFile(socketPath, nil, 0o600))
+
+	// A process carrying the socket path in its command line (e.g. a debug
+	// client like ch-remote) without holding the listener must not resolve
+	// as the owner; a missing listener is proof the hypervisor is gone.
+	bystander := exec.Command("sh", "-c", "sleep 30", "sh", socketPath)
+	require.NoError(t, bystander.Start())
+	t.Cleanup(func() {
+		_ = bystander.Process.Kill()
+		_ = bystander.Wait()
+	})
+
+	_, err := ResolveProcessPID(socketPath)
+	require.ErrorIs(t, err, ErrNoOwningProcess)
 }
 
 func TestResolveProcessPIDDuringProcessChurn(t *testing.T) {
@@ -328,9 +329,8 @@ func TestResolveProcessPIDDuringProcessChurn(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		pid, confirmed, err := ResolveProcessPIDForOwner(socketPath, os.Getpid())
+		pid, err := ResolveProcessPIDForOwner(socketPath, os.Getpid())
 		require.NoError(t, err)
-		require.True(t, confirmed)
 		require.Equal(t, os.Getpid(), pid)
 	}
 }

--- a/lib/hypervisor/socket_pid_other.go
+++ b/lib/hypervisor/socket_pid_other.go
@@ -6,11 +6,11 @@ import "fmt"
 
 // ResolveProcessPID is only implemented on Linux, where the project relies on
 // /proc socket metadata for runtime PID discovery.
-func ResolveProcessPID(socketPath string) (int, bool, error) {
-	return 0, false, fmt.Errorf("resolve process pid for socket %s: not supported on this platform", socketPath)
+func ResolveProcessPID(socketPath string) (int, error) {
+	return 0, fmt.Errorf("resolve process pid for socket %s: not supported on this platform", socketPath)
 }
 
 // ResolveProcessPIDForOwner is only implemented on Linux.
-func ResolveProcessPIDForOwner(socketPath string, _ int) (int, bool, error) {
+func ResolveProcessPIDForOwner(socketPath string, _ int) (int, error) {
 	return ResolveProcessPID(socketPath)
 }

--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -808,15 +808,13 @@ func (m *manager) startAndBootVM(
 // resolveRuntimeHypervisorPID resolves the runtime PID of the hypervisor
 // serving the instance socket and records its process identity. The
 // boot-scoped identity token is minted only for a trustworthy PID — the
-// direct child we spawned or the confirmed socket owner. A command-line-only
-// match records the bare PID without the token, so destructive paths must
-// confirm socket ownership before trusting it.
+// direct child we spawned or the confirmed socket owner.
 func resolveRuntimeHypervisorPID(log *slog.Logger, stored *StoredMetadata, fallbackPID int) int {
 	if ProcessExists(fallbackPID) {
 		stored.HypervisorProcessIdentity.Set(fallbackPID)
 		return fallbackPID
 	}
-	pid, confirmed, err := hypervisor.ResolveProcessPID(stored.SocketPath)
+	pid, err := hypervisor.ResolveProcessPID(stored.SocketPath)
 	if err != nil {
 		// The fallback PID was just proven dead, so it gets no identity
 		// token: minting one would stamp the current boot ID (and, if the
@@ -826,11 +824,7 @@ func resolveRuntimeHypervisorPID(log *slog.Logger, stored *StoredMetadata, fallb
 		stored.HypervisorProcessIdentity.SetUnconfirmed(fallbackPID)
 		return fallbackPID
 	}
-	if confirmed {
-		stored.HypervisorProcessIdentity.Set(pid)
-		return pid
-	}
-	stored.HypervisorProcessIdentity.SetUnconfirmed(pid)
+	stored.HypervisorProcessIdentity.Set(pid)
 	return pid
 }
 

--- a/lib/instances/guestmemory_linux_test.go
+++ b/lib/instances/guestmemory_linux_test.go
@@ -214,7 +214,7 @@ func requireHypervisorPID(t *testing.T, ctx context.Context, mgr *manager, insta
 	if inst.HypervisorPID != nil && ProcessExists(*inst.HypervisorPID) {
 		return *inst.HypervisorPID
 	}
-	if pid, _, err := hypervisor.ResolveProcessPID(inst.SocketPath); err == nil {
+	if pid, err := hypervisor.ResolveProcessPID(inst.SocketPath); err == nil {
 		return pid
 	}
 	require.NotNil(t, inst.HypervisorPID)

--- a/lib/instances/identity_backfill_linux_test.go
+++ b/lib/instances/identity_backfill_linux_test.go
@@ -82,7 +82,7 @@ func TestBackfillHypervisorProcessIdentitiesSkipsMissingSocketOwner(t *testing.T
 	assert.NoError(t, syscall.Kill(stalePID, 0))
 }
 
-func TestBackfillHypervisorProcessIdentitiesSkipsUnconfirmedCommandLineMatch(t *testing.T) {
+func TestBackfillHypervisorProcessIdentitiesIgnoresCommandLineBystander(t *testing.T) {
 	mgr := &manager{paths: paths.New(t.TempDir())}
 	socketPath := filepath.Join(t.TempDir(), "test.sock")
 	match := exec.Command("sh", "-c", "sleep 30", "sh", socketPath)

--- a/lib/instances/process_identity.go
+++ b/lib/instances/process_identity.go
@@ -66,11 +66,10 @@ func (h *HypervisorProcessIdentity) Set(pid int) {
 }
 
 // SetUnconfirmed records a bare PID without the boot-scoped identity token.
-// Used when the PID matched the socket by command line only or was just
-// proven dead: minting a token would stamp the current boot ID (and, if the
-// PID is recycled mid-call, a live start time) onto a process that is not the
-// hypervisor. Destructive paths must confirm socket ownership before trusting
-// an unconfirmed PID.
+// Used when the PID was just proven dead: minting a token would stamp the
+// current boot ID (and, if the PID is recycled mid-call, a live start time)
+// onto a process that is not the hypervisor. Destructive paths must confirm
+// socket ownership before trusting an unconfirmed PID.
 func (h *HypervisorProcessIdentity) SetUnconfirmed(pid int) {
 	h.HypervisorPID = &pid
 	h.HypervisorStartTime = 0
@@ -98,25 +97,18 @@ func refreshHypervisorPID(stored *StoredMetadata, state State) {
 	if stored.SocketPath == "" {
 		return
 	}
-	pid, confirmed, err := hypervisor.ResolveProcessPID(stored.SocketPath)
+	pid, err := hypervisor.ResolveProcessPID(stored.SocketPath)
 	if err != nil {
 		return
 	}
-	if confirmed {
-		stored.HypervisorProcessIdentity.Set(pid)
-		return
-	}
-	// Command-line-only match: record the bare PID without the identity
-	// token, same rule as resolveRuntimeHypervisorPID.
-	stored.HypervisorProcessIdentity.SetUnconfirmed(pid)
+	stored.HypervisorProcessIdentity.Set(pid)
 }
 
 // resolveLiveHypervisorPID returns the PID of the live hypervisor that owns
 // the instance socket, or 0 when no live hypervisor is found. A live stored PID
 // whose recorded boot ID and start time match is returned without socket
-// confirmation. It returns an error when socket ownership cannot be confirmed:
-// a live process matches the socket path by command line only, or a live stored
-// PID's ownership cannot be verified.
+// confirmation. It returns an error when socket ownership cannot be confirmed
+// because the socket scan itself failed.
 func resolveLiveHypervisorPID(id HypervisorProcessIdentity, socketPath string) (int, error) {
 	stored := 0
 	if id.HypervisorPID != nil && ProcessExists(*id.HypervisorPID) {
@@ -136,54 +128,38 @@ func resolveLiveHypervisorPID(id HypervisorProcessIdentity, socketPath string) (
 		return stored, nil
 	}
 	var resolved int
-	var confirmed bool
 	var err error
 	if stored != 0 && id.HypervisorStartTime == 0 {
-		resolved, confirmed, err = hypervisor.ResolveProcessPIDForOwner(socketPath, stored)
+		resolved, err = hypervisor.ResolveProcessPIDForOwner(socketPath, stored)
 	} else {
-		resolved, confirmed, err = hypervisor.ResolveProcessPID(socketPath)
+		resolved, err = hypervisor.ResolveProcessPID(socketPath)
 	}
-	return classifyResolvedHypervisorOwner(socketPath, stored, resolved, confirmed, err)
+	return classifyResolvedHypervisorOwner(socketPath, stored, resolved, err)
 }
 
 // classifyResolvedHypervisorOwner interprets a socket resolution result for
 // resolveLiveHypervisorPID: which live PID, if any, is the recorded
 // hypervisor, and whether the ambiguity must fail closed.
-func classifyResolvedHypervisorOwner(socketPath string, stored, resolved int, confirmed bool, err error) (int, error) {
+func classifyResolvedHypervisorOwner(socketPath string, stored, resolved int, err error) (int, error) {
 	switch {
-	case err == nil && confirmed && ProcessExists(resolved):
+	case err == nil && ProcessExists(resolved):
 		return resolved, nil
-	case err == nil && confirmed:
-		return 0, nil
-	case err == nil && !confirmed && ProcessExists(resolved):
-		if stored != 0 {
-			return 0, fmt.Errorf("cannot confirm ownership of socket %s for stored hypervisor PID %d: process %d matched by command line only", socketPath, stored, resolved)
-		}
-		return 0, fmt.Errorf("cannot confirm ownership of socket %s: process %d matched by command line only", socketPath, resolved)
 	case err == nil:
-		// The only match was by command line and that process is already
-		// gone: the socket-owner scan found nothing and no live process
-		// matches the command line, the same provable-death conclusion as
-		// ErrNoOwningProcess below.
-		return 0, nil
-	}
-	if stored == 0 {
-		if !errors.Is(err, hypervisor.ErrNoOwningProcess) {
-			return 0, fmt.Errorf("cannot confirm ownership of socket %s: %w", socketPath, err)
-		}
 		return 0, nil
 	}
 	if errors.Is(err, hypervisor.ErrNoOwningProcess) {
-		// Neither the socket-owner scan nor the full command-line scan
-		// found any process tied to the socket. A live hypervisor always
-		// holds its control-socket listener, so the recorded hypervisor is
-		// gone and the live stored PID is a recycled number — the same
-		// conclusion already drawn above when the stored PID is dead.
+		// The socket-owner scan found no process holding the listener. A live
+		// hypervisor always holds its control-socket listener, so the recorded
+		// hypervisor is gone and a live stored PID is a recycled number — the
+		// same conclusion already drawn above when the stored PID is dead.
 		// Without this, legacy metadata carrying no boot-scoped identity
 		// wedges stop and delete forever once its PID is reused.
 		return 0, nil
 	}
-	return 0, fmt.Errorf("cannot confirm ownership of socket %s for stored hypervisor PID %d: %w", socketPath, stored, err)
+	if stored != 0 {
+		return 0, fmt.Errorf("cannot confirm ownership of socket %s for stored hypervisor PID %d: %w", socketPath, stored, err)
+	}
+	return 0, fmt.Errorf("cannot confirm ownership of socket %s: %w", socketPath, err)
 }
 
 // ProcessExists reports whether pid belongs to a live, non-zombie process.

--- a/lib/instances/process_identity_linux_test.go
+++ b/lib/instances/process_identity_linux_test.go
@@ -5,6 +5,7 @@ package instances
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -274,29 +275,31 @@ func TestClassifyResolvedHypervisorOwner(t *testing.T) {
 	})
 	livePID := live.Process.Pid
 
-	// A command-line match that exited between the scan and the liveness
-	// check means no live process owns or references the socket: provably
-	// dead, same conclusion as ErrNoOwningProcess, even with a live stored
-	// PID. A live command-line-only match is genuinely ambiguous and fails
-	// closed whether or not a stored PID exists.
+	// A resolved owner that exited between the scan and the liveness check is
+	// the same provable-death conclusion as ErrNoOwningProcess, even with a
+	// live stored PID. Only a failed scan fails closed.
 	for _, tc := range []struct {
 		name             string
 		stored, resolved int
+		err              error
+		wantPID          int
 		wantErr          bool
 	}{
-		{"dead cmdline match with live stored PID", livePID, deadPID, false},
-		{"dead cmdline match without stored PID", 0, deadPID, false},
-		{"live cmdline match with stored PID", livePID, livePID, true},
-		{"live cmdline match without stored PID", 0, livePID, true},
+		{name: "live resolved owner", resolved: livePID, wantPID: livePID},
+		{name: "dead resolved owner with live stored PID", stored: livePID, resolved: deadPID},
+		{name: "dead resolved owner without stored PID", resolved: deadPID},
+		{name: "no owning process with live stored PID", stored: livePID, err: fmt.Errorf("wrapped: %w", hypervisor.ErrNoOwningProcess)},
+		{name: "scan failure with stored PID", stored: livePID, err: errors.New("inspect process fds: permission denied"), wantErr: true},
+		{name: "scan failure without stored PID", err: errors.New("inspect process fds: permission denied"), wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			pid, err := classifyResolvedHypervisorOwner("/fake.sock", tc.stored, tc.resolved, false, nil)
+			pid, err := classifyResolvedHypervisorOwner("/fake.sock", tc.stored, tc.resolved, tc.err)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Zero(t, pid)
+			assert.Equal(t, tc.wantPID, pid)
 		})
 	}
 }
@@ -334,7 +337,7 @@ func TestShutdownHypervisorKillsResolvedOwnerWhenClientUnavailable(t *testing.T)
 	assert.True(t, os.IsNotExist(statErr), "instance socket should be removed")
 }
 
-func TestShutdownHypervisorFailsClosedOnUnconfirmedOwnership(t *testing.T) {
+func TestShutdownHypervisorIgnoresCommandLineBystander(t *testing.T) {
 	socketPath := filepath.Join(t.TempDir(), "test.sock")
 	require.NoError(t, os.WriteFile(socketPath, nil, 0600))
 	match := exec.Command("sh", "-c", "sleep 30", "sh", socketPath)
@@ -351,21 +354,22 @@ func TestShutdownHypervisorFailsClosedOnUnconfirmedOwnership(t *testing.T) {
 		_ = stale.Wait()
 	})
 
+	// No process owns the socket listener; a debug client carrying the socket
+	// path in its command line must not be mistaken for the hypervisor or
+	// block shutdown.
 	stalePID := stale.Process.Pid
 	m := &manager{}
 	err := m.shutdownHypervisor(context.Background(), &Instance{
 		StoredMetadata: StoredMetadata{
-			Id:                        "shutdown-unconfirmed",
+			Id:                        "shutdown-cmdline-bystander",
 			HypervisorType:            hypervisor.TypeCloudHypervisor,
 			HypervisorProcessIdentity: HypervisorProcessIdentity{HypervisorPID: &stalePID},
 			SocketPath:                socketPath,
 		},
 	})
-	require.ErrorContains(t, err, "confirm hypervisor ownership before shutdown")
-	assert.NoError(t, syscall.Kill(stalePID, 0), "stored PID must not be signaled on unconfirmed ownership")
-	assert.NoError(t, syscall.Kill(match.Process.Pid, 0), "command-line match must not be signaled")
-	_, statErr := os.Stat(socketPath)
-	assert.NoError(t, statErr, "socket must be kept as evidence for the hardened kill path")
+	require.NotContains(t, fmt.Sprint(err), "confirm hypervisor ownership")
+	assert.NoError(t, syscall.Kill(stalePID, 0), "process with a recycled PID must not be killed")
+	assert.NoError(t, syscall.Kill(match.Process.Pid, 0), "command-line bystander must not be signaled")
 }
 
 func TestKillProcessAndWaitIgnoresExitedProcess(t *testing.T) {
@@ -476,10 +480,12 @@ func TestKillHypervisorSucceedsOnReusedPIDWhenNoProcessOwnsSocket(t *testing.T) 
 	assert.NoError(t, syscall.Kill(stalePID, 0), "process with a recycled PID must not be killed")
 }
 
-func TestKillHypervisorFailsOnUnconfirmedCommandLineMatch(t *testing.T) {
+func TestKillHypervisorIgnoresCommandLineBystander(t *testing.T) {
 	socketPath := filepath.Join(t.TempDir(), "test.sock")
 	// A process whose command line contains the socket path but that does not
-	// own a listening socket: ResolveProcessPID resolves it unconfirmed.
+	// own a listening socket (e.g. a debug client like ch-remote) is invisible
+	// to resolution: no listener exists, so the recorded hypervisor is
+	// provably gone and the kill completes without signaling the bystander.
 	match := exec.Command("sh", "-c", "sleep 30", "sh", socketPath)
 	require.NoError(t, match.Start())
 	t.Cleanup(func() {
@@ -489,11 +495,11 @@ func TestKillHypervisorFailsOnUnconfirmedCommandLineMatch(t *testing.T) {
 
 	matchPID := match.Process.Pid
 	m := &manager{}
-	require.Error(t, m.killHypervisor(context.Background(), &Instance{
+	require.NoError(t, m.killHypervisor(context.Background(), &Instance{
 		StoredMetadata: StoredMetadata{Id: "kill-test", HypervisorProcessIdentity: HypervisorProcessIdentity{HypervisorPID: &matchPID}, SocketPath: socketPath},
-	}), "a command-line match must not satisfy destructive ownership verification")
+	}))
 
-	assert.NoError(t, syscall.Kill(matchPID, 0), "process matched only by command line must not be killed")
+	assert.NoError(t, syscall.Kill(matchPID, 0), "command-line bystander must not be killed")
 }
 
 func TestResolveRuntimeHypervisorPIDMintsIdentityOnlyWhenConfirmed(t *testing.T) {
@@ -535,7 +541,7 @@ func TestResolveRuntimeHypervisorPIDMintsIdentityOnlyWhenConfirmed(t *testing.T)
 		assert.NotEmpty(t, stored.HypervisorBootID)
 	})
 
-	t.Run("command-line-only match stores bare PID", func(t *testing.T) {
+	t.Run("command-line bystander is not adopted", func(t *testing.T) {
 		socketPath := filepath.Join(t.TempDir(), "test.sock")
 		match := exec.Command("sh", "-c", "sleep 30", "sh", socketPath)
 		require.NoError(t, match.Start())
@@ -547,11 +553,11 @@ func TestResolveRuntimeHypervisorPIDMintsIdentityOnlyWhenConfirmed(t *testing.T)
 		stored := &StoredMetadata{SocketPath: socketPath}
 		pid := resolveRuntimeHypervisorPID(log, stored, deadPID)
 
-		assert.Equal(t, match.Process.Pid, pid)
+		assert.Equal(t, deadPID, pid, "a process matching only by command line must not be resolved")
 		require.NotNil(t, stored.HypervisorPID)
-		assert.Equal(t, match.Process.Pid, *stored.HypervisorPID)
-		assert.Zero(t, stored.HypervisorStartTime, "unconfirmed match must not mint the identity token")
-		assert.Empty(t, stored.HypervisorBootID, "unconfirmed match must not mint the identity token")
+		assert.Equal(t, deadPID, *stored.HypervisorPID)
+		assert.Zero(t, stored.HypervisorStartTime, "a dead fallback must not mint the identity token")
+		assert.Empty(t, stored.HypervisorBootID, "a dead fallback must not mint the identity token")
 	})
 
 	t.Run("dead fallback with unresolvable socket stores bare PID", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Stacked on #363. Deletes `pidByCmdline` and the `confirmed` flag from socket owner resolution, collapsing `classifyResolvedHypervisorOwner` from an 8-branch matrix to 4 cases.

A command-line-only match could never authorize teardown — destructive paths already refused unconfirmed PIDs — so the fallback's only effect was distinguishing provable death from ambiguity. That distinction only matters if the fd scan can miss a live owner, which requires the caller to lack `CAP_SYS_PTRACE`. Hypeman runs as root (dev) or with a full capability set (prod), so the listener scan is authoritative: a confirmed owner is returned, a missing listener is proof the hypervisor is gone, and only a failed scan fails closed.

The fallback was also actively harmful: a debug client carrying the socket path in its argv (`ch-remote`, `socat`) resolved as a live unconfirmed match and wedged stop/delete with a 500 until the client exited. That case now correctly classifies as provable death and the bystander is never signaled.

**Assumption made explicit:** resolution correctness now depends on hypeman retaining ptrace-equivalent capabilities (root or `CAP_SYS_PTRACE`). This is documented on `ResolveProcessPID`. If the service is ever de-privileged below that, the fd scan can miss owners and this needs revisiting.

## Testing

- `go vet` clean; `go test -race ./lib/hypervisor/ ./lib/instances/` targeted identity/kill/shutdown/backfill suites pass locally (`TestSocketCacheKeyChangesWhenSocketIsRecreated` fails in this sandbox on the unmodified base too — inode reuse in /tmp)
- Same suites cross-compiled and run as root on a dev host with real `/proc`: all pass
- Live validation on that host: a real daemon control socket resolves to its owning PID; a dead socket path held in a live process's argv returns `ErrNoOwningProcess` instead of failing closed
- New/updated coverage: `TestResolveProcessPIDIgnoresCommandLineBystander`, `TestKillHypervisorIgnoresCommandLineBystander`, `TestShutdownHypervisorIgnoresCommandLineBystander`, reworked `TestClassifyResolvedHypervisorOwner` table