### PR TITLE
Repair SDK tracking generation

### DIFF
--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -52,6 +52,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   STAINLESS_WORKSPACE: stainless
@@ -124,16 +125,23 @@ jobs:
             exit 0
           fi
 
-          # Merging the seal-back PR must not trigger another build. The
-          # compare API caps the file list at 300, so a full-length list might
-          # be truncated and can't prove the push was custom-code-only.
+          # Merging the generated seal-back PR must not trigger another build.
+          # Other tracking-only PRs still regenerate every target: they may
+          # update only one target and leave the others' tracking stale.
+          # The compare API caps the file list at 300, so a full-length list
+          # might be truncated and can't prove the push was custom-code-only.
           if [ "$EVENT" = "push" ] && [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
             changed=$(gh api "repos/$REPO/compare/$BEFORE...$AFTER" --jq '.files[].filename')
             count=$(printf '%s\n' "$changed" | wc -l)
             if [ -n "$changed" ] && [ "$count" -lt 300 ] && ! printf '%s\n' "$changed" | grep -qvE "^${STAINLESS_WORKSPACE}/custom-code/"; then
-              echo "::notice::Only custom-code tracking files changed, skipping regeneration."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
+              seal_back=$(gh api "repos/$REPO/commits/$AFTER/pulls" \
+                --jq 'any(.[]; .merged_at != null and .head.ref == "stlc/seal-tracking")')
+              if [ "$seal_back" = "true" ]; then
+                echo "::notice::Only generated seal-back tracking files changed, skipping regeneration."
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "::notice::Tracking files changed outside the generated seal-back PR; regenerating every target."
             fi
           fi
 

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -134,8 +134,13 @@ jobs:
             changed=$(gh api "repos/$REPO/compare/$BEFORE...$AFTER" --jq '.files[].filename')
             count=$(printf '%s\n' "$changed" | wc -l)
             if [ -n "$changed" ] && [ "$count" -lt 300 ] && ! printf '%s\n' "$changed" | grep -qvE "^${STAINLESS_WORKSPACE}/custom-code/"; then
-              seal_back=$(gh api "repos/$REPO/commits/$AFTER/pulls" \
-                --jq 'any(.[]; .merged_at != null and .head.ref == "stlc/seal-tracking")')
+              seal_back=$(gh api --method GET "repos/$REPO/pulls" \
+                -f state=closed \
+                -f head="${REPO%%/*}:stlc/seal-tracking" \
+                -f sort=updated \
+                -f direction=desc \
+                -f per_page=100 \
+                --jq 'any(.[]; .merged_at != null and .merge_commit_sha == env.AFTER)')
               if [ "$seal_back" = "true" ]; then
                 echo "::notice::Only generated seal-back tracking files changed, skipping regeneration."
                 echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/stainless/custom-code/go/2026-08-04T13-39-02-159Z-custom-code.json
+++ b/stainless/custom-code/go/2026-08-04T13-39-02-159Z-custom-code.json
@@ -1,6 +1,0 @@
-{
-  "base": "a2d6427b9255f0dee78a758c9b399831f5d7706c",
-  "integrated": "913f5b9d8432fe6bd2f0c7af7aba16a71bfe1c5a",
-  "filename": "2026-08-04T13-39-02-159Z-custom-code.json",
-  "branch": "main"
-}

--- a/stainless/custom-code/go/2026-08-21T19-11-19-339Z-custom-code.json
+++ b/stainless/custom-code/go/2026-08-21T19-11-19-339Z-custom-code.json
@@ -1,0 +1,6 @@
+{
+  "base": "a5832ef211c551ec5cbe0c37a09a638a78d31176",
+  "integrated": "3819f7931388d925f77c3f1e921d76ea65ff3e43",
+  "branch": "main",
+  "filename": "2026-08-21T19-11-19-339Z-custom-code.json"
+}

--- a/stainless/custom-code/typescript/2026-08-04T13-39-02-159Z-custom-code.json
+++ b/stainless/custom-code/typescript/2026-08-04T13-39-02-159Z-custom-code.json
@@ -1,6 +1,0 @@
-{
-  "base": "9a63b8c9d027266ee9faec0639ebde7e6e701d48",
-  "integrated": "9145d064670b4eb38fea6f4bf0f5c9f3b46653d2",
-  "filename": "2026-08-04T13-39-02-159Z-custom-code.json",
-  "branch": "main"
-}

--- a/stainless/custom-code/typescript/2026-08-21T19-11-20-278Z-custom-code.json
+++ b/stainless/custom-code/typescript/2026-08-21T19-11-20-278Z-custom-code.json
@@ -1,0 +1,6 @@
+{
+  "base": "c0758e9db2158528211faa1bc87054cce107602a",
+  "integrated": "92548306b20b73725d35bb8bb684752c7966fe94",
+  "branch": "main",
+  "filename": "2026-08-21T19-11-20-278Z-custom-code.json"
+}


### PR DESCRIPTION
## Summary

- re-anchor Go and TypeScript custom-code tracking to the current published SDK histories
- regenerate after hand-authored tracking-only changes so partial tracking updates cannot leave other targets stale
- skip regeneration only when a merged change came from the generated `stlc/seal-tracking` branch

## Why

A target-specific tracking update can legitimately change only one SDK. Treating every tracking-only merge as an automatic seal-back skips the all-target regeneration that consolidates the remaining tracking state.

## Testing

- `stlc repair --dry-run --force --targets go,typescript --branch main`
- `stlc repair --dry-run --force --targets go,typescript --branch main` reports both targets clean after repair
- generated Go and TypeScript SDKs in a disposable checkout with the CI-pinned stlc toolchain
- `stlc exec --targets go,typescript -- ./scripts/bootstrap`
- `stlc lint --targets go,typescript`
- `stlc test --targets go,typescript`
- validated both merged-PR classifications against the GitHub API
- parsed `.github/workflows/stlc-generate.yml` as YAML
- `git diff --check`

Full Python SDK validation was not run locally; this change does not modify its tracking state, and CI validates all targets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI skip logic for SDK generation on main, which can cause extra full regenerations or missed skips if the GitHub PR lookup is wrong. Tracking file updates affect how custom code is sealed into Go and TypeScript SDKs.
> 
> **Overview**
> Stops treating every custom-code-only merge as a no-op. The generate workflow now skips a follow-on build **only** when the push is the merged `stlc/seal-tracking` PR; other tracking-only changes still regenerate every SDK so a one-target update cannot leave the rest stale.
> 
> Adds `pull-requests: read` so the guard can look up that closed seal-back PR. Also re-anchors Go and TypeScript custom-code tracking files to current published SDK histories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd458d39f51ae3ac4fcc290838888d07068d910d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->