### PR TITLE
Fix Python SDK copy metadata handling

### DIFF
--- a/stainless/custom-code/python/2026-08-17T14-04-38-940Z-custom-code.json
+++ b/stainless/custom-code/python/2026-08-17T14-04-38-940Z-custom-code.json
@@ -1,6 +1,6 @@
 {
-  "base": "ef334cf435298ff75e9a59a5e453eb0bf9647e11",
-  "integrated": "55f973e52ff962aeeedebed77c4d3d0f896e592b",
+  "base": "72c539aaa62c2866981403cc86b3850b21514e61",
+  "integrated": "b885bb2d68b62c7cbf10232bb95c2b2b48ce5f37",
   "filename": "2026-08-17T14-04-38-940Z-custom-code.json",
   "branch": "main"
 }


### PR DESCRIPTION
## review the generated code

This source PR intentionally contains only an `stlc` seal-tracking update. The reviewable Python SDK code is generated in `kernel/hypeman-python-staging`:

**[View the generated SDK diff](https://github.com/kernel/hypeman-python-staging/compare/main...stlc/preview/pr-424)**

## generated SDK changes

- preserve root UID/GID values when creating archive upload requests
- defer downloaded directory metadata until all child entries are written
- add regression coverage for both cases

## validation

- `./scripts/bootstrap`
- `./scripts/lint`
- `./scripts/test` (509 passed, 1280 skipped; Pydantic 1: 496 passed, 1293 skipped)
- `pytest -n 0 -q tests/lib/test_websocket_lib.py` (35 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> In-repo change is seal metadata only; functional risk is in the generated SDK preview, described as copy/metadata handling with tests.
> 
> **Overview**
> This PR only **updates the Python `stlc` seal** in `2026-08-17T14-04-38-940Z-custom-code.json`, pointing `base` and `integrated` at new commits so the generator tracks the latest integrated custom-code revision.
> 
> The **reviewable SDK work** lives in the generated staging repo (per the PR description): fixes for **archive upload** copy metadata—keeping root **UID/GID** on upload requests and **deferring directory metadata** until child entries are finished—plus regression tests. None of that Python source appears in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49fbcf9c46758f404ef87d0cd28f385a279a5df0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->