### PR TITLE
Harden shared CI against transient failures

### DIFF
--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -238,7 +238,15 @@ jobs:
             --targets all \
             "${commit_args[@]}"
           stlc exec --targets "$SDK_TARGETS" -- ./scripts/bootstrap
-          stlc lint --targets "$SDK_TARGETS"
+          for attempt in 1 2 3; do
+            if stlc lint --targets "$SDK_TARGETS"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 5
+          done
           stlc test --targets "$SDK_TARGETS"
           stlc exec --targets "$SDK_TARGETS" -- sh -c \
             'status=$(git status --porcelain --untracked-files=all) && [ -z "$status" ] || { printf "%s\n" "$status" >&2; exit 1; }'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,8 +111,8 @@ jobs:
       - name: Stage Windows test fixtures
         run: |
           fixture_dir=/mnt/data/ci-fixtures/windows
-          image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit)
-          base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit)
+          image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit 2>/dev/null || true)
+          base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit 2>/dev/null || true)
           sudo mkdir -p "$fixture_dir" /ci/windows
           if test -n "$image_source"; then
             sudo cp --reflink=auto --sparse=always "$image_source" "$fixture_dir/image-agent.qcow2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
           sudo mount -t ntfs-3g "$partition" "$work/mount"
           target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
           test -n "$target"
-          sudo sh -c 'cat "$1" > "$2"' sh "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
+          sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
           sudo sync "$target"
           sudo umount "$work/mount"
           sudo qemu-nbd --disconnect /dev/nbd15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,10 +111,10 @@ jobs:
       - name: Stage Windows test fixtures
         run: |
           fixture_dir=/mnt/data/ci-fixtures/windows
-          image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit 2>/dev/null || true)
-          base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit 2>/dev/null || true)
+          image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit)
+          base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit)
           sudo mkdir -p "$fixture_dir" /ci/windows
-          if test -n "$image_source"; then
+          if ! test -r "$fixture_dir/image-agent.qcow2" && test -n "$image_source"; then
             sudo cp --reflink=auto --sparse=always "$image_source" "$fixture_dir/image-agent.qcow2"
             sudo chmod 0444 "$fixture_dir/image-agent.qcow2"
           fi
@@ -136,7 +136,7 @@ jobs:
           set -euo pipefail
           work=$(mktemp -d)
           trap 'rm -rf "$work"' EXIT
-          gh api repos/kernel/hypeman/tarball/088612571b2aa2b6b07c70a63fc23c2542abdc99 > "$work/source.tar.gz"
+          gh api repos/kernel/hypeman/tarball/hypeship/windows-guest-control > "$work/source.tar.gz"
           mkdir "$work/source"
           tar -xzf "$work/source.tar.gz" --strip-components=1 -C "$work/source"
           make -C "$work/source" build-windows-guest-agent
@@ -164,10 +164,9 @@ jobs:
           test -n "$partition"
           mkdir "$work/mount"
           sudo mount -t ntfs-3g "$partition" "$work/mount"
-          target="$work/mount/Windows/System32/hypeman-guest-agent.exe"
-          test -f "$target"
-          sudo cp "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
-          sudo chmod 0755 "$target"
+          target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
+          test -n "$target"
+          sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
           sudo sync "$target"
           sudo umount "$work/mount"
           sudo qemu-nbd --disconnect /dev/nbd15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,9 +140,6 @@ jobs:
           mkdir "$work/source"
           tar -xzf "$work/source.tar.gz" --strip-components=1 -C "$work/source"
           make -C "$work/source" build-windows-guest-agent
-          if ! command -v ntfs-3g >/dev/null; then
-            timeout 300s sudo apt-get install -y ntfs-3g
-          fi
 
           exec 9>/run/lock/hypeman-windows-fixture.lock
           flock 9
@@ -163,7 +160,7 @@ jobs:
           done
           test -n "$partition"
           mkdir "$work/mount"
-          sudo mount -t ntfs-3g "$partition" "$work/mount"
+          sudo mount -t ntfs3 "$partition" "$work/mount"
           target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
           test -n "$target"
           sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,10 +164,9 @@ jobs:
           test -n "$partition"
           mkdir "$work/mount"
           sudo mount -t ntfs-3g "$partition" "$work/mount"
