### PR TITLE
Deploy Hypeman staging after merges to main

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,34 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint token for infra
+        id: infra-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ADMIN_APP_ID }}
+          private-key: ${{ secrets.ADMIN_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: infra
+          permission-actions: write
+
+      - name: Deploy commit to staging
+        env:
+          GH_TOKEN: ${{ steps.infra-token.outputs.token }}
+          HYPEMAN_REF: ${{ github.sha }}
+        run: |
+          gh workflow run ansible-deploy-hypeman.yml \
+            --repo kernel/infra \
+            --ref main \
+            --field env=staging \
+            --field ref="$HYPEMAN_REF" \
+            --field cli-version=latest


### PR DESCRIPTION
## summary

- trigger a staging deployment after commits land on `main`
- dispatch the existing `kernel/infra` Hypeman deploy workflow with the exact merged commit SHA
- use the repository admin app token for cross-repository workflow access

## testing

- `actionlint .github/workflows/deploy-staging.yml`
- `git diff --check main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automated staging deploys on every main push and relies on admin app credentials to trigger infra workflows; misconfiguration could deploy wrong refs or fail silently if secrets or infra workflow inputs change.
> 
> **Overview**
> Adds a new GitHub Actions workflow that **automatically deploys Hypeman to staging** whenever commits land on `main`.
> 
> The job mints a GitHub App token (`ADMIN_APP_ID` / `ADMIN_APP_PRIVATE_KEY`) scoped to `kernel/infra` with Actions write permission, then uses `gh workflow run` to trigger **`ansible-deploy-hypeman.yml`** with `env=staging`, `ref` set to the pushed commit SHA, and `cli-version=latest`. Workflow permissions stay minimal (`contents: read` at the workflow level; cross-repo dispatch uses the app token).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efb23378dcefa4a83b4969d63af5979ab9af6a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->