### PR TITLE
Extend delete shutdown grace period

### DIFF
--- a/lib/instances/delete.go
+++ b/lib/instances/delete.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-const deleteGracefulShutdownTimeout = 2
+const deleteGracefulShutdownTimeout = 5
 
 type deleteInstanceOptions struct {
 	skipGracefulShutdown bool


### PR DESCRIPTION
## summary

- increase the maximum graceful shutdown window used during instance deletion from 2 seconds to 5 seconds
- give guest shutdown hooks more time to finish before the hypervisor is force-killed

## testing

- `go test -tags containers_image_openpgp -run '^$' ./...`
- focused existing instance deletion/process-exit tests
- attempted `make test`; tests requiring fresh Docker Hub pulls were blocked by the unauthenticated registry rate limit, and `TestFCUFFDGraduationLifecycle` requires the host UFFD systemd unit