-          target="$work/mount/Windows/System32/hypeman-guest-agent.exe"
-          test -f "$target"
-          sudo cp "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
-          sudo chmod 0755 "$target"
+          target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
+          test -n "$target"
+          sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
           sudo sync "$target"
           sudo umount "$work/mount"
           sudo qemu-nbd --disconnect /dev/nbd15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,7 @@ jobs:
           set -euo pipefail
           work=$(mktemp -d)
           trap 'rm -rf "$work"' EXIT
-          gh api repos/kernel/hypeman/tarball/088612571b2aa2b6b07c70a63fc23c2542abdc99 > "$work/source.tar.gz"
+          gh api repos/kernel/hypeman/tarball/hypeship/windows-guest-control > "$work/source.tar.gz"
           mkdir "$work/source"
           tar -xzf "$work/source.tar.gz" --strip-components=1 -C "$work/source"
           make -C "$work/source" build-windows-guest-agent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
           image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit)
           base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit)
           sudo mkdir -p "$fixture_dir" /ci/windows
-          if ! test -r "$fixture_dir/image-agent.qcow2" && test -n "$image_source"; then
+          if test -n "$image_source"; then
             sudo cp --reflink=auto --sparse=always "$image_source" "$fixture_dir/image-agent.qcow2"
             sudo chmod 0444 "$fixture_dir/image-agent.qcow2"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,46 +129,6 @@ jobs:
             sudo ln -sfn "$fixture_dir/base.raw" /ci/windows/base.raw
           fi
 
-      - name: Refresh Windows guest agent fixture
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          work=$(mktemp -d)
-          trap 'rm -rf "$work"' EXIT
-          gh api repos/kernel/hypeman/tarball/hypeship/windows-guest-control > "$work/source.tar.gz"
-          mkdir "$work/source"
-          tar -xzf "$work/source.tar.gz" --strip-components=1 -C "$work/source"
-          make -C "$work/source" build-windows-guest-agent
-
-          exec 9>/run/lock/hypeman-windows-fixture.lock
-          flock 9
-          sudo modprobe nbd max_part=16
-          sudo qemu-nbd --disconnect /dev/nbd15 >/dev/null 2>&1 || true
-          sudo chmod u+w /mnt/data/ci-fixtures/windows/image-agent.qcow2
-          sudo qemu-nbd --connect=/dev/nbd15 /mnt/data/ci-fixtures/windows/image-agent.qcow2
-          cleanup_nbd() {
-            if mountpoint -q "$work/mount"; then sudo umount "$work/mount"; fi
-            sudo qemu-nbd --disconnect /dev/nbd15 >/dev/null 2>&1 || true
-          }
-          trap 'cleanup_nbd; rm -rf "$work"' EXIT
-          partition=
-          for _ in $(seq 1 100); do
-            partition=$(lsblk -lnpo NAME,FSTYPE /dev/nbd15 | awk '$2 == "ntfs" { print $1; exit }')
-            test -n "$partition" && break
-            sleep 0.1
-          done
-          test -n "$partition"
-          mkdir "$work/mount"
-          sudo mount -t ntfs3 "$partition" "$work/mount"
-          target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
-          test -n "$target"
-          sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
-          sudo sync "$target"
-          sudo umount "$work/mount"
-          sudo qemu-nbd --disconnect /dev/nbd15
-          trap 'rm -rf "$work"' EXIT
-
       # Slash-command runs are maintainer-approved and need authenticated pulls
       # for images that are not covered by the prewarm cache.
       - name: Login to Docker Hub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,46 @@ jobs:
             sudo ln -sfn "$fixture_dir/base.raw" /ci/windows/base.raw
           fi
 
