### PR TITLE
Validate persisted VF health records

### DIFF
--- a/lib/devices/vf_health.go
+++ b/lib/devices/vf_health.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"sync"
 	"time"
@@ -39,6 +40,8 @@ type vfHealthStore struct {
 	loadErr error
 }
 
+var vfHealthAddressPattern = regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-7]$`)
+
 var vfHealth = &vfHealthStore{records: make(map[string]VFHealthRecord)}
 
 // initVFHealthStore points the store at its state file and loads any
@@ -67,9 +70,27 @@ func (s *vfHealthStore) loadLocked() error {
 		s.loadErr = fmt.Errorf("unmarshal VF health state: %w", err)
 		return s.loadErr
 	}
-	for _, record := range records {
-		s.records[record.VFAddress] = record
+	if records == nil {
+		s.loadErr = fmt.Errorf("validate VF health state: expected an array")
+		return s.loadErr
 	}
+	loaded := make(map[string]VFHealthRecord, len(records))
+	for i, record := range records {
+		if !vfHealthAddressPattern.MatchString(record.VFAddress) {
+			s.loadErr = fmt.Errorf("validate VF health state record %d: invalid VF address %q", i, record.VFAddress)
+			return s.loadErr
+		}
+		if record.QuarantinedAt.IsZero() {
+			s.loadErr = fmt.Errorf("validate VF health state record %d: missing quarantine timestamp", i)
+			return s.loadErr
+		}
+		if _, exists := loaded[record.VFAddress]; exists {
+			s.loadErr = fmt.Errorf("validate VF health state record %d: duplicate VF address %q", i, record.VFAddress)
+			return s.loadErr
+		}
+		loaded[record.VFAddress] = record
+	}
+	s.records = loaded
 	return nil
 }
 
@@ -145,6 +166,9 @@ func (s *vfHealthStore) quarantine(q VFQuarantine) (bool, error) {
 	defer s.mu.Unlock()
 	if err := s.ensureLoadedLocked(); err != nil {
 		return false, err
+	}
+	if !vfHealthAddressPattern.MatchString(q.VFAddress) {
+		return false, fmt.Errorf("invalid VF address %q", q.VFAddress)
 	}
 	if _, ok := s.records[q.VFAddress]; ok {
 		return true, nil

--- a/lib/devices/vf_health_test.go
+++ b/lib/devices/vf_health_test.go
@@ -54,6 +54,14 @@ func TestQuarantineVFPersistsAcrossReload(t *testing.T) {
 	assert.Equal(t, "instance-1", records[0].InstanceID)
 }
 
+func TestQuarantineVFRejectsInvalidAddress(t *testing.T) {
+	resetVFHealthStore(t)
+
+	_, err := QuarantineVF(VFQuarantine{VFAddress: "not-a-pci-address"})
+	require.ErrorContains(t, err, "invalid VF address")
+	assert.Empty(t, QuarantinedVFs())
+}
+
 func TestQuarantineVFRollsBackOnPersistFailure(t *testing.T) {
 	resetVFHealthStore(t)
 	// Point the store below a path component that is a file, so persisting
@@ -91,6 +99,53 @@ func TestCheckedAddressesFailsClosedOnUnloadedState(t *testing.T) {
 	addresses, err := vfHealth.checkedAddresses()
 	require.NoError(t, err)
 	assert.Contains(t, addresses, "0000:e3:00.4")
+}
+
+func TestCheckedAddressesFailsClosedOnInvalidRecord(t *testing.T) {
+	tests := []struct {
+		name    string
+		state   string
+		wantErr string
+	}{
+		{
+			name:    "null state",
+			state:   `null`,
+			wantErr: "expected an array",
+		},
+		{
+			name:    "missing fields",
+			state:   `[{}]`,
+			wantErr: "invalid VF address",
+		},
+		{
+			name:    "invalid address",
+			state:   `[{"vf_address":"not-a-pci-address","quarantined_at":"2026-08-20T00:00:00Z"}]`,
+			wantErr: "invalid VF address",
+		},
+		{
+			name:    "missing timestamp",
+			state:   `[{"vf_address":"0000:e3:00.4"}]`,
+			wantErr: "missing quarantine timestamp",
+		},
+		{
+			name:    "duplicate address",
+			state:   `[{"vf_address":"0000:e3:00.4","quarantined_at":"2026-08-20T00:00:00Z"},{"vf_address":"0000:e3:00.4","quarantined_at":"2026-08-21T00:00:00Z"}]`,
+			wantErr: "duplicate VF address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := resetVFHealthStore(t)
+			require.NoError(t, os.WriteFile(path, []byte(tt.state), 0644))
+			require.ErrorContains(t, initVFHealthStore(path), tt.wantErr)
+			assert.True(t, VFHealthStoreUnavailable())
+			assert.Empty(t, QuarantinedVFs())
+
+			_, err := vfHealth.checkedAddresses()
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestQuarantineVFRefusesToClobberUnloadedState(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject null, incomplete, invalid, and duplicate VF health records during load
- keep placement fail-closed when persisted quarantine state is semantically invalid
- reject invalid VF addresses before writing new quarantine records

## Testing

- `go test ./lib/devices -count=1`
- `go test -race ./lib/devices -run 'Test(QuarantineVF|CheckedAddresses)' -count=1`\n- `go vet ./lib/devices`