### PR TITLE
Upgrade Firecracker to v1.16.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,22 +53,23 @@ download-ch-binaries:
 	@chmod +x lib/vmm/binaries/cloud-hypervisor/v*/*/cloud-hypervisor
 	@echo "Binaries downloaded successfully"
 
-# Firecracker version to embed
-FIRECRACKER_VERSION := v1.14.2
+# Firecracker versions to embed for backwards-compatible snapshot restores
+FIRECRACKER_VERSIONS := v1.14.2 v1.16.1
 
 # Download Firecracker binaries
 download-firecracker-binaries:
 	@echo "Downloading Firecracker binaries..."
-	@mkdir -p lib/hypervisor/firecracker/binaries/firecracker/$(FIRECRACKER_VERSION)/{x86_64,aarch64}
-	@echo "Downloading $(FIRECRACKER_VERSION) for x86_64..."
-	@curl -L "https://github.com/firecracker-microvm/firecracker/releases/download/$(FIRECRACKER_VERSION)/firecracker-$(FIRECRACKER_VERSION)-x86_64.tgz" \
-		| tar -xzO "release-$(FIRECRACKER_VERSION)-x86_64/firecracker-$(FIRECRACKER_VERSION)-x86_64" \
-		> lib/hypervisor/firecracker/binaries/firecracker/$(FIRECRACKER_VERSION)/x86_64/firecracker
-	@echo "Downloading $(FIRECRACKER_VERSION) for aarch64..."
-	@curl -L "https://github.com/firecracker-microvm/firecracker/releases/download/$(FIRECRACKER_VERSION)/firecracker-$(FIRECRACKER_VERSION)-aarch64.tgz" \
-		| tar -xzO "release-$(FIRECRACKER_VERSION)-aarch64/firecracker-$(FIRECRACKER_VERSION)-aarch64" \
-		> lib/hypervisor/firecracker/binaries/firecracker/$(FIRECRACKER_VERSION)/aarch64/firecracker
-	@chmod +x lib/hypervisor/firecracker/binaries/firecracker/$(FIRECRACKER_VERSION)/*/firecracker
+	@set -euo pipefail; \
+	for version in $(FIRECRACKER_VERSIONS); do \
+		mkdir -p lib/hypervisor/firecracker/binaries/firecracker/$$version/{x86_64,aarch64}; \
+		for arch in x86_64 aarch64; do \
+			echo "Downloading $$version for $$arch..."; \
+			curl -fL "https://github.com/firecracker-microvm/firecracker/releases/download/$$version/firecracker-$$version-$$arch.tgz" \
+				| tar -xzO "release-$$version-$$arch/firecracker-$$version-$$arch" \
+				> lib/hypervisor/firecracker/binaries/firecracker/$$version/$$arch/firecracker; \
+		done; \
+	done
+	@chmod +x lib/hypervisor/firecracker/binaries/firecracker/v*/*/firecracker
 	@echo "Firecracker binaries downloaded successfully"
 
 # Caddy version and modules
@@ -208,10 +209,13 @@ ensure-firecracker-binaries:
 	else \
 		echo "Unsupported architecture: $$ARCH"; exit 1; \
 	fi; \
-	if [ ! -f lib/hypervisor/firecracker/binaries/firecracker/$(FIRECRACKER_VERSION)/$$FC_ARCH/firecracker ]; then \
-		echo "Firecracker binaries not found, downloading..."; \
-		$(MAKE) download-firecracker-binaries; \
-	fi
+	for version in $(FIRECRACKER_VERSIONS); do \
+		if [ ! -f lib/hypervisor/firecracker/binaries/firecracker/$$version/$$FC_ARCH/firecracker ]; then \
+			echo "Firecracker binaries not found, downloading..."; \
+			$(MAKE) download-firecracker-binaries; \
+			break; \
+		fi; \
+	done
 
 # Check if Caddy binaries exist, build if missing
 .PHONY: ensure-caddy-binaries

--- a/lib/hypervisor/firecracker/README.md
+++ b/lib/hypervisor/firecracker/README.md
@@ -15,6 +15,8 @@ Like Cloud Hypervisor, Firecracker binaries are embedded and extracted into `dat
 - Download helper: `make download-firecracker-binaries`
 - Runtime override: `hypervisor.firecracker_binary_path` (uses external binary instead of embedded)
 
+Multiple versions are embedded so snapshots can be restored with the Firecracker version recorded in their instance metadata. `defaultVersion` in `binaries.go` controls the version used for new instances; changing it does not migrate running or standby instances.
+
 ## VM State Mapping
 
 `mapVMState()` maps Firecracker `GET /` state strings to internal states:

--- a/lib/hypervisor/firecracker/binaries.go
+++ b/lib/hypervisor/firecracker/binaries.go
@@ -18,12 +18,14 @@ type Version string
 
 const (
 	V1_14_2 Version = "v1.14.2"
+	V1_16_1 Version = "v1.16.1"
 )
 
-const defaultVersion = V1_14_2
+const defaultVersion = V1_16_1
 
 var supportedVersions = []Version{
 	V1_14_2,
+	V1_16_1,
 }
 
 //go:embed binaries

--- a/lib/hypervisor/firecracker/binaries_test.go
+++ b/lib/hypervisor/firecracker/binaries_test.go
@@ -36,9 +36,34 @@ func TestResolveBinaryPathInvalidCustomPath(t *testing.T) {
 }
 
 func TestParseVersionFallback(t *testing.T) {
+	assert.Equal(t, V1_16_1, defaultVersion)
 	assert.Equal(t, defaultVersion, parseVersion(""))
 	assert.Equal(t, defaultVersion, parseVersion("unknown"))
 	assert.Equal(t, V1_14_2, parseVersion("v1.14.2"))
+	assert.Equal(t, V1_16_1, parseVersion("v1.16.1"))
+}
+
+func TestResolveEmbeddedBinaryVersions(t *testing.T) {
+	SetCustomBinaryPath("")
+	t.Cleanup(func() { SetCustomBinaryPath("") })
+
+	arch, err := normalizeArch()
+	require.NoError(t, err)
+
+	for _, version := range supportedVersions {
+		t.Run(string(version), func(t *testing.T) {
+			embeddedPath := filepath.ToSlash(filepath.Join("binaries", "firecracker", string(version), arch, "firecracker"))
+			if _, err := binaryFS.ReadFile(embeddedPath); err != nil {
+				t.Skipf("embedded binary %s not present in this checkout", embeddedPath)
+			}
+
+			path, err := resolveBinaryPath(paths.New(t.TempDir()), string(version))
+			require.NoError(t, err)
+			detected, err := detectVersion(path)
+			require.NoError(t, err)
+			assert.Equal(t, string(version), detected)
+		})
+	}
 }
 
 func TestResolveBinaryPathConcurrentExtraction(t *testing.T) {


### PR DESCRIPTION
## summary

- embed Firecracker v1.16.1 alongside v1.14.2
- use v1.16.1 for newly created VMs and snapshots
- retain v1.14.2 for restoring existing snapshots with that recorded hypervisor version
- update the binary download and validation paths to require both versions

## why

Firecracker v1.16.1 includes [upstream fix #5972](https://github.com/firecracker-microvm/firecracker/pull/5972), which serializes `IA32_XSS` in snapshots. Without it, restoring a guest that uses supervisor xstate such as CET can fail in `restore_fpregs_from_fpstate`.

This follows the existing versioned restore behavior: new instances resolve the new default, while running and standby instances keep the Firecracker version already stored in their metadata. There is no in-place migration.

## test plan

- `make download-firecracker-binaries`
- `make build`
- `go test ./lib/hypervisor/firecracker/...`
- `go test ./lib/instances/... -run '^$'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Firecracker build runs for new workloads and which binaries must be embedded; snapshot restore correctness depends on keeping the older version available.
> 
> **Overview**
> **Bumps the default Firecracker binary to v1.16.1** for new VMs and snapshots, while **embedding v1.14.2 alongside it** so restores can use the hypervisor version stored in instance metadata (no in-place migration).
> 
> Makefile download and `ensure-firecracker-binaries` now loop over `FIRECRACKER_VERSIONS` (`v1.14.2`, `v1.16.1`) for both architectures. `binaries.go` adds `V1_16_1`, sets `defaultVersion` to it, and extends `supportedVersions`. Tests cover version parsing and per-version embedded binary resolution when binaries are present in the checkout.
> 
> This targets upstream snapshot behavior (e.g. `IA32_XSS` serialization) that can break guest restore when supervisor xstate such as CET is in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd31febda6932ded6c8e3b41e89ec44d7e15168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->