+      - name: Refresh Windows guest agent fixture
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          work=$(mktemp -d)
+          trap 'rm -rf "$work"' EXIT
+          gh api repos/kernel/hypeman/tarball/hypeship/windows-guest-control > "$work/source.tar.gz"
+          mkdir "$work/source"
+          tar -xzf "$work/source.tar.gz" --strip-components=1 -C "$work/source"
+          make -C "$work/source" build-windows-guest-agent
+
+          exec 9>/run/lock/hypeman-windows-fixture.lock
+          flock 9
+          sudo modprobe nbd max_part=16
+          sudo qemu-nbd --disconnect /dev/nbd15 >/dev/null 2>&1 || true
+          sudo chmod u+w /mnt/data/ci-fixtures/windows/image-agent.qcow2
+          sudo qemu-nbd --connect=/dev/nbd15 /mnt/data/ci-fixtures/windows/image-agent.qcow2
+          cleanup_nbd() {
+            if mountpoint -q "$work/mount"; then sudo umount "$work/mount"; fi
+            sudo qemu-nbd --disconnect /dev/nbd15 >/dev/null 2>&1 || true
+          }
+          trap 'cleanup_nbd; rm -rf "$work"' EXIT
+          partition=
+          for _ in $(seq 1 100); do
+            partition=$(lsblk -lnpo NAME,FSTYPE /dev/nbd15 | awk '$2 == "ntfs" { print $1; exit }')
+            test -n "$partition" && break
+            sleep 0.1
+          done
+          test -n "$partition"
+          mkdir "$work/mount"
+          sudo mount -t ntfs3 "$partition" "$work/mount"
+          target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
+          test -n "$target"
+          sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
+          sudo sync "$target"
+          sudo umount "$work/mount"
+          sudo qemu-nbd --disconnect /dev/nbd15
+          trap 'rm -rf "$work"' EXIT
+
       # Slash-command runs are maintainer-approved and need authenticated pulls
       # for images that are not covered by the prewarm cache.
       - name: Login to Docker Hub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,7 @@ jobs:
           set -euo pipefail
           work=$(mktemp -d)
           trap 'rm -rf "$work"' EXIT
-          gh api repos/kernel/hypeman/tarball/hypeship/windows-guest-control > "$work/source.tar.gz"
+          gh api repos/kernel/hypeman/tarball/088612571b2aa2b6b07c70a63fc23c2542abdc99 > "$work/source.tar.gz"
           mkdir "$work/source"
           tar -xzf "$work/source.tar.gz" --strip-components=1 -C "$work/source"
           make -C "$work/source" build-windows-guest-agent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,8 +111,8 @@ jobs:
       - name: Stage Windows test fixtures
         run: |
           fixture_dir=/mnt/data/ci-fixtures/windows
-          image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit 2>/dev/null || true)
-          base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit 2>/dev/null || true)
+          image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit)
+          base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit)
           sudo mkdir -p "$fixture_dir" /ci/windows
           if test -n "$image_source"; then
             sudo cp --reflink=auto --sparse=always "$image_source" "$fixture_dir/image-agent.qcow2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,14 @@ jobs:
       - name: Stage Windows test fixture
         run: |
           source=/mnt/data/ci-fixtures/windows/image-agent.qcow2
+          if ! test -r "$source"; then
+            existing=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit)
+            if test -n "$existing"; then
+              sudo mkdir -p "$(dirname "$source")"
+              sudo cp --reflink=auto --sparse=always "$existing" "$source"
+              sudo chmod 0444 "$source"
+            fi
+          fi
           if test -r "$source"; then
             sudo mkdir -p /ci/windows
             sudo ln -sfn "$source" /ci/windows/image-agent.qcow2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,9 @@ jobs:
           mkdir "$work/source"
           tar -xzf "$work/source.tar.gz" --strip-components=1 -C "$work/source"
           make -C "$work/source" build-windows-guest-agent
+          if ! command -v ntfs-3g >/dev/null; then
+            timeout 300s sudo apt-get install -y ntfs-3g
+          fi
 
           exec 9>/run/lock/hypeman-windows-fixture.lock
           flock 9
@@ -160,7 +163,7 @@ jobs:
           done
           test -n "$partition"
           mkdir "$work/mount"
-          sudo mount -t ntfs3 "$partition" "$work/mount"
+          sudo mount -t ntfs-3g "$partition" "$work/mount"
           target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
           test -n "$target"
           sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,14 @@ jobs:
             sudo env "PATH=$TEST_PATH" bash -lc "command -v '$bin'"
           done
 
+      - name: Stage Windows test fixture
+        run: |
+          source=/mnt/data/ci-fixtures/windows/image-agent.qcow2
+          if test -r "$source"; then
+            sudo mkdir -p /ci/windows
+            sudo ln -sfn "$source" /ci/windows/image-agent.qcow2
+          fi
+
       # Slash-command runs are maintainer-approved and need authenticated pulls
       # for images that are not covered by the prewarm cache.
       - name: Login to Docker Hub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,20 +97,25 @@ jobs:
             sudo env "PATH=$TEST_PATH" bash -lc "command -v '$bin'"
           done
 
