### PR TITLE
Serialize auto-standby persistence per instance

### DIFF
--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -104,6 +104,11 @@ type ControllerOptions struct {
 }
 
 type controllerState struct {
+	// runtimeMu orders metadata writes; runtimeRevision invalidates writes that
+	// have been superseded before they acquire the mutex.
+	runtimeMu       sync.Mutex
+	runtimeRevision uint64
+
 	instance         Instance
 	compiledPolicy   *compiledPolicy
 	activeInbound    map[ConnectionKey]struct{}
@@ -116,6 +121,15 @@ type controllerState struct {
 	reconcileTimer   *time.Timer
 	standbyRequested bool
 	standbyExecuting bool
+}
+
+type runtimePersistence struct {
+	id         string
+	state      *controllerState
+	revision   uint64
+	runtime    *Runtime
+	bestEffort bool
+	operation  string
 }
 
 // Controller decides when eligible instances should transition to standby.
@@ -537,9 +551,12 @@ func (c *Controller) periodicSnapshotSync(ctx context.Context) error {
 
 func (c *Controller) seedInstanceState(ctx context.Context, inst Instance, conns []Connection, now time.Time) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return c.refreshInstanceLocked(ctx, inst, conns, now)
+	persistence, err := c.refreshInstanceLocked(inst, conns, now)
+	c.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return c.persistRuntime(ctx, persistence)
 }
 
 func (c *Controller) handleInstanceEvent(ctx context.Context, event InstanceEvent) error {
@@ -559,11 +576,15 @@ func (c *Controller) handleInstanceEvent(ctx context.Context, event InstanceEven
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.refreshInstanceLocked(ctx, *event.Instance, conns, c.now().UTC())
+	persistence, err := c.refreshInstanceLocked(*event.Instance, conns, c.now().UTC())
+	c.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return c.persistRuntime(ctx, persistence)
 }
 
-func (c *Controller) refreshInstanceLocked(ctx context.Context, inst Instance, conns []Connection, now time.Time) error {
+func (c *Controller) refreshInstanceLocked(inst Instance, conns []Connection, now time.Time) (runtimePersistence, error) {
 	state := c.ensureStateLocked(inst.ID)
 	state.instance = cloneInstance(inst)
 
@@ -571,21 +592,21 @@ func (c *Controller) refreshInstanceLocked(ctx context.Context, inst Instance, c
 		hadRuntime := inst.Runtime != nil || state.idleSince != nil || state.lastInboundAt != nil
 		c.clearStateLocked(state)
 		if hadRuntime {
-			return c.persistRuntime(ctx, inst.ID, nil)
+			return c.stageRuntimePersistenceLocked(inst.ID, state, nil, false, "refresh disabled instance"), nil
 		}
-		return nil
+		return runtimePersistence{}, nil
 	}
 
 	compiled, err := compilePolicy(inst.AutoStandby)
 	if err != nil {
-		return err
+		return runtimePersistence{}, err
 	}
 	state.compiledPolicy = compiled
 	state.idleTimeout = compiled.idleTimeout
 
 	activeSet, err := matchingConnections(inst, compiled, conns)
 	if err != nil {
-		return err
+		return runtimePersistence{}, err
 	}
 	// Cancel any queued standby attempt only once the refresh is guaranteed to
 	// re-establish a countdown or reconcile below; an erroring refresh above
@@ -596,21 +617,34 @@ func (c *Controller) refreshInstanceLocked(ctx context.Context, inst Instance, c
 	runtime := cloneRuntime(inst.Runtime)
 	if len(activeSet) > 0 {
 		state.idleSince = nil
-		if runtime != nil && runtime.LastInboundActivityAt != nil {
+		if runtime != nil && runtime.LastInboundActivityAt != nil && (state.lastInboundAt == nil || runtime.LastInboundActivityAt.After(*state.lastInboundAt)) {
 			state.lastInboundAt = cloneTimePtr(runtime.LastInboundActivityAt)
-		} else {
+		} else if state.lastInboundAt == nil {
 			state.lastInboundAt = &now
 		}
 		c.cancelTimerLocked(state)
 		c.armReconcileLocked(inst.ID, state)
-		return c.persistRuntime(ctx, inst.ID, &Runtime{
+		return c.stageRuntimePersistenceLocked(inst.ID, state, &Runtime{
 			LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
-		})
+		}, false, "refresh active instance"), nil
 	}
 
+	var persistence runtimePersistence
 	if runtime != nil && runtime.IdleSince != nil {
-		state.idleSince = cloneTimePtr(runtime.IdleSince)
-		state.lastInboundAt = cloneTimePtr(runtime.LastInboundActivityAt)
+		stale := state.idleSince != nil && state.idleSince.After(*runtime.IdleSince)
+		if state.idleSince == nil && state.lastInboundAt != nil && !state.lastInboundAt.Before(*runtime.IdleSince) {
+			state.idleSince = &now
+			stale = true
+		}
+		if stale {
+			persistence = c.stageRuntimePersistenceLocked(inst.ID, state, &Runtime{
+				IdleSince:             cloneTimePtr(state.idleSince),
+				LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
+			}, true, "repair stale refresh")
+		} else {
+			state.idleSince = cloneTimePtr(runtime.IdleSince)
+			state.lastInboundAt = cloneTimePtr(runtime.LastInboundActivityAt)
+		}
 	} else {
 		state.idleSince = &now
 		if runtime != nil {
@@ -618,19 +652,13 @@ func (c *Controller) refreshInstanceLocked(ctx context.Context, inst Instance, c
 		} else {
 			state.lastInboundAt = nil
 		}
-		runtime = &Runtime{
+		persistence = c.stageRuntimePersistenceLocked(inst.ID, state, &Runtime{
 			IdleSince:             cloneTimePtr(state.idleSince),
 			LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
-		}
-		// Persist failures must not strand the instance without a countdown;
-		// the runtime only matters for recovery across controller restarts.
-		if err := c.persistRuntime(ctx, inst.ID, runtime); err != nil {
-			c.recordControllerError("persist_runtime")
-			c.log.Warn("auto-standby failed to persist runtime during refresh", "instance_id", inst.ID, "error", err)
-		}
+		}, true, "refresh idle instance")
 	}
 	c.armTimerLocked(inst.ID, state, now)
-	return nil
+	return persistence, nil
 }
 
 func (c *Controller) handleConnectionEvent(ctx context.Context, event ConnectionEvent) {
@@ -648,9 +676,8 @@ func (c *Controller) handleConnectionEvent(ctx context.Context, event Connection
 	}
 	c.recordConntrackEvent(string(event.Type), "received")
 
+	var persistences []runtimePersistence
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	for id, state := range c.states {
 		if state.compiledPolicy == nil {
 			continue
@@ -676,13 +703,10 @@ func (c *Controller) handleConnectionEvent(ctx context.Context, event Connection
 				state.standbyRequested = false
 				c.cancelReconcileLocked(state)
 				c.armTimerLocked(id, state, idleSince)
-				if err := c.persistRuntime(ctx, id, &Runtime{
+				persistences = append(persistences, c.stageRuntimePersistenceLocked(id, state, &Runtime{
 					IdleSince:             cloneTimePtr(state.idleSince),
 					LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
-				}); err != nil {
-					c.recordControllerError("persist_runtime")
-					c.log.Warn("auto-standby failed to persist runtime when idle countdown started", "instance_id", id, "error", err)
-				}
+				}, true, "start idle countdown"))
 				c.log.Info("auto-standby idle countdown started", "instance_id", id, "idle_timeout", state.idleTimeout)
 				continue
 			}
@@ -695,12 +719,9 @@ func (c *Controller) handleConnectionEvent(ctx context.Context, event Connection
 			state.standbyRequested = false
 			c.cancelTimerLocked(state)
 			c.armReconcileLocked(id, state)
-			if err := c.persistRuntime(ctx, id, &Runtime{
+			persistences = append(persistences, c.stageRuntimePersistenceLocked(id, state, &Runtime{
 				LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
-			}); err != nil {
-				c.recordControllerError("persist_runtime")
-				c.log.Warn("auto-standby failed to persist runtime after inbound activity", "instance_id", id, "error", err)
-			}
+			}, true, "record inbound activity"))
 			c.log.Info("auto-standby inbound activity observed", "instance_id", id, "active_inbound_connections", len(state.activeInbound))
 		case ConnectionEventDestroy:
 			if _, ok := state.activeInbound[key]; !ok {
@@ -716,15 +737,17 @@ func (c *Controller) handleConnectionEvent(ctx context.Context, event Connection
 			state.standbyRequested = false
 			c.cancelReconcileLocked(state)
 			c.armTimerLocked(id, state, idleSince)
-			if err := c.persistRuntime(ctx, id, &Runtime{
+			persistences = append(persistences, c.stageRuntimePersistenceLocked(id, state, &Runtime{
 				IdleSince:             cloneTimePtr(state.idleSince),
 				LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
-			}); err != nil {
-				c.recordControllerError("persist_runtime")
-				c.log.Warn("auto-standby failed to persist runtime when idle countdown started", "instance_id", id, "error", err)
-			}
+			}, true, "start idle countdown"))
 			c.log.Info("auto-standby idle countdown started", "instance_id", id, "idle_timeout", state.idleTimeout)
 		}
+	}
+	c.mu.Unlock()
+
+	for _, persistence := range persistences {
+		_ = c.persistRuntime(ctx, persistence)
 	}
 }
 
@@ -738,12 +761,11 @@ func (c *Controller) confirmIdleBeforeStandby(ctx context.Context, id string) bo
 	conns, listErr := c.source.ListConnections(ctx)
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	state := c.states[id]
 	// Activity can land between the timer firing and this check, and it already
 	// owns idleSince and the reconcile loop; the paths below must not clobber it.
 	if state == nil || state.compiledPolicy == nil || len(state.activeInbound) > 0 {
+		c.mu.Unlock()
 		return false
 	}
 
@@ -756,18 +778,18 @@ func (c *Controller) confirmIdleBeforeStandby(ctx context.Context, id string) bo
 		idleSince := c.now().UTC()
 		state.idleSince = &idleSince
 		c.armTimerLocked(id, state, idleSince)
-		if persistErr := c.persistRuntime(ctx, id, &Runtime{
+		persistence := c.stageRuntimePersistenceLocked(id, state, &Runtime{
 			IdleSince:             cloneTimePtr(state.idleSince),
 			LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
-		}); persistErr != nil {
-			c.recordControllerError("persist_runtime")
-			c.log.Warn("auto-standby failed to persist runtime after unconfirmed standby", "instance_id", id, "error", persistErr)
-		}
+		}, true, "recover from unconfirmed standby")
+		c.mu.Unlock()
+		_ = c.persistRuntime(ctx, persistence)
 		c.recordControllerError("standby_confirm")
 		c.log.Warn("auto-standby could not confirm idle before standby", "instance_id", id, "error", err)
 		return false
 	}
 	if len(activeSet) == 0 {
+		c.mu.Unlock()
 		return true
 	}
 
@@ -777,13 +799,12 @@ func (c *Controller) confirmIdleBeforeStandby(ctx context.Context, id string) bo
 	state.lastInboundAt = &now
 	c.cancelTimerLocked(state)
 	c.armReconcileLocked(id, state)
-	if err := c.persistRuntime(ctx, id, &Runtime{
+	persistence := c.stageRuntimePersistenceLocked(id, state, &Runtime{
 		LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
-	}); err != nil {
-		c.recordControllerError("persist_runtime")
-		c.log.Warn("auto-standby failed to persist runtime after standby confirmation found connections", "instance_id", id, "error", err)
-	}
+	}, true, "record standby confirmation activity")
 	c.log.Info("auto-standby skipped standby, conntrack still reports inbound connections", "instance_id", id, "active_inbound_connections", len(activeSet))
+	c.mu.Unlock()
+	_ = c.persistRuntime(ctx, persistence)
 	return false
 }
 
@@ -902,32 +923,35 @@ func (c *Controller) executeStandby(ctx context.Context, id string, instanceName
 		c.recordControllerError("standby")
 
 		c.mu.Lock()
-		defer c.mu.Unlock()
 		if errors.Is(err, ErrInstanceNotFound) {
 			c.log.Info("auto-standby target instance no longer exists, dropping state", "instance_id", id, "instance_name", instanceName)
 			c.removeStateLocked(id)
+			c.mu.Unlock()
 			return
 		}
 		c.log.Warn("auto-standby standby attempt failed", "instance_id", id, "instance_name", instanceName, "error", err)
-		if state := c.states[id]; state != nil {
-			state.standbyRequested = false
-			// Inbound activity that arrived during the attempt owns the state
-			// now; the reconcile/destroy flow restarts the countdown once the
-			// connections drain.
-			if len(state.activeInbound) > 0 {
-				return
-			}
-			idleSince := c.now().UTC()
-			state.idleSince = &idleSince
-			c.armTimerLocked(id, state, idleSince)
-			if persistErr := c.persistRuntime(ctx, id, &Runtime{
-				IdleSince:             cloneTimePtr(state.idleSince),
-				LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
-			}); persistErr != nil {
-				c.recordControllerError("persist_runtime")
-				c.log.Warn("auto-standby failed to persist runtime after standby failure", "instance_id", id, "error", persistErr)
-			}
+		state := c.states[id]
+		if state == nil {
+			c.mu.Unlock()
+			return
 		}
+		state.standbyRequested = false
+		// Inbound activity that arrived during the attempt owns the state
+		// now; the reconcile/destroy flow restarts the countdown once the
+		// connections drain.
+		if len(state.activeInbound) > 0 {
+			c.mu.Unlock()
+			return
+		}
+		idleSince := c.now().UTC()
+		state.idleSince = &idleSince
+		c.armTimerLocked(id, state, idleSince)
+		persistence := c.stageRuntimePersistenceLocked(id, state, &Runtime{
+			IdleSince:             cloneTimePtr(state.idleSince),
+			LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
+		}, true, "recover from standby failure")
+		c.mu.Unlock()
+		_ = c.persistRuntime(ctx, persistence)
 		return
 	}
 
@@ -935,14 +959,14 @@ func (c *Controller) executeStandby(ctx context.Context, id string, instanceName
 	c.log.Info("instance entered standby due to inbound inactivity", "instance_id", id, "instance_name", instanceName, "idle_timeout", idleTimeout)
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	if state := c.states[id]; state != nil {
+	state = c.states[id]
+	var persistence runtimePersistence
+	if state != nil {
 		c.clearStateLocked(state)
-		if err := c.persistRuntime(ctx, id, nil); err != nil {
-			c.recordControllerError("persist_runtime")
-			c.log.Warn("auto-standby failed to clear runtime after standby", "instance_id", id, "error", err)
-		}
+		persistence = c.stageRuntimePersistenceLocked(id, state, nil, true, "clear after standby")
 	}
+	c.mu.Unlock()
+	_ = c.persistRuntime(ctx, persistence)
 }
 
 func (c *Controller) handleActiveReconcile(ctx context.Context, id string) {
@@ -962,10 +986,9 @@ func (c *Controller) handleActiveReconcile(ctx context.Context, id string) {
 	now := c.now().UTC()
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	state := c.states[id]
 	if state == nil || state.compiledPolicy == nil {
+		c.mu.Unlock()
 		return
 	}
 
@@ -976,6 +999,7 @@ func (c *Controller) handleActiveReconcile(ctx context.Context, id string) {
 		if len(state.activeInbound) > 0 {
 			c.armReconcileLocked(id, state)
 		}
+		c.mu.Unlock()
 		return
 	}
 
@@ -983,6 +1007,7 @@ func (c *Controller) handleActiveReconcile(ctx context.Context, id string) {
 	if len(activeSet) > 0 {
 		state.standbyRequested = false
 		c.armReconcileLocked(id, state)
+		c.mu.Unlock()
 		return
 	}
 
@@ -990,14 +1015,13 @@ func (c *Controller) handleActiveReconcile(ctx context.Context, id string) {
 	state.standbyRequested = false
 	c.cancelReconcileLocked(state)
 	c.armTimerLocked(id, state, now)
-	if err := c.persistRuntime(ctx, id, &Runtime{
+	persistence := c.stageRuntimePersistenceLocked(id, state, &Runtime{
 		IdleSince:             cloneTimePtr(state.idleSince),
 		LastInboundActivityAt: cloneTimePtr(state.lastInboundAt),
-	}); err != nil {
-		c.recordControllerError("persist_runtime")
-		c.log.Warn("auto-standby failed to persist runtime after active connection reconcile drained", "instance_id", id, "error", err)
-	}
+	}, true, "start idle countdown after reconcile")
 	c.log.Info("auto-standby idle countdown started after active connection reconcile", "instance_id", id, "idle_timeout", state.idleTimeout)
+	c.mu.Unlock()
+	_ = c.persistRuntime(ctx, persistence)
 }
 
 func (c *Controller) reconnectStream(ctx context.Context) {
@@ -1129,8 +1153,40 @@ func (c *Controller) stopAllTimers() {
 	}
 }
 
-func (c *Controller) persistRuntime(ctx context.Context, id string, runtime *Runtime) error {
-	return c.store.SetRuntime(ctx, id, runtime)
+func (c *Controller) stageRuntimePersistenceLocked(id string, state *controllerState, runtime *Runtime, bestEffort bool, operation string) runtimePersistence {
+	state.runtimeRevision++
+	return runtimePersistence{
+		id:         id,
+		state:      state,
+		revision:   state.runtimeRevision,
+		runtime:    runtime,
+		bestEffort: bestEffort,
+		operation:  operation,
+	}
+}
+
+func (c *Controller) persistRuntime(ctx context.Context, persistence runtimePersistence) error {
+	if persistence.state == nil {
+		return nil
+	}
+
+	persistence.state.runtimeMu.Lock()
+	defer persistence.state.runtimeMu.Unlock()
+
+	c.mu.RLock()
+	current := c.states[persistence.id] == persistence.state && persistence.state.runtimeRevision == persistence.revision
+	c.mu.RUnlock()
+	if !current {
+		return nil
+	}
+
+	err := c.store.SetRuntime(ctx, persistence.id, persistence.runtime)
+	if err != nil && persistence.bestEffort {
+		c.recordControllerError("persist_runtime")
+		c.log.Warn("auto-standby failed to persist runtime", "instance_id", persistence.id, "operation", persistence.operation, "error", err)
+		return nil
+	}
+	return err
 }
 
 func (c *Controller) setObserverConnected(connected bool) {

--- a/lib/autostandby/controller.go
+++ b/lib/autostandby/controller.go
@@ -150,6 +150,8 @@ type Controller struct {
 	standbySlots         chan struct{}
 	standbyWG            sync.WaitGroup
 
+	// mu guards in-memory state only and must never be held across metadata
+	// or conntrack I/O; HoldStandby latency depends on it.
 	mu                sync.RWMutex
 	states            map[string]*controllerState
 	standbyInFlight   int
@@ -448,6 +450,7 @@ func (c *Controller) Describe(inst Instance) StatusSnapshot {
 // a standby operation is executing, and is a no-op for instances that cannot
 // auto-standby at all (unconfigured, disabled, or ineligible).
 func (c *Controller) HoldStandby(_ context.Context, inst Instance) (StatusSnapshot, error) {
+	defer c.recordHoldDuration(time.Now())
 	now := c.now().UTC()
 
 	c.mu.Lock()
@@ -586,6 +589,12 @@ func (c *Controller) handleInstanceEvent(ctx context.Context, event InstanceEven
 
 func (c *Controller) refreshInstanceLocked(inst Instance, conns []Connection, now time.Time) (runtimePersistence, error) {
 	state := c.ensureStateLocked(inst.ID)
+	// A refresh built from a snapshot taken before an in-flight standby
+	// completes would re-arm the countdown and supersede the standby's runtime
+	// clear; the standby worker owns the state until it finishes.
+	if state.standbyExecuting {
+		return runtimePersistence{}, nil
+	}
 	state.instance = cloneInstance(inst)
 
 	if !eligible(inst) {

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -1126,6 +1126,49 @@ func idleTestInstance(id, ip string, idleSince time.Time) Instance {
 	}
 }
 
+func TestRefreshDuringExecutingStandbyDoesNotRearm(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	now := idleSince.Add(time.Minute)
+	inst := idleTestInstance("inst-refresh-during-standby", "192.168.100.165", idleSince)
+	store := newFakeInstanceStore([]Instance{inst})
+	store.standbyStarted = make(chan string, 1)
+	store.standbyRelease = make(chan struct{})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), inst.ID)
+	require.Equal(t, inst.ID, <-store.standbyStarted)
+
+	// A resync snapshot taken before the standby completes still carries the
+	// old idle runtime; it must not re-arm the countdown or persist it.
+	stale := cloneInstance(inst)
+	require.NoError(t, controller.seedInstanceState(context.Background(), stale, nil, now))
+
+	controller.mu.RLock()
+	state := controller.states[inst.ID]
+	require.NotNil(t, state)
+	assert.True(t, state.standbyExecuting)
+	assert.Nil(t, state.nextStandbyAt)
+	controller.mu.RUnlock()
+
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
+
+	controller.mu.RLock()
+	state = controller.states[inst.ID]
+	require.NotNil(t, state)
+	assert.Nil(t, state.idleSince)
+	assert.Nil(t, state.nextStandbyAt)
+	controller.mu.RUnlock()
+	runtime, ok := store.persistedRuntime[inst.ID]
+	require.True(t, ok)
+	assert.Nil(t, runtime)
+}
+
 func TestStandbyExecutionBoundedByMaxConcurrent(t *testing.T) {
 	t.Parallel()
 
@@ -1545,6 +1588,41 @@ func TestHoldStandbyDoesNotWaitForRuntimePersistence(t *testing.T) {
 
 	close(persistenceRelease)
 	require.NoError(t, <-resyncDone)
+}
+
+func TestHoldStandbyFastWhileAnotherInstanceStandbyBlocked(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	now := idleSince.Add(time.Minute)
+	blocked := idleTestInstance("inst-blocked-standby", "192.168.100.166", idleSince)
+	other := idleTestInstance("inst-held", "192.168.100.167", idleSince)
+	store := newFakeInstanceStore([]Instance{blocked, other})
+	store.standbyStarted = make(chan string, 1)
+	store.standbyRelease = make(chan struct{})
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), blocked.ID)
+	require.Equal(t, blocked.ID, <-store.standbyStarted)
+
+	holdDone := make(chan error, 1)
+	go func() {
+		_, err := controller.HoldStandby(context.Background(), other)
+		holdDone <- err
+	}()
+	select {
+	case err := <-holdDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		close(store.standbyRelease)
+		require.FailNow(t, "hold blocked behind another instance's standby")
+	}
+
+	close(store.standbyRelease)
+	controller.standbyWG.Wait()
 }
 
 func TestHoldStandbyExtendsArmedCountdown(t *testing.T) {

--- a/lib/autostandby/controller_test.go
+++ b/lib/autostandby/controller_test.go
@@ -22,6 +22,7 @@ type fakeInstanceStore struct {
 	standbyErr       error
 	listErr          error
 	setRuntimeErr    error
+	setRuntimeHook   func(string, *Runtime)
 	standbyStarted   chan string
 	standbyRelease   chan struct{}
 }
@@ -67,6 +68,9 @@ func (f *fakeInstanceStore) standbyCalls() []string {
 }
 
 func (f *fakeInstanceStore) SetRuntime(_ context.Context, id string, runtime *Runtime) error {
+	if f.setRuntimeHook != nil {
+		f.setRuntimeHook(id, cloneRuntime(runtime))
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.setRuntimeErr != nil {
@@ -626,6 +630,143 @@ func TestHandleStandbyTimerFailureRearmsIdleCountdown(t *testing.T) {
 	require.NotNil(t, state.nextStandbyAt)
 	assert.Equal(t, now.Add(time.Minute), *state.nextStandbyAt)
 	controller.mu.RUnlock()
+}
+
+func TestStandbyFailurePersistenceDoesNotOverwriteNewActivity(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	now := idleSince.Add(time.Minute)
+	inst := idleTestInstance("inst-failure-activity", "192.168.100.162", idleSince)
+	store := newFakeInstanceStore([]Instance{inst})
+	store.standbyErr = errors.New("standby failed")
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	persistenceStarted := make(chan struct{}, 1)
+	persistenceRelease := make(chan struct{})
+	store.setRuntimeHook = func(_ string, runtime *Runtime) {
+		if runtime != nil && runtime.IdleSince != nil && runtime.IdleSince.Equal(now) {
+			persistenceStarted <- struct{}{}
+			<-persistenceRelease
+		}
+	}
+
+	controller.handleStandbyTimer(context.Background(), inst.ID)
+	require.Eventually(t, func() bool {
+		select {
+		case <-persistenceStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	activityAt := now.Add(time.Second)
+	activityDone := make(chan struct{})
+	go func() {
+		controller.handleConnectionEvent(context.Background(), ConnectionEvent{
+			Type:       ConnectionEventNew,
+			ObservedAt: activityAt,
+			Connection: Connection{
+				OriginalSourceIP:        mustAddr("1.2.3.4"),
+				OriginalSourcePort:      50162,
+				OriginalDestinationIP:   mustAddr(inst.IP),
+				OriginalDestinationPort: 8080,
+				TCPState:                TCPStateEstablished,
+			},
+		})
+		close(activityDone)
+	}()
+
+	require.Eventually(t, func() bool {
+		controller.mu.RLock()
+		defer controller.mu.RUnlock()
+		state := controller.states[inst.ID]
+		return state != nil && state.lastInboundAt != nil && state.lastInboundAt.Equal(activityAt)
+	}, time.Second, time.Millisecond)
+
+	close(persistenceRelease)
+	controller.standbyWG.Wait()
+	select {
+	case <-activityDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "activity remained blocked after standby failure persistence completed")
+	}
+
+	runtime := store.persistedRuntime[inst.ID]
+	require.NotNil(t, runtime)
+	assert.Nil(t, runtime.IdleSince)
+	require.NotNil(t, runtime.LastInboundActivityAt)
+	assert.Equal(t, activityAt, *runtime.LastInboundActivityAt)
+}
+
+func TestRefreshDoesNotRollBackNewerIdleSince(t *testing.T) {
+	t.Parallel()
+
+	idleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	now := idleSince.Add(time.Minute)
+	inst := idleTestInstance("inst-stale-refresh", "192.168.100.163", idleSince)
+	store := newFakeInstanceStore([]Instance{inst})
+	store.standbyErr = errors.New("standby failed")
+	controller := NewController(store, &fakeConnectionSource{}, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	controller.handleStandbyTimer(context.Background(), inst.ID)
+	controller.standbyWG.Wait()
+
+	stale := cloneInstance(inst)
+	require.NoError(t, controller.seedInstanceState(context.Background(), stale, nil, now))
+
+	controller.mu.RLock()
+	state := controller.states[inst.ID]
+	require.NotNil(t, state)
+	require.NotNil(t, state.idleSince)
+	assert.Equal(t, now, *state.idleSince)
+	require.NotNil(t, state.nextStandbyAt)
+	assert.Equal(t, now.Add(time.Minute), *state.nextStandbyAt)
+	controller.mu.RUnlock()
+	require.NotNil(t, store.persistedRuntime[inst.ID])
+	assert.Equal(t, now, *store.persistedRuntime[inst.ID].IdleSince)
+}
+
+func TestRefreshDoesNotRestoreIdleBeforeRecentActivity(t *testing.T) {
+	t.Parallel()
+
+	oldIdleSince := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	activityAt := oldIdleSince.Add(time.Minute)
+	refreshAt := activityAt.Add(time.Second)
+	inst := idleTestInstance("inst-stale-active-refresh", "192.168.100.164", oldIdleSince)
+	connection := Connection{
+		OriginalSourceIP:        mustAddr("1.2.3.4"),
+		OriginalSourcePort:      50164,
+		OriginalDestinationIP:   mustAddr(inst.IP),
+		OriginalDestinationPort: 8080,
+		TCPState:                TCPStateEstablished,
+	}
+	store := newFakeInstanceStore([]Instance{inst})
+	controller := NewController(store, &fakeConnectionSource{connections: []Connection{connection}}, ControllerOptions{
+		Now: func() time.Time { return activityAt },
+	})
+	require.NoError(t, controller.startupResync(context.Background()))
+
+	stale := cloneInstance(inst)
+	require.NoError(t, controller.seedInstanceState(context.Background(), stale, nil, refreshAt))
+
+	controller.mu.RLock()
+	state := controller.states[inst.ID]
+	require.NotNil(t, state)
+	require.NotNil(t, state.idleSince)
+	assert.Equal(t, refreshAt, *state.idleSince)
+	require.NotNil(t, state.nextStandbyAt)
+	assert.Equal(t, refreshAt.Add(time.Minute), *state.nextStandbyAt)
+	controller.mu.RUnlock()
+	require.NotNil(t, store.persistedRuntime[inst.ID])
+	assert.Equal(t, refreshAt, *store.persistedRuntime[inst.ID].IdleSince)
 }
 
 func TestHandleStandbyTimerSkipsStandbyWhenConntrackReportsConnection(t *testing.T) {
@@ -1346,6 +1487,64 @@ func TestRefreshPersistFailureStillArmsIdleTimer(t *testing.T) {
 	assert.NotNil(t, state.nextStandbyAt)
 	assert.NotNil(t, state.idleSince)
 	controller.mu.RUnlock()
+}
+
+func TestHoldStandbyDoesNotWaitForRuntimePersistence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 6, 10, 55, 0, 0, time.UTC)
+	inst := Instance{
+		ID:             "inst-hold-during-persist",
+		Name:           "inst-hold-during-persist",
+		State:          StateRunning,
+		NetworkEnabled: true,
+		IP:             "192.168.100.100",
+		AutoStandby:    &Policy{Enabled: true, IdleTimeout: "1m"},
+	}
+	conn := Connection{
+		OriginalSourceIP:        mustAddr("1.2.3.4"),
+		OriginalSourcePort:      50010,
+		OriginalDestinationIP:   mustAddr(inst.IP),
+		OriginalDestinationPort: 8080,
+		TCPState:                TCPStateEstablished,
+	}
+	store := newFakeInstanceStore([]Instance{inst})
+	persistenceStarted := make(chan struct{}, 1)
+	persistenceRelease := make(chan struct{})
+	store.setRuntimeHook = func(_ string, _ *Runtime) {
+		persistenceStarted <- struct{}{}
+		<-persistenceRelease
+	}
+	controller := NewController(store, &fakeConnectionSource{connections: []Connection{conn}}, ControllerOptions{
+		Now: func() time.Time { return now },
+	})
+
+	resyncDone := make(chan error, 1)
+	go func() {
+		resyncDone <- controller.startupResync(context.Background())
+	}()
+	select {
+	case <-persistenceStarted:
+	case <-time.After(time.Second):
+		close(persistenceRelease)
+		require.FailNow(t, "runtime persistence did not start")
+	}
+
+	holdDone := make(chan error, 1)
+	go func() {
+		_, err := controller.HoldStandby(context.Background(), inst)
+		holdDone <- err
+	}()
+	select {
+	case err := <-holdDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		close(persistenceRelease)
+		require.FailNow(t, "hold waited for runtime persistence")
+	}
+
+	close(persistenceRelease)
+	require.NoError(t, <-resyncDone)
 }
 
 func TestHoldStandbyExtendsArmedCountdown(t *testing.T) {

--- a/lib/autostandby/metrics.go
+++ b/lib/autostandby/metrics.go
@@ -14,6 +14,7 @@ type Metrics struct {
 	conntrackEventsTotal   metric.Int64Counter
 	startupResyncDuration  metric.Float64Histogram
 	standbyAttemptsTotal   metric.Int64Counter
+	holdDuration           metric.Float64Histogram
 	controllerErrorsTotal  metric.Int64Counter
 	trackedInstancesGauge  metric.Int64ObservableGauge
 	activeConnectionsGauge metric.Int64ObservableGauge
@@ -46,6 +47,15 @@ func newMetrics(meter metric.Meter, tracer trace.Tracer, controller *Controller)
 	standbyAttemptsTotal, err := meter.Int64Counter(
 		"hypeman_auto_standby_standby_attempts_total",
 		metric.WithDescription("Total standby attempts issued by the auto-standby controller"),
+	)
+	if err != nil {
+		return &Metrics{tracer: tracer}
+	}
+	holdDuration, err := meter.Float64Histogram(
+		"hypeman_auto_standby_hold_duration_seconds",
+		metric.WithDescription("Time spent placing an auto-standby hold"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(hypotel.CommonDurationHistogramBuckets()...),
 	)
 	if err != nil {
 		return &Metrics{tracer: tracer}
@@ -90,6 +100,7 @@ func newMetrics(meter metric.Meter, tracer trace.Tracer, controller *Controller)
 		conntrackEventsTotal:   conntrackEventsTotal,
 		startupResyncDuration:  startupResyncDuration,
 		standbyAttemptsTotal:   standbyAttemptsTotal,
+		holdDuration:           holdDuration,
 		controllerErrorsTotal:  controllerErrorsTotal,
 		trackedInstancesGauge:  trackedInstancesGauge,
 		activeConnectionsGauge: activeConnectionsGauge,
@@ -142,6 +153,13 @@ func (c *Controller) recordStandbyAttempt(status string) {
 	c.metrics.standbyAttemptsTotal.Add(context.Background(), 1, metric.WithAttributes(
 		attribute.String("status", status),
 	))
+}
+
+func (c *Controller) recordHoldDuration(start time.Time) {
+	if c.metrics == nil || c.metrics.holdDuration == nil {
+		return
+	}
+	c.metrics.holdDuration.Record(context.Background(), time.Since(start).Seconds())
 }
 
 func (c *Controller) recordControllerError(operation string) {


### PR DESCRIPTION
Purpose is to speed up auto standby hold requests, which have some higher p90 because of being blocked by other instances' metadata writes.

## Summary
- order auto-standby runtime writes per instance and skip superseded writes
- release the controller mutex before metadata I/O so holds remain responsive
- prevent stale refresh snapshots from moving the idle countdown backward

## Testing
- `go test -race -count=100 ./lib/autostandby`
- `go test ./lib/providers`
- `go test ./lib/instances -run 'AutoStandby|SetAutoStandbyRuntime'`
- `go test ./cmd/api/api -run AutoStandby`
- `go vet ./lib/autostandby ./lib/providers ./lib/instances ./cmd/api/...`

The full local suite was attempted, but environment-dependent image and VM tests require `mkfs.erofs`, networking privileges, and working image builds. CI covers the complete suite.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and ordering of idle-countdown persistence and refresh during standby—behavior is heavily tested but affects when VMs may enter standby.
> 
> **Overview**
> **Auto-standby** runtime metadata writes are **staged and applied after releasing the controller lock**, so `HoldStandby` and other paths are not blocked by slow `SetRuntime` on other instances. Each instance gets a **revision counter and `runtimeMu`**: superseded writes are dropped before hitting the store, with optional best-effort logging on failure.
> 
> **Refresh/resync** no longer clobber fresher in-memory idle state from stale snapshots (including while **standby is executing**), and inbound activity is merged without rolling `idleSince` backward.
> 
> Observability adds **`hypeman_auto_standby_hold_duration_seconds`**; tests cover hold latency, persistence races, and stale refresh behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c2d86ea03f30b6a4c81decb2f40458536b7d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



