### PR TITLE
Install the breakglass caller

### DIFF
--- a/.github/workflows/breakglass.yml
+++ b/.github/workflows/breakglass.yml
@@ -1,0 +1,21 @@
+name: Breakglass
+
+# Comment `/breakglass <reason>` on a PR to merge it without its required approval.
+# The mechanism lives in kernel/security-workflows; this file is the whole per-repo install
+# and should never grow logic. See kernel/infra docs/breakglass.md.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  merge:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/breakglass')
+    uses: kernel/security-workflows/.github/workflows/breakglass-merge.yml@main
+    # Named rather than `secrets: inherit`: this calls a workflow in another repository, and
+    # inherit would hand it every secret this repo holds.
+    secrets:
+      BREAKGLASS_APP_ID: ${{ secrets.BREAKGLASS_APP_ID }}
+      BREAKGLASS_APP_PRIVATE_KEY: ${{ secrets.BREAKGLASS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Nineteen lines, no logic — the whole per-repo install for breakglass.

Comment `/breakglass <reason>` on a PR here and it merges without its required approval, recording the reason on the PR. The mechanism lives in [kernel/security-workflows](https://github.com/kernel/security-workflows/pull/18) and is shared, so changes to it need no PR here.

**This repo is public**, which is why the mechanism is hosted in a public repo — a public repository cannot call a reusable workflow stored in a private one, and the failure is silent (run created, zero jobs, nothing on the PR).

Why a file per repo: `issue_comment` fires in the repo where the comment is left, and GitHub only runs a workflow if the file is on *that* repo's default branch. Reusable workflows share logic, not triggers.

Docs: [kernel/infra docs/breakglass.md](https://github.com/kernel/infra/blob/main/docs/breakglass.md)

Depends on kernel/security-workflows#18 landing first. Requires the org-level `BREAKGLASS_APP_ID` / `BREAKGLASS_APP_PRIVATE_KEY` secrets shared with this repo, and the `kernel-breakglass` app installed on it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an approval-bypass merge path gated by comment and shared app credentials; misconfiguration or compromised breakglass secrets could allow unauthorized merges.
> 
> **Overview**
> Adds a **minimal GitHub Actions workflow** so reviewers can comment `/breakglass <reason>` on a PR to merge it without required approvals, with the reason recorded on the PR.
> 
> The new `.github/workflows/breakglass.yml` only wires the trigger: it runs on `issue_comment` when the body starts with `/breakglass`, uses **no job permissions**, and delegates to the shared `kernel/security-workflows` `breakglass-merge.yml` reusable workflow. It passes only **`BREAKGLASS_APP_ID`** and **`BREAKGLASS_APP_PRIVATE_KEY`** (not `secrets: inherit`) so the external workflow does not receive every repo secret.
> 
> **Depends on** the shared breakglass workflow in `kernel/security-workflows` and org/repo secrets plus the `kernel-breakglass` GitHub App on this repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ab6973a61235b48769103193add7ae51e8add1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->