-      - name: Stage Windows test fixture
+      - name: Stage Windows test fixtures
         run: |
-          source=/mnt/data/ci-fixtures/windows/image-agent.qcow2
-          if ! test -r "$source"; then
-            existing=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit)
-            if test -n "$existing"; then
-              sudo mkdir -p "$(dirname "$source")"
-              sudo cp --reflink=auto --sparse=always "$existing" "$source"
-              sudo chmod 0444 "$source"
-            fi
+          fixture_dir=/mnt/data/ci-fixtures/windows
+          image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit)
+          base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit)
+          sudo mkdir -p "$fixture_dir" /ci/windows
+          if ! test -r "$fixture_dir/image-agent.qcow2" && test -n "$image_source"; then
+            sudo cp --reflink=auto --sparse=always "$image_source" "$fixture_dir/image-agent.qcow2"
+            sudo chmod 0444 "$fixture_dir/image-agent.qcow2"
           fi
-          if test -r "$source"; then
-            sudo mkdir -p /ci/windows
-            sudo ln -sfn "$source" /ci/windows/image-agent.qcow2
+          if ! test -r "$fixture_dir/base.raw" && test -n "$base_source"; then
+            sudo cp --reflink=auto --sparse=always "$base_source" "$fixture_dir/base.raw"
+            sudo chmod 0444 "$fixture_dir/base.raw"
+          fi
+          if test -r "$fixture_dir/image-agent.qcow2"; then
+            sudo ln -sfn "$fixture_dir/image-agent.qcow2" /ci/windows/image-agent.qcow2
+          fi
+          if test -r "$fixture_dir/base.raw"; then
+            sudo ln -sfn "$fixture_dir/base.raw" /ci/windows/base.raw
           fi
 
       # Slash-command runs are maintainer-approved and need authenticated pulls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,17 @@ jobs:
     runs-on: [self-hosted, linux, x64, kvm]
     steps:
       - uses: actions/checkout@v4
+        id: checkout
+        continue-on-error: true
+        with:
+          clean: false
+          repository: ${{ env.TEST_SOURCE_REPO }}
+          ref: ${{ env.TEST_SOURCE_REF }}
+          persist-credentials: false
+
+      - name: Retry checkout
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
         with:
           clean: false
           repository: ${{ env.TEST_SOURCE_REPO }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
           sudo mount -t ntfs-3g "$partition" "$work/mount"
           target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
           test -n "$target"
-          sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
+          sudo sh -c 'cat "$1" > "$2"' sh "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
           sudo sync "$target"
           sudo umount "$work/mount"
           sudo qemu-nbd --disconnect /dev/nbd15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,9 +164,10 @@ jobs:
           test -n "$partition"
           mkdir "$work/mount"
           sudo mount -t ntfs-3g "$partition" "$work/mount"
-          target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
-          test -n "$target"
-          sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
+          target="$work/mount/Windows/System32/hypeman-guest-agent.exe"
+          test -f "$target"
+          sudo cp "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
+          sudo chmod 0755 "$target"
           sudo sync "$target"
           sudo umount "$work/mount"
           sudo qemu-nbd --disconnect /dev/nbd15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
           image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit)
           base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit)
           sudo mkdir -p "$fixture_dir" /ci/windows
-          if test -n "$image_source"; then
+          if ! test -r "$fixture_dir/image-agent.qcow2" && test -n "$image_source"; then
             sudo cp --reflink=auto --sparse=always "$image_source" "$fixture_dir/image-agent.qcow2"
             sudo chmod 0444 "$fixture_dir/image-agent.qcow2"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,10 +111,10 @@ jobs:
       - name: Stage Windows test fixtures
         run: |
           fixture_dir=/mnt/data/ci-fixtures/windows
-          image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit)
-          base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit)
+          image_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-agent.qcow2' -print -quit 2>/dev/null || true)
+          base_source=$(sudo find /mnt/data/home -path '*/windows-vm-exp/build/*-golden.raw' -print -quit 2>/dev/null || true)
           sudo mkdir -p "$fixture_dir" /ci/windows
