### PR TITLE
Use PyPI trusted publishing

### DIFF
--- a/stainless.yaml
+++ b/stainless.yaml
@@ -34,7 +34,9 @@ targets:
     production_repo: kernel/hypeman-python
     staging_repo: kernel/hypeman-python-staging
     publish:
-      pypi: true
+      pypi:
+        auth_method: oidc
+        release_environment: pypi
       release:
         branch: main
         prerelease: false

--- a/stainless/custom-code/python/2026-08-17T14-04-38-940Z-custom-code.json
+++ b/stainless/custom-code/python/2026-08-17T14-04-38-940Z-custom-code.json
@@ -1,6 +1,6 @@
 {
-  "base": "192444585c150d0f39dbb7038bb67176c44aef2c",
-  "integrated": "caf71961faafb465db0d8f7c00de1d40e56ba731",
+  "base": "ef334cf435298ff75e9a59a5e453eb0bf9647e11",
+  "integrated": "55f973e52ff962aeeedebed77c4d3d0f896e592b",
   "filename": "2026-08-17T14-04-38-940Z-custom-code.json",
   "branch": "main"
 }


### PR DESCRIPTION
## summary

- configure the generated Python SDK to publish to PyPI with GitHub OIDC through the `pypi` environment
- seal the trusted-publishing workflow with the pinned official PyPI action
- align Release Doctor with the existing GitHub App release credentials and remove the obsolete token-based publishing helper

## tests

- `stlc build --branch stlc/preview/pr-422 --trunk-branch main --no-lint --push --targets python`
- `stlc exec --targets python -- ./scripts/bootstrap`
- `stlc lint --targets python`
- `stlc test --targets python` (507 passed, 1280 skipped; Pydantic 1: 494 passed, 1293 skipped)
- `actionlint .github/workflows/publish-pypi.yml .github/workflows/release-doctor.yml`
- `rye build --clean`
- release-environment script checks for missing, partial, and complete GitHub App credentials