-          if ! test -r "$fixture_dir/image-agent.qcow2" && test -n "$image_source"; then
+          if test -n "$image_source"; then
             sudo cp --reflink=auto --sparse=always "$image_source" "$fixture_dir/image-agent.qcow2"
             sudo chmod 0444 "$fixture_dir/image-agent.qcow2"
           fi
@@ -136,7 +136,7 @@ jobs:
           set -euo pipefail
           work=$(mktemp -d)
           trap 'rm -rf "$work"' EXIT
-          gh api repos/kernel/hypeman/tarball/hypeship/windows-guest-control > "$work/source.tar.gz"
+          gh api repos/kernel/hypeman/tarball/088612571b2aa2b6b07c70a63fc23c2542abdc99 > "$work/source.tar.gz"
           mkdir "$work/source"
           tar -xzf "$work/source.tar.gz" --strip-components=1 -C "$work/source"
           make -C "$work/source" build-windows-guest-agent
@@ -164,9 +164,10 @@ jobs:
           test -n "$partition"
           mkdir "$work/mount"
           sudo mount -t ntfs-3g "$partition" "$work/mount"
-          target=$(sudo find "$work/mount" -type f -iname 'hypeman-guest-agent.exe' -print -quit)
-          test -n "$target"
-          sudo install -m 0755 "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
+          target="$work/mount/Windows/System32/hypeman-guest-agent.exe"
+          test -f "$target"
+          sudo cp "$work/source/lib/system/guest_agent/hypeman-guest-agent.exe" "$target"
+          sudo chmod 0755 "$target"
           sudo sync "$target"
           sudo umount "$work/mount"
           sudo qemu-nbd --disconnect /dev/nbd15

--- a/lib/instances/test_network_config_test.go
+++ b/lib/instances/test_network_config_test.go
@@ -161,7 +161,10 @@ func allocateTestNetworkLease(testName string, seq uint32) (*testNetworkLease, e
 			return err
 		}
 
-		bridgeName = fmt.Sprintf("hm%04x%03x", testNetworkRunSeed&0xffff, seq%0xfff)
+		bridgeName, err = testBridgeNameForSubnet(subnet)
+		if err != nil {
+			return err
+		}
 		allocatedSubnet = subnet
 		leases[subnet] = subnetLease{
 			TestName:   testName,
@@ -440,6 +443,34 @@ func pruneStaleLeases(leases map[string]subnetLease, routes []hostRoute) {
 			continue
 		}
 		delete(leases, subnet)
+	}
+}
+
+func testBridgeNameForSubnet(subnet string) (string, error) {
+	ip, _, err := net.ParseCIDR(subnet)
+	if err != nil {
+		return "", fmt.Errorf("parse test subnet %q: %w", subnet, err)
+	}
+	ip = ip.To4()
+	if ip == nil {
+		return "", fmt.Errorf("test subnet %q is not IPv4", subnet)
+	}
+	return fmt.Sprintf("hm%02x%02x", ip[1], ip[2]), nil
+}
+
+func TestBridgeNameForTestSubnet(t *testing.T) {
+	t.Parallel()
+
+	first, err := testBridgeNameForSubnet("10.200.1.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := testBridgeNameForSubnet("10.200.2.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != "hmc801" || second != "hmc802" || first == second {
+		t.Fatalf("unexpected bridge names: %q %q", first, second)
 	}
 }
 


### PR DESCRIPTION
## summary

- retry checkout and SDK lint validation after transient network or dependency-download failures
- derive test bridge names from uniquely leased subnets to prevent cross-process bridge collisions without reducing parallelism
- recover and restage the host-provisioned Windows image and backing fixtures into `/ci` on every test run

## tests

- `go test ./lib/instances -run ^TestBridgeNameForTestSubnet$ -count=1`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only and test-infra changes: retries and fixture copies are low-impact, but renaming Linux test bridges affects isolation of concurrent network tests on shared runners.
> 
> **Overview**
> Hardens shared CI against transient checkout/lint failures, missing Windows VM images, and colliding test network bridges.
> 
> Checkout in `test.yml` now retries once on failure. SDK lint in `stlc-generate.yml` retries up to three times. Each Linux test run restages host-provisioned Windows qcow2/raw fixtures into `/ci/windows` when they are present.
> 
> Test Linux bridges are named from the leased subnet (`hm` + octets) instead of a seed/seq combo, so parallel processes no longer share a bridge name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f33dca0672add4c55ae4f17080baf84b0d692b66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->