### PR TITLE
Materialize per-layer artifacts with explicit whiteout handling

### DIFF
--- a/lib/images/README.md
+++ b/lib/images/README.md
@@ -65,6 +65,10 @@ Content-addressable storage with tag symlinks (similar to Docker/Unikraft):
         rootfs.erofs
       latest -> abc123def456...   # Tag symlink to digest
       3.18 -> def456abc123...     # Another tag
+    layers/                       # Shared materialized layer artifacts
+      abc123def456.../
+        layer.erofs
+        artifact.erofs.json
   system/
     oci-cache/              # Shared OCI layout for all images
       index.json            # Manifest index with digest-based tags
@@ -82,6 +86,7 @@ Content-addressable storage with tag symlinks (similar to Docker/Unikraft):
 - Natural hierarchy: All versions of an image grouped under repository
 - Easy inspection: Clear which digest belongs to which image
 - Layer caching: All images share the same blob storage, layers deduplicated automatically
+- Materialized layer artifacts are reference-protected and reconciled by the layer lifecycle manager; stale temporary trees are age-gated before removal.
 
 **Design:**
 - Images stored by manifest digest (content hash)
@@ -92,6 +97,7 @@ Content-addressable storage with tag symlinks (similar to Docker/Unikraft):
 - Shared blob storage enables automatic layer deduplication across all images
 - Orphaned digests are automatically deleted when the last tag referencing them is removed
 - Symlinks only created after successful build (status: ready)
+- Disk accounting uses logical file sizes, matching image metadata and storage admission rather than filesystem block allocation.
 
 ## Reference Handling (reference.go)
 

--- a/lib/images/disk.go
+++ b/lib/images/disk.go
@@ -1,7 +1,9 @@
 package images
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,15 +31,20 @@ var DefaultImageFormat = func() ExportFormat {
 	return FormatErofs
 }()
 
-// ExportRootfs exports rootfs directory in specified format (public for system manager)
+// ExportRootfs exports rootfs directory in specified format (public for system manager).
 func ExportRootfs(rootfsDir, outputPath string, format ExportFormat) (int64, error) {
+	return ExportRootfsWithContext(context.Background(), rootfsDir, outputPath, format)
+}
+
+// ExportRootfsWithContext exports rootfs directory and cancels external formatters with ctx.
+func ExportRootfsWithContext(ctx context.Context, rootfsDir, outputPath string, format ExportFormat) (int64, error) {
 	switch format {
 	case FormatExt4:
-		return convertToExt4(rootfsDir, outputPath)
+		return convertToExt4(ctx, rootfsDir, outputPath)
 	case FormatErofs:
-		return convertToErofs(rootfsDir, outputPath)
+		return convertToErofs(ctx, rootfsDir, outputPath)
 	case FormatCpio:
-		return convertToCpio(rootfsDir, outputPath)
+		return convertToCpio(ctx, rootfsDir, outputPath)
 	default:
 		return 0, fmt.Errorf("unsupported export format: %s", format)
 	}
@@ -45,7 +52,7 @@ func ExportRootfs(rootfsDir, outputPath string, format ExportFormat) (int64, err
 
 // convertToCpio packages directory as uncompressed cpio archive (initramfs format)
 // Uses uncompressed format for faster boot (kernel loads directly without decompression)
-func convertToCpio(rootfsDir, outputPath string) (int64, error) {
+func convertToCpio(ctx context.Context, rootfsDir, outputPath string) (int64, error) {
 	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
 		return 0, fmt.Errorf("create output dir: %w", err)
@@ -56,7 +63,13 @@ func convertToCpio(rootfsDir, outputPath string) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("create output file: %w", err)
 	}
-	defer outFile.Close()
+	keepOutput := false
+	defer func() {
+		_ = outFile.Close()
+		if !keepOutput {
+			_ = os.Remove(outputPath)
+		}
+	}()
 
 	// Create newc format cpio writer (kernel-compatible format)
 	cpioWriter := cpio.Newc.Writer(outFile)
@@ -66,6 +79,9 @@ func convertToCpio(rootfsDir, outputPath string) (int64, error) {
 
 	// Walk the rootfs directory and add all files
 	err = filepath.Walk(rootfsDir, func(path string, info os.FileInfo, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if err != nil {
 			return err
 		}
@@ -89,6 +105,13 @@ func convertToCpio(rootfsDir, outputPath string) (int64, error) {
 
 		// Set the name to be relative to root
 		rec.Name = relPath
+		if rec.ReaderAt != nil {
+			rec.ReaderAt = &contextReaderAt{
+				ctx:    ctx,
+				reader: rec.ReaderAt,
+				closer: readerCloser(rec.ReaderAt),
+			}
+		}
 
 		// Write the record to the archive
 		if err := cpioWriter.WriteRecord(rec); err != nil {
@@ -113,7 +136,33 @@ func convertToCpio(rootfsDir, outputPath string) (int64, error) {
 		return 0, fmt.Errorf("stat output: %w", err)
 	}
 
+	keepOutput = true
 	return stat.Size(), nil
+}
+
+type contextReaderAt struct {
+	ctx    context.Context
+	reader io.ReaderAt
+	closer io.Closer
+}
+
+func (r *contextReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.ReadAt(p, off)
+}
+
+func (r *contextReaderAt) Close() error {
+	if r.closer == nil {
+		return nil
+	}
+	return r.closer.Close()
+}
+
+func readerCloser(reader io.ReaderAt) io.Closer {
+	closer, _ := reader.(io.Closer)
+	return closer
 }
 
 // sectorSize is the block size for disk images (required by Virtualization.framework)
@@ -128,9 +177,9 @@ func alignToSector(size int64) int64 {
 }
 
 // convertToExt4 converts a rootfs directory to an ext4 disk image using mkfs.ext4
-func convertToExt4(rootfsDir, diskPath string) (int64, error) {
+func convertToExt4(ctx context.Context, rootfsDir, diskPath string) (int64, error) {
 	// Calculate size of rootfs directory
-	sizeBytes, err := dirSize(rootfsDir)
+	sizeBytes, err := dirSizeWithContext(ctx, rootfsDir)
 	if err != nil {
 		return 0, fmt.Errorf("calculate dir size: %w", err)
 	}
@@ -168,7 +217,7 @@ func convertToExt4(rootfsDir, diskPath string) (int64, error) {
 	// -O ^has_journal: Disable journal (not needed for read-only VM mounts)
 	// -d: Copy directory contents into filesystem
 	// -F: Force creation (file not block device)
-	cmd := exec.Command(mkfsExt4Binary(), "-b", "4096", "-O", "^has_journal", "-d", rootfsDir, "-F", diskPath)
+	cmd := exec.CommandContext(ctx, mkfsExt4Binary(), "-b", "4096", "-O", "^has_journal", "-d", rootfsDir, "-F", diskPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return 0, fmt.Errorf("mkfs.ext4 failed: %w, output: %s", err, output)
@@ -193,7 +242,7 @@ func convertToExt4(rootfsDir, diskPath string) (int64, error) {
 }
 
 // convertToErofs converts a rootfs directory to an erofs disk image using mkfs.erofs
-func convertToErofs(rootfsDir, diskPath string) (int64, error) {
+func convertToErofs(ctx context.Context, rootfsDir, diskPath string) (int64, error) {
 	// Ensure parent directory exists
 	if err := os.MkdirAll(filepath.Dir(diskPath), 0755); err != nil {
 		return 0, fmt.Errorf("create disk parent dir: %w", err)
@@ -202,7 +251,7 @@ func convertToErofs(rootfsDir, diskPath string) (int64, error) {
 	// Create erofs image with LZ4 fast compression
 	// -zlz4: LZ4 fast compression (~20-25% space savings, faster builds)
 	// erofs doesn't need pre-allocation, creates file directly
-	cmd := exec.Command("mkfs.erofs", "-zlz4", diskPath, rootfsDir)
+	cmd := exec.CommandContext(ctx, "mkfs.erofs", "-zlz4", diskPath, rootfsDir)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return 0, fmt.Errorf("mkfs.erofs failed: %w, output: %s", err, output)
@@ -226,11 +275,18 @@ func convertToErofs(rootfsDir, diskPath string) (int64, error) {
 	return stat.Size(), nil
 }
 
-// dirSize calculates the total size of a directory
+// dirSize is used by layer-store reconciliation.
 func dirSize(path string) (int64, error) {
+	return dirSizeWithContext(context.Background(), path)
+}
+
+func dirSizeWithContext(ctx context.Context, path string) (int64, error) {
 	var size int64
 	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
 		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 		if !info.IsDir() {

--- a/lib/images/disk_usage.go
+++ b/lib/images/disk_usage.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,42 +9,64 @@ import (
 	"syscall"
 )
 
+func walkWithContext(ctx context.Context, root string, walkFn filepath.WalkFunc) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return walkFn(path, info, err)
+	})
+}
+
 // totalReadyImageBytesFromMetadata sums ready image sizes directly from metadata.json files.
 // This is conservative for admission control and disk accounting: if metadata says an
 // image is ready, we count its recorded size without re-validating the rootfs path. If
 // the metadata file is unreadable or malformed, we fall back to counting any rootfs disk
 // files found in the digest directory so we do not undercount host disk usage.
-func totalReadyImageBytesFromMetadata(imagesDir string) (int64, error) {
+func totalReadyImageBytesFromMetadataWithContext(ctx context.Context, imagesDir string) (int64, error) {
 	var total int64
 	seenRootfs := make(map[rootfsIdentity]struct{})
+	layersDir := filepath.Join(imagesDir, "layers")
 
-	err := filepath.Walk(imagesDir, func(path string, info os.FileInfo, err error) error {
+	err := walkWithContext(ctx, imagesDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil
 			}
 			return err
 		}
-		if info.IsDir() || info.Name() != "metadata.json" {
+		if info.IsDir() {
+			if filepath.Clean(path) == filepath.Clean(layersDir) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if info.Name() != "metadata.json" {
 			return nil
 		}
 
 		data, err := os.ReadFile(path)
 		if err != nil {
-			rootfsBytes, fallbackErr := totalUniqueRootfsBytesInDigestDir(filepath.Dir(path), seenRootfs)
+			rootfsBytes, fallbackErr := totalRootfsBytesInDigestDirWithContext(ctx, filepath.Dir(path), seenRootfs)
 			if fallbackErr == nil {
 				total += rootfsBytes
 				return nil
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
 			}
 			return fmt.Errorf("read image metadata %s: %w", path, err)
 		}
 
 		var meta imageMetadata
 		if err := json.Unmarshal(data, &meta); err != nil {
-			rootfsBytes, fallbackErr := totalUniqueRootfsBytesInDigestDir(filepath.Dir(path), seenRootfs)
+			rootfsBytes, fallbackErr := totalRootfsBytesInDigestDirWithContext(ctx, filepath.Dir(path), seenRootfs)
 			if fallbackErr == nil {
 				total += rootfsBytes
 				return nil
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
 			}
 			return fmt.Errorf("unmarshal image metadata %s: %w", path, err)
 		}
@@ -67,7 +90,7 @@ func totalReadyImageBytesFromMetadata(imagesDir string) (int64, error) {
 				total += meta.SizeBytes
 				return nil
 			}
-			rootfsBytes, err := totalRootfsBytesInDigestDir(filepath.Dir(path))
+			rootfsBytes, err := totalRootfsBytesInDigestDirWithContext(ctx, filepath.Dir(path), nil)
 			if err != nil {
 				return fmt.Errorf("stat ready image rootfs for %s: %w", path, err)
 			}
@@ -82,86 +105,138 @@ func totalReadyImageBytesFromMetadata(imagesDir string) (int64, error) {
 	return total, nil
 }
 
-// totalOCICacheBlobBytesFromFilesystem sums blob sizes directly from the OCI cache blob store.
-// This counts the actual bytes on disk, including any blob files that are currently
-// present but no longer referenced by the OCI layout index.
-func totalOCICacheBlobBytesFromFilesystem(blobDir string) (int64, error) {
+func totalFileBytesWithContext(ctx context.Context, dir, label string) (int64, error) {
 	var total int64
-
-	err := filepath.Walk(blobDir, func(path string, info os.FileInfo, err error) error {
+	err := walkWithContext(ctx, dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil
 			}
 			return err
 		}
-		if info.IsDir() {
-			return nil
+		if !info.IsDir() {
+			total += info.Size()
 		}
-		total += info.Size()
 		return nil
 	})
 	if err != nil && !os.IsNotExist(err) {
-		return 0, fmt.Errorf("walk OCI cache blobs: %w", err)
+		return 0, fmt.Errorf("walk %s: %w", label, err)
 	}
-
 	return total, nil
 }
 
-func (m *manager) getDiskUsageTotals() (int64, int64, error) {
-	m.diskUsageMu.RLock()
-	if m.diskUsageLoaded {
-		readyImageBytes := m.readyImageBytes
-		ociCacheBytes := m.ociCacheBytes
-		m.diskUsageMu.RUnlock()
-		return readyImageBytes, ociCacheBytes, nil
-	}
-	m.diskUsageMu.RUnlock()
-
-	readyImageBytes, ociCacheBytes, err := m.computeDiskUsageTotals()
-	if err != nil {
-		return 0, 0, err
-	}
-
-	m.diskUsageMu.Lock()
-	if !m.diskUsageLoaded {
-		m.readyImageBytes = readyImageBytes
-		m.ociCacheBytes = ociCacheBytes
-		m.diskUsageLoaded = true
-	}
-	readyImageBytes = m.readyImageBytes
-	ociCacheBytes = m.ociCacheBytes
-	m.diskUsageMu.Unlock()
-
-	return readyImageBytes, ociCacheBytes, nil
+// totalLayerArtifactBytesFromFilesystem includes records and in-progress trees.
+func totalLayerArtifactBytesFromFilesystemWithContext(ctx context.Context, layersDir string) (int64, error) {
+	return totalFileBytesWithContext(ctx, layersDir, "layer artifacts")
 }
 
-func (m *manager) refreshDiskUsageTotals() {
-	readyImageBytes, ociCacheBytes, err := m.computeDiskUsageTotals()
+// totalOCICacheBlobBytesFromFilesystem includes unreferenced blobs still on disk.
+func totalOCICacheBlobBytesFromFilesystemWithContext(ctx context.Context, blobDir string) (int64, error) {
+	return totalFileBytesWithContext(ctx, blobDir, "OCI cache blobs")
+}
+
+func (s *layerStore) getDiskUsageTotals(ctx context.Context) (int64, int64, error) {
+	for attempt := 0; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
+		s.diskUsageMu.RLock()
+		generation := s.diskUsageGeneration
+		if s.diskUsageLoaded {
+			readyImageBytes := s.readyImageBytes
+			ociCacheBytes := s.ociCacheBytes
+			s.diskUsageMu.RUnlock()
+			return readyImageBytes, ociCacheBytes, nil
+		}
+		s.diskUsageMu.RUnlock()
+
+		readyImageBytes, ociCacheBytes, err := s.computeDiskUsageTotals(ctx)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		s.diskUsageMu.Lock()
+		if s.diskUsageGeneration != generation {
+			s.diskUsageMu.Unlock()
+			if attempt >= 2 {
+				return 0, 0, fmt.Errorf("disk usage changed during scan")
+			}
+			continue
+		}
+		if s.activeBuilds == 0 {
+			if !s.diskUsageLoaded {
+				s.readyImageBytes = readyImageBytes
+				s.ociCacheBytes = ociCacheBytes
+				s.diskUsageLoaded = true
+			}
+			readyImageBytes = s.readyImageBytes
+			ociCacheBytes = s.ociCacheBytes
+		}
+		s.diskUsageMu.Unlock()
+
+		return readyImageBytes, ociCacheBytes, nil
+	}
+}
+
+func (s *layerStore) invalidateDiskUsageTotals() {
+	s.diskUsageMu.Lock()
+	s.diskUsageGeneration++
+	s.diskUsageLoaded = false
+	s.diskUsageMu.Unlock()
+}
+
+func (s *layerStore) beginLayerBuild() {
+	s.diskUsageMu.Lock()
+	s.activeBuilds++
+	s.diskUsageGeneration++
+	s.diskUsageLoaded = false
+	s.diskUsageMu.Unlock()
+}
+
+func (s *layerStore) endLayerBuild() {
+	s.diskUsageMu.Lock()
+	s.activeBuilds--
+	s.diskUsageGeneration++
+	s.diskUsageLoaded = false
+	s.diskUsageMu.Unlock()
+}
+
+func (s *layerStore) refreshDiskUsageTotals() {
+	s.diskUsageMu.RLock()
+	generation := s.diskUsageGeneration
+	s.diskUsageMu.RUnlock()
+
+	readyImageBytes, ociCacheBytes, err := s.computeDiskUsageTotals(context.Background())
 	if err != nil {
 		return
 	}
 
-	m.diskUsageMu.Lock()
-	m.readyImageBytes = readyImageBytes
-	m.ociCacheBytes = ociCacheBytes
-	m.diskUsageLoaded = true
-	m.diskUsageMu.Unlock()
+	s.diskUsageMu.Lock()
+	if s.diskUsageGeneration == generation && s.activeBuilds == 0 {
+		s.readyImageBytes = readyImageBytes
+		s.ociCacheBytes = ociCacheBytes
+		s.diskUsageLoaded = true
+	}
+	s.diskUsageMu.Unlock()
 }
 
-func (m *manager) computeDiskUsageTotals() (int64, int64, error) {
-	readyImageBytes, err := totalReadyImageBytesFromMetadata(m.paths.ImagesDir())
+func (s *layerStore) computeDiskUsageTotals(ctx context.Context) (int64, int64, error) {
+	readyImageBytes, err := totalReadyImageBytesFromMetadataWithContext(ctx, s.paths.ImagesDir())
 	if err != nil {
 		return 0, 0, err
 	}
-	ociCacheBytes, err := totalOCICacheBlobBytesFromFilesystem(m.paths.OCICacheBlobDir())
+	ociCacheBytes, err := totalOCICacheBlobBytesFromFilesystemWithContext(ctx, s.paths.OCICacheBlobDir())
 	if err != nil {
 		return 0, 0, err
 	}
-	return readyImageBytes, ociCacheBytes, nil
+	layerArtifactBytes, err := totalLayerArtifactBytesFromFilesystemWithContext(ctx, s.paths.ImageLayersDir())
+	if err != nil {
+		return 0, 0, err
+	}
+	return readyImageBytes, ociCacheBytes + layerArtifactBytes, nil
 }
 
-func totalRootfsBytesInDigestDir(digestDir string) (int64, error) {
+func totalRootfsBytesInDigestDirWithContext(ctx context.Context, digestDir string, seen map[rootfsIdentity]struct{}) (int64, error) {
 	rootfsPaths, err := filepath.Glob(filepath.Join(digestDir, "rootfs.*"))
 	if err != nil {
 		return 0, err
@@ -171,7 +246,11 @@ func totalRootfsBytesInDigestDir(digestDir string) (int64, error) {
 	}
 
 	var total int64
+	found := false
 	for _, rootfsPath := range rootfsPaths {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
 		info, err := os.Stat(rootfsPath)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -182,9 +261,13 @@ func totalRootfsBytesInDigestDir(digestDir string) (int64, error) {
 		if info.IsDir() {
 			continue
 		}
+		found = true
+		if seen != nil && !markUniqueRootfs(info, seen) {
+			continue
+		}
 		total += info.Size()
 	}
-	if total == 0 {
+	if !found || seen == nil && total == 0 {
 		return 0, os.ErrNotExist
 	}
 	return total, nil
@@ -206,38 +289,4 @@ func markUniqueRootfs(info os.FileInfo, seen map[rootfsIdentity]struct{}) bool {
 	}
 	seen[identity] = struct{}{}
 	return true
-}
-
-func totalUniqueRootfsBytesInDigestDir(digestDir string, seen map[rootfsIdentity]struct{}) (int64, error) {
-	rootfsPaths, err := filepath.Glob(filepath.Join(digestDir, "rootfs.*"))
-	if err != nil {
-		return 0, err
-	}
-	if len(rootfsPaths) == 0 {
-		return 0, os.ErrNotExist
-	}
-
-	var total int64
-	found := false
-	for _, rootfsPath := range rootfsPaths {
-		info, err := os.Stat(rootfsPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return 0, err
-		}
-		if info.IsDir() {
-			continue
-		}
-		found = true
-		if !markUniqueRootfs(info, seen) {
-			continue
-		}
-		total += info.Size()
-	}
-	if !found {
-		return 0, os.ErrNotExist
-	}
-	return total, nil
 }

--- a/lib/images/disk_usage_test.go
+++ b/lib/images/disk_usage_test.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,7 +18,7 @@ func TestTotalReadyImageBytesFromMetadata_UsesRootfsFallbackForMalformedMetadata
 	require.NoError(t, os.WriteFile(filepath.Join(digestDir, "metadata.json"), []byte("{not-json"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(digestDir, "rootfs.erofs"), []byte("rootfs-data"), 0o644))
 
-	total, err := totalReadyImageBytesFromMetadata(imagesDir)
+	total, err := totalReadyImageBytesFromMetadataWithContext(context.Background(), imagesDir)
 	require.NoError(t, err)
 	require.Equal(t, int64(len("rootfs-data")), total)
 }
@@ -39,7 +40,7 @@ func TestTotalReadyImageBytesFromMetadata_DeduplicatesHardLinkedAliases(t *testi
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "metadata.json"), metadata, 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "metadata.json"), metadata, 0o644))
 
-	total, err := totalReadyImageBytesFromMetadata(imagesDir)
+	total, err := totalReadyImageBytesFromMetadataWithContext(context.Background(), imagesDir)
 	require.NoError(t, err)
 	require.Equal(t, int64(len("shared-rootfs")), total)
 }
@@ -59,9 +60,29 @@ func TestTotalReadyImageBytesFromMetadata_DeduplicatesMalformedAliases(t *testin
 	require.NoError(t, os.WriteFile(filepath.Join(malformedDir, "metadata.json"), []byte("{not-json"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(validDir, "metadata.json"), []byte(`{"status":"ready","size_bytes":13}`), 0o644))
 
-	total, err := totalReadyImageBytesFromMetadata(imagesDir)
+	total, err := totalReadyImageBytesFromMetadataWithContext(context.Background(), imagesDir)
 	require.NoError(t, err)
 	require.Equal(t, int64(len("shared-rootfs")), total)
+}
+
+func TestTotalFileBytesWithContextStopsWhenCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := totalFileBytesWithContext(ctx, t.TempDir(), "test files")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestExportRootfsWithContextStopsCpioWhenCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ExportRootfsWithContext(ctx, t.TempDir(), filepath.Join(t.TempDir(), "rootfs.cpio"), FormatCpio)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestTotalReadyImageBytesFromMetadata_UsesRootfsFallbackForReadyImageWithoutSize(t *testing.T) {
@@ -73,7 +94,7 @@ func TestTotalReadyImageBytesFromMetadata_UsesRootfsFallbackForReadyImageWithout
 	require.NoError(t, os.WriteFile(filepath.Join(digestDir, "metadata.json"), []byte(`{"status":"ready","size_bytes":0}`), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(digestDir, "rootfs.erofs"), []byte("another-rootfs"), 0o644))
 
-	total, err := totalReadyImageBytesFromMetadata(imagesDir)
+	total, err := totalReadyImageBytesFromMetadataWithContext(context.Background(), imagesDir)
 	require.NoError(t, err)
 	require.Equal(t, int64(len("another-rootfs")), total)
 }

--- a/lib/images/layer_artifact.go
+++ b/lib/images/layer_artifact.go
@@ -1,0 +1,546 @@
+package images
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/klauspost/compress/zstd"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/umoci/oci/layer"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	layerRecordSchemaVersion = 3
+	maxLayerUnpackedBytes    = 100 << 30
+
+	// layerBuildTimeout bounds a shared layer build end to end. Builds are
+	// detached from the initiating request's context, so this deadline is the
+	// only thing that can abort a hung unpack and free the singleflight key.
+	layerBuildTimeout = time.Hour
+)
+
+var errCorruptLayerRecord = errors.New("corrupt layer record")
+
+// layerArtifact is the persisted record for one materialized layer artifact.
+// The key is the compressed layer blob digest plus the artifact format. The
+// encoding records the descriptor's decompression class so conflicting
+// descriptors cannot overwrite one artifact path.
+type layerArtifact struct {
+	SchemaVersion  int       `json:"schema_version"`
+	Digest         string    `json:"digest"` // compressed layer blob digest, sha256:...
+	Encoding       string    `json:"encoding"`
+	DiffID         string    `json:"diff_id,omitempty"`
+	Format         string    `json:"format"`
+	SizeBytes      int64     `json:"size_bytes"`      // artifact bytes on disk
+	ArtifactDigest string    `json:"artifact_digest"` // sha256 of artifact bytes
+	UnpackedBytes  int64     `json:"unpacked_bytes"`  // decompressed tar stream bytes
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+// validate checks a record read back from disk. The format fully determines
+// the artifact options (erofs is always lz4-compressed, ext4 uncompressed),
+// so only the format is stored.
+func (a *layerArtifact) validate() error {
+	if a.SchemaVersion != layerRecordSchemaVersion {
+		return fmt.Errorf("unsupported schema version: %d", a.SchemaVersion)
+	}
+	if _, err := parseSHA256Digest(a.Digest); err != nil {
+		return fmt.Errorf("invalid digest: %w", err)
+	}
+	if _, err := parseSHA256Digest(a.ArtifactDigest); err != nil {
+		return fmt.Errorf("invalid artifact digest: %w", err)
+	}
+	if a.Format != string(FormatErofs) && a.Format != string(FormatExt4) {
+		return fmt.Errorf("invalid format: %s", a.Format)
+	}
+	if a.Encoding != "raw" && a.Encoding != "gzip" && a.Encoding != "zstd" {
+		return fmt.Errorf("invalid encoding: %s", a.Encoding)
+	}
+	if a.SizeBytes < 0 || a.UnpackedBytes < 0 {
+		return fmt.Errorf("invalid size")
+	}
+	return nil
+}
+
+// matches decides whether the stored record satisfies a lookup. A descriptor
+// without a DiffID (a manifest lookup that did not consult the image config)
+// matches any record: the compressed digest content-addresses the blob, and
+// unpackCachedLayer re-verifies the diff ID whenever one is supplied.
+func (a *layerArtifact) matches(desc layerDescriptor) bool {
+	if a.Digest != desc.Digest || a.Format != layerArtifactFormat() || a.Encoding != layerEncoding(desc.MediaType) {
+		return false
+	}
+	return desc.DiffID == "" || a.DiffID == desc.DiffID
+}
+
+func layerEncoding(mediaType string) string {
+	normalized := convertToOCIMediaType(mediaType)
+	switch {
+	case normalized == v1.MediaTypeImageLayerZstd, strings.HasSuffix(normalized, ".tar.zstd"):
+		return "zstd"
+	case normalized == v1.MediaTypeImageLayerGzip, strings.HasSuffix(normalized, ".tar.gzip"):
+		return "gzip"
+	default:
+		return "raw"
+	}
+}
+
+func layerArtifactFormat() string {
+	switch DefaultImageFormat {
+	case FormatErofs, FormatExt4:
+		return string(DefaultImageFormat)
+	default:
+		return ""
+	}
+}
+
+func layerArtifactPath(p *paths.Paths, layerHex string) string {
+	return p.ImageLayerArtifactForFormat(layerHex, layerArtifactFormat())
+}
+
+func layerArtifactRecordPath(p *paths.Paths, layerHex string) string {
+	return p.ImageLayerRecordForFormat(layerHex, layerArtifactFormat())
+}
+
+func layerDigestHex(value string) (string, error) {
+	digest, err := parseSHA256Digest(value)
+	if err != nil || digest.String() != value {
+		return "", fmt.Errorf("invalid layer digest %q", value)
+	}
+	return digest.Encoded(), nil
+}
+
+// layerMapOptions preserves tar ownership when running as root. Otherwise
+// umoci's rootless mode skips chown and stands in empty files for device nodes.
+// Unlike unpackLayers in oci.go, which maps container root to the current
+// user, this deliberately leaves ownership untouched as root: artifacts must
+// keep the layer's on-disk ownership for later stacking.
+func layerMapOptions() layer.MapOptions {
+	return layer.MapOptions{Rootless: os.Geteuid() != 0}
+}
+
+// supportsLayerArtifacts reports whether the host can create the native
+// overlayfs representation used by per-layer artifacts. Other platforms and
+// rootless processes must compose the OCI layers into one rootfs instead.
+func supportsLayerArtifacts() bool {
+	return runtime.GOOS == "linux" && os.Geteuid() == 0
+}
+
+func probeLayerArtifactSupport(layersDir string) bool {
+	if !supportsLayerArtifacts() || os.MkdirAll(layersDir, 0755) != nil {
+		return false
+	}
+	probeDir, err := os.MkdirTemp(layersDir, ".probe-*")
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(probeDir)
+
+	whiteout := filepath.Join(probeDir, "whiteout")
+	if err := unix.Mknod(whiteout, unix.S_IFCHR|0600, int(unix.Mkdev(0, 0))); err != nil {
+		return false
+	}
+	if err := unix.Lsetxattr(probeDir, "trusted.overlay.opaque", []byte("y"), 0); err != nil {
+		return false
+	}
+	value := make([]byte, 1)
+	n, err := unix.Lgetxattr(probeDir, "trusted.overlay.opaque", value)
+	return err == nil && n == 1 && value[0] == 'y'
+}
+
+func (m *manager) layerArtifactSupport() bool {
+	return m.layers.artifactsSupported
+}
+
+func (m *manager) materializeLayerArtifact(ctx context.Context, desc layerDescriptor) (*layerArtifact, error) {
+	return m.layers.materializeLayerArtifact(ctx, desc)
+}
+
+// layerArtifactOnDiskFormat is the extraction format for per-layer artifacts.
+// Whiteouts become overlayfs whiteout inodes and opaque xattrs, which an
+// overlayfs mount of stacked layers understands, so the artifact retains the
+// layer's deletions without a private marker format. Callers must check
+// supportsLayerArtifacts before materializing this format.
+func layerArtifactOnDiskFormat() layer.OnDiskFormat {
+	return layer.OverlayfsRootfs{MapOptions: layerMapOptions()}
+}
+
+// readLayerRecord loads the artifact record for a layer digest, if present.
+// A missing record returns (nil, nil): the layer simply was never
+// materialized.
+func readLayerRecord(p *paths.Paths, layerHex string) (*layerArtifact, error) {
+	recordPath := layerArtifactRecordPath(p, layerHex)
+	info, err := os.Lstat(recordPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat layer record: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: layer record is not a regular file", errCorruptLayerRecord)
+	}
+	data, err := os.ReadFile(recordPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read layer record: %w", err)
+	}
+	var record layerArtifact
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, fmt.Errorf("%w: unmarshal layer record: %v", errCorruptLayerRecord, err)
+	}
+	if err := record.validate(); err != nil {
+		return nil, fmt.Errorf("%w: invalid layer record: %v", errCorruptLayerRecord, err)
+	}
+	return &record, nil
+}
+
+func discardLayerCache(p *paths.Paths, layerHex string) error {
+	for _, path := range []string{
+		layerArtifactRecordPath(p, layerHex),
+		layerArtifactPath(p, layerHex),
+	} {
+		if err := removePath(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *layerStore) clearLayerCache(layerHex string) error {
+	err := discardLayerCache(s.paths, layerHex)
+	s.invalidateDiskUsageTotals()
+	return err
+}
+
+// materializeLayerArtifact ensures a layer has a materialized artifact keyed
+// by its blob digest, building it from the shared OCI cache blob when absent.
+// The layer is unpacked into an isolated temp directory, converted to the
+// default image format, and installed atomically. Normal failures remove the
+// temp directory; a crash mid-build can leave a stale .unpack-* directory
+// behind, which reconciliation landing with the pull integration is expected
+// to sweep. No production caller yet: pull integration and
+// composition land in later changes.
+//
+// Concurrent callers share one build. The build itself is detached from the
+// initiating caller's cancellation so one cancelled pull cannot fail every
+// other pull waiting on the same layer; each caller still returns as soon as
+// its own context is done.
+func (s *layerStore) materializeLayerArtifact(ctx context.Context, desc layerDescriptor) (*layerArtifact, error) {
+	layerHex, err := layerDigestHex(desc.Digest)
+	if err != nil {
+		return nil, err
+	}
+	key := desc.Digest + "\x00" + layerArtifactFormat()
+	result := s.flights.DoChan(key, func() (any, error) {
+		// The build outlives the initiating request, so this deadline is its
+		// only bound: without it a hung cache-blob read would wedge the
+		// singleflight key, and every future caller for the layer, forever.
+		buildCtx, cancel := context.WithTimeout(context.Background(), layerBuildTimeout)
+		defer cancel()
+		if s.builds != nil {
+			select {
+			case s.builds <- struct{}{}:
+				defer func() { <-s.builds }()
+			case <-buildCtx.Done():
+				return nil, buildCtx.Err()
+			}
+		}
+		return s.materializeLayerArtifactOnce(buildCtx, desc, layerHex)
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case shared := <-result:
+		if shared.Err != nil {
+			return nil, shared.Err
+		}
+		artifact := shared.Val.(*layerArtifact)
+		if !artifact.matches(desc) {
+			return nil, fmt.Errorf("layer artifact metadata does not match descriptor %s", desc.Digest)
+		}
+		return artifact, nil
+	}
+}
+
+func (s *layerStore) materializeLayerArtifactOnce(ctx context.Context, desc layerDescriptor, layerHex string) (*layerArtifact, error) {
+	if layerArtifactFormat() == "" {
+		return nil, fmt.Errorf("unsupported layer artifact format: %s", DefaultImageFormat)
+	}
+	if !s.artifactsSupported {
+		return nil, fmt.Errorf("layer artifacts are unsupported on this host")
+	}
+
+	if record, err := readLayerRecord(s.paths, layerHex); err != nil {
+		if !errors.Is(err, errCorruptLayerRecord) {
+			return nil, err
+		}
+		if discardErr := s.clearLayerCache(layerHex); discardErr != nil {
+			return nil, fmt.Errorf("discard corrupt layer cache: %w", discardErr)
+		}
+	} else if record != nil && record.Digest == desc.Digest && record.Format == layerArtifactFormat() && record.Encoding != layerEncoding(desc.MediaType) {
+		return nil, fmt.Errorf("layer artifact encoding does not match descriptor %s", desc.Digest)
+	} else if record != nil && record.matches(desc) {
+		artifactInfo, statErr := os.Lstat(layerArtifactPath(s.paths, layerHex))
+		if statErr == nil && artifactInfo.Mode().IsRegular() && record.SizeBytes > 0 && artifactInfo.Size() == record.SizeBytes {
+			artifactDigest, digestErr := fileSHA256(ctx, layerArtifactPath(s.paths, layerHex))
+			if digestErr == nil && artifactDigest == record.ArtifactDigest {
+				return record, nil
+			}
+		}
+		if discardErr := s.clearLayerCache(layerHex); discardErr != nil {
+			return nil, fmt.Errorf("discard invalid layer cache: %w", discardErr)
+		}
+	}
+
+	artifactPath := layerArtifactPath(s.paths, layerHex)
+	if artifactInfo, statErr := os.Lstat(artifactPath); statErr == nil && !artifactInfo.Mode().IsRegular() {
+		if discardErr := s.clearLayerCache(layerHex); discardErr != nil {
+			return nil, fmt.Errorf("discard invalid layer artifact: %w", discardErr)
+		}
+	}
+
+	layerDir := s.paths.ImageLayerDir(layerHex)
+	if err := os.MkdirAll(layerDir, 0755); err != nil {
+		return nil, fmt.Errorf("create layer directory: %w", err)
+	}
+	unpackDir, err := os.MkdirTemp(layerDir, ".unpack-*")
+	if err != nil {
+		return nil, fmt.Errorf("create unpack directory: %w", err)
+	}
+	s.beginLayerBuild()
+	defer func() {
+		if err := removePath(unpackDir); err != nil {
+			slog.Warn("failed to remove layer unpack directory", "dir", unpackDir, "error", err)
+		}
+		s.endLayerBuild()
+	}()
+
+	stats, err := unpackCachedLayer(ctx, s.paths, desc, unpackDir, layerArtifactOnDiskFormat())
+	if err != nil {
+		return nil, err
+	}
+	record, err := s.installLayerArtifact(ctx, desc, layerHex, unpackDir, stats)
+	if err != nil {
+		s.invalidateDiskUsageTotals()
+		return nil, err
+	}
+	s.invalidateDiskUsageTotals()
+	return record, nil
+}
+
+func (s *layerStore) installLayerArtifact(ctx context.Context, desc layerDescriptor, layerHex, unpackDir string, stats *unpackStats) (*layerArtifact, error) {
+	record := &layerArtifact{
+		SchemaVersion: layerRecordSchemaVersion,
+		Digest:        desc.Digest,
+		Encoding:      layerEncoding(desc.MediaType),
+		DiffID:        stats.diffID,
+		Format:        layerArtifactFormat(),
+		UnpackedBytes: stats.unpackedBytes,
+		CreatedAt:     time.Now(),
+	}
+
+	if err := installAtomically(layerArtifactPath(s.paths, layerHex), func(path string) error {
+		size, err := ExportRootfsWithContext(ctx, unpackDir, path, DefaultImageFormat)
+		if err != nil {
+			return err
+		}
+		record.SizeBytes = size
+		record.ArtifactDigest, err = fileSHA256(ctx, path)
+		return err
+	}); err != nil {
+		return nil, fmt.Errorf("install layer artifact %s: %w", desc.Digest, err)
+	}
+
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal layer record: %w", err)
+	}
+	if err := writeJSONAtomic(layerArtifactRecordPath(s.paths, layerHex), data); err != nil {
+		_ = os.Remove(layerArtifactPath(s.paths, layerHex))
+		return nil, fmt.Errorf("write layer record: %w", err)
+	}
+	return record, nil
+}
+
+type unpackStats struct {
+	unpackedBytes int64
+	diffID        string
+	blobDigest    string // sha256 of the compressed bytes as read
+}
+
+func fileSHA256(ctx context.Context, path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, contextReader{ctx: ctx, reader: file}); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("sha256:%x", hash.Sum(nil)), nil
+}
+
+// contextReader fails reads once ctx is done so a cancelled caller stops a
+// long extraction instead of running it to completion.
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r contextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(p)
+}
+
+// unpackCachedLayer locates desc's blob in the shared OCI cache, unpacks it
+// into dest, and verifies both the blob digest and the diff ID when the
+// descriptor carries one. The caller must have validated desc.Digest.
+func unpackCachedLayer(ctx context.Context, p *paths.Paths, desc layerDescriptor, dest string, onDisk layer.OnDiskFormat) (*unpackStats, error) {
+	blobPath := p.OCICacheBlob(strings.TrimPrefix(desc.Digest, "sha256:"))
+	if _, err := os.Stat(blobPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("layer blob missing from oci cache: %s", desc.Digest)
+		}
+		return nil, fmt.Errorf("stat layer blob: %w", err)
+	}
+	stats, err := unpackLayerBlob(ctx, blobPath, desc.MediaType, dest, onDisk)
+	if err != nil {
+		return nil, fmt.Errorf("unpack layer %s: %w", desc.Digest, err)
+	}
+	if desc.Digest != "" && stats.blobDigest != desc.Digest {
+		return nil, fmt.Errorf("layer blob digest mismatch: got %s, want %s", stats.blobDigest, desc.Digest)
+	}
+	if desc.DiffID != "" && stats.diffID != desc.DiffID {
+		return nil, fmt.Errorf("layer %s diff id mismatch: got %s, want %s", desc.Digest, stats.diffID, desc.DiffID)
+	}
+	return stats, nil
+}
+
+// unpackLayerBlob extracts one compressed layer blob into dest with umoci,
+// which confines every entry to dest and interprets whiteouts per onDisk.
+// The compressed stream is hashed to verify the blob digest, the decompressed
+// stream for the diff ID, and capped in size.
+func unpackLayerBlob(ctx context.Context, blobPath, mediaType, dest string, onDisk layer.OnDiskFormat) (*unpackStats, error) {
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return nil, fmt.Errorf("create extraction root: %w", err)
+	}
+	blob, err := os.Open(blobPath)
+	if err != nil {
+		return nil, fmt.Errorf("open blob: %w", err)
+	}
+	defer blob.Close()
+
+	blobHash := sha256.New()
+	compressed := io.TeeReader(contextReader{ctx: ctx, reader: blob}, blobHash)
+	reader, closer, err := decompressLayer(compressed, mediaType)
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+
+	hash := sha256.New()
+	limited := &io.LimitedReader{R: contextReader{ctx: ctx, reader: reader}, N: maxLayerUnpackedBytes + 1}
+	hashed := io.TeeReader(limited, hash)
+	if err := layer.UnpackLayer(dest, hashed, &layer.UnpackOptions{OnDiskFormat: onDisk}); err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(io.Discard, hashed); err != nil {
+		return nil, fmt.Errorf("drain layer: %w", err)
+	}
+	if _, err := io.Copy(io.Discard, compressed); err != nil {
+		return nil, fmt.Errorf("drain blob: %w", err)
+	}
+	if limited.N == 0 {
+		return nil, fmt.Errorf("layer exceeds maximum unpacked size of %d bytes", maxLayerUnpackedBytes)
+	}
+	return &unpackStats{
+		unpackedBytes: maxLayerUnpackedBytes + 1 - limited.N,
+		diffID:        fmt.Sprintf("sha256:%x", hash.Sum(nil)),
+		blobDigest:    fmt.Sprintf("sha256:%x", blobHash.Sum(nil)),
+	}, nil
+}
+
+// decompressLayer wraps the blob in the reader for its layer media type. Both
+// OCI-style suffixes (+gzip, +zstd) and docker-style media types (tar.gzip,
+// tar.zstd) are matched so neither encoding falls through to the raw path.
+func decompressLayer(r io.Reader, mediaType string) (io.Reader, io.Closer, error) {
+	switch layerEncoding(mediaType) {
+	case "zstd":
+		decoder, err := zstd.NewReader(r)
+		if err != nil {
+			return nil, nil, fmt.Errorf("zstd reader: %w", err)
+		}
+		decodeCloser := decoder.IOReadCloser()
+		return decodeCloser, decodeCloser, nil
+	case "gzip":
+		gz, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, nil, fmt.Errorf("gzip reader: %w", err)
+		}
+		return gz, gz, nil
+	default:
+		return r, io.NopCloser(r), nil
+	}
+}
+
+// removePath removes a tree that may contain read-only directories restored
+// from layer metadata.
+func removePath(path string) error {
+	if err := os.RemoveAll(path); err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	if err := makeTreeWritable(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func makeTreeWritable(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+	if err := os.Chmod(path, info.Mode().Perm()|0700); err != nil {
+		return err
+	}
+	return filepath.WalkDir(path, func(p string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() && entry.Type()&os.ModeSymlink == 0 {
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			return os.Chmod(p, info.Mode().Perm()|0700)
+		}
+		return nil
+	})
+}

--- a/lib/images/layer_artifact_smoke_test.go
+++ b/lib/images/layer_artifact_smoke_test.go
@@ -1,0 +1,126 @@
+package images
+
+import (
+	"archive/tar"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
+)
+
+// Smoke tests for layer-artifact edge cases beyond the standard suite.
+// Media types, path validation, singleflight sharing, and device/fifo
+// entries (root only).
+
+const (
+	ociZstdMediaType     = "application/vnd.oci.image.layer.v1.tar+zstd"
+	dockerZstdMediaType  = "application/vnd.docker.image.rootfs.diff.tar.zstd"
+	dockerGzipMediaType  = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	ociPlainTarMediaType = "application/vnd.oci.image.layer.v1.tar"
+)
+
+func TestSmokeUnpackZstdMediaTypes(t *testing.T) {
+	root := t.TempDir()
+	for name, tc := range map[string]struct {
+		mediaType string
+		blob      string
+	}{
+		"oci_suffix_zstd":   {ociZstdMediaType, writeZstdTarLayer(t, root, "oci.tar.zst", fileEntry("f.txt", "zstd"))},
+		"docker_tar_zstd":   {dockerZstdMediaType, writeZstdTarLayer(t, root, "docker.tar.zstd", fileEntry("f.txt", "zstd"))},
+		"docker_tar_gzip":   {dockerGzipMediaType, writeLayerBlob(t, root, "docker.tar.gz", fileEntry("f.txt", "gzip"))},
+		"plain_tar":         {ociPlainTarMediaType, writeRawTarLayer(t, root, "plain.tar", fileEntry("f.txt", "raw"))},
+		"unknown_media_raw": {"application/vnd.custom.tar", writeRawTarLayer(t, root, "custom.tar", fileEntry("f.txt", "raw"))},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dest := filepath.Join(root, t.Name())
+			stats, err := unpackLayerBlob(context.Background(), tc.blob, tc.mediaType, dest, composeOnDiskFormat())
+			require.NoError(t, err)
+			require.Greater(t, stats.unpackedBytes, int64(0))
+			require.FileExists(t, filepath.Join(dest, "f.txt"))
+		})
+	}
+}
+
+func TestSmokeRejectsBadLayerHex(t *testing.T) {
+	p := paths.New(t.TempDir())
+	m := testLayerArtifactManager(p)
+	for _, digest := range []string{
+		"sha256:..",
+		"sha256:../escape",
+		"sha256:a/b",
+		"sha256:",
+	} {
+		_, err := m.materializeLayerArtifact(context.Background(), layerDescriptor{
+			Digest:    digest,
+			MediaType: testTarGzMediaType,
+		})
+		require.ErrorContains(t, err, "invalid layer digest", "digest %q must be rejected", digest)
+	}
+	require.NoDirExists(t, filepath.Join(p.ImageLayersDir(), "..", "layers-escape"))
+
+	_, err := m.materializeLayerArtifact(context.Background(), layerDescriptor{
+		Digest:    "notadigest",
+		MediaType: testTarGzMediaType,
+	})
+	require.ErrorContains(t, err, "invalid layer digest")
+}
+
+func TestSmokeConcurrentMaterializeSharesFlight(t *testing.T) {
+	p, m, desc := layerArtifactFixture(t, FormatExt4)
+
+	const callers = 8
+	records := make([]*layerArtifact, callers)
+	start := time.Now()
+	group, groupCtx := errgroup.WithContext(context.Background())
+	for i := 0; i < callers; i++ {
+		group.Go(func() error {
+			record, err := m.materializeLayerArtifact(groupCtx, desc)
+			records[i] = record
+			return err
+		})
+	}
+	require.NoError(t, group.Wait())
+	for i := range records {
+		require.Equal(t, records[0], records[i], "all callers must share one build result")
+	}
+	t.Logf("8 callers finished in %s sharing one flight", time.Since(start))
+	layerHex := desc.Digest[len("sha256:"):]
+	require.FileExists(t, p.ImageLayerArtifactForFormat(layerHex, layerArtifactFormat()))
+}
+
+func TestSmokeDeviceAndFifoEntries(t *testing.T) {
+	if !probeLayerArtifactSupport(t.TempDir()) {
+		t.Skip("device and fifo tar entries need mknod")
+	}
+	root := t.TempDir()
+	blob := writeRawTarLayer(t, root, "devices.tar",
+		fileEntry("regular.txt", "x"),
+		func(t *testing.T, tw *tar.Writer) {
+			require.NoError(t, tw.WriteHeader(&tar.Header{
+				Name: "dev/null", Typeflag: tar.TypeChar,
+				Devmajor: 1, Devminor: 3, Mode: 0666,
+			}))
+		},
+		func(t *testing.T, tw *tar.Writer) {
+			require.NoError(t, tw.WriteHeader(&tar.Header{
+				Name: "pipes/fifo", Typeflag: tar.TypeFifo, Mode: 0644,
+			}))
+		},
+	)
+	dest := filepath.Join(root, "dest")
+	_, err := unpackLayerBlob(context.Background(), blob, ociPlainTarMediaType, dest, composeOnDiskFormat())
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(dest, "regular.txt"))
+	var stat unix.Stat_t
+	require.NoError(t, unix.Lstat(filepath.Join(dest, "dev", "null"), &stat))
+	require.Equal(t, uint32(unix.S_IFCHR), stat.Mode&unix.S_IFMT)
+	require.Equal(t, uint64(0x103), uint64(stat.Rdev), "char device 1:3")
+	require.NoError(t, unix.Lstat(filepath.Join(dest, "pipes", "fifo"), &stat))
+	require.Equal(t, uint32(unix.S_IFIFO), stat.Mode&unix.S_IFMT)
+}

--- a/lib/images/layer_artifact_test.go
+++ b/lib/images/layer_artifact_test.go
@@ -1,0 +1,487 @@
+package images
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gcr "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/kernel/hypeman/lib/paths"
+	"github.com/klauspost/compress/zstd"
+	"github.com/opencontainers/umoci/oci/layer"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// whiteoutPrefix marks OCI whiteout entries (".wh.<name>" and ".wh..wh..opq").
+// umoci interprets them during extraction: composeOnDiskFormat applies them
+// against the tree being composed, layerArtifactOnDiskFormat converts them to
+// overlayfs whiteout inodes and opaque xattrs so per-layer artifacts can
+// later be stacked.
+const whiteoutPrefix = ".wh."
+
+// composeOnDiskFormat applies whiteouts against the tree being composed. It
+// belongs to the composition flow and moves to production with that change.
+func composeOnDiskFormat() layer.OnDiskFormat {
+	return layer.DirRootfs{MapOptions: layerMapOptions()}
+}
+
+const testTarGzMediaType = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+// writeLayerTestLayout writes img into the shared OCI cache of p tagged with
+// the image's digest, mirroring pullToOCILayout.
+func testLayerArtifactManager(p *paths.Paths) *manager {
+	store := newLayerStore(p, 1)
+	store.artifactsSupported = true
+	return &manager{paths: p, layers: store}
+}
+
+func writeLayerTestLayout(t *testing.T, p *paths.Paths, img gcr.Image) {
+	t.Helper()
+	digest, err := img.Digest()
+	require.NoError(t, err)
+	layoutPath, err := layout.Write(p.SystemOCICache(), empty.Index)
+	require.NoError(t, err)
+	require.NoError(t, layoutPath.AppendImage(img, layout.WithAnnotations(map[string]string{
+		"org.opencontainers.image.ref.name": digestToLayoutTag(digest.String()),
+	})))
+}
+
+func layerDescFromImage(t *testing.T, img gcr.Image, index int) layerDescriptor {
+	t.Helper()
+	manifest, err := img.Manifest()
+	require.NoError(t, err)
+	configFile, err := img.ConfigFile()
+	require.NoError(t, err)
+	layer := manifest.Layers[index]
+	return layerDescriptor{
+		Digest:    layer.Digest.String(),
+		Size:      layer.Size,
+		MediaType: string(layer.MediaType),
+		DiffID:    configFile.RootFS.DiffIDs[index].String(),
+	}
+}
+
+// tarGz builds a gzipped tar from the entries written by fn.
+func tarGz(t *testing.T, fn func(tw *tar.Writer)) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	fn(tw)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+	return buf.Bytes()
+}
+
+func writeTarEntry(t *testing.T, tw *tar.Writer, header *tar.Header, content string) {
+	t.Helper()
+	if header.Typeflag == tar.TypeReg {
+		header.Size = int64(len(content))
+	}
+	require.NoError(t, tw.WriteHeader(header))
+	if content != "" {
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+}
+
+func fileEntry(name, content string) func(*testing.T, *tar.Writer) {
+	return func(t *testing.T, tw *tar.Writer) {
+		writeTarEntry(t, tw, &tar.Header{Name: name, Typeflag: tar.TypeReg, Mode: 0644}, content)
+	}
+}
+
+func dirEntry(name string) func(*testing.T, *tar.Writer) {
+	return func(t *testing.T, tw *tar.Writer) {
+		writeTarEntry(t, tw, &tar.Header{Name: name, Typeflag: tar.TypeDir, Mode: 0755}, "")
+	}
+}
+
+func symlinkEntry(name, target string) func(*testing.T, *tar.Writer) {
+	return func(t *testing.T, tw *tar.Writer) {
+		writeTarEntry(t, tw, &tar.Header{Name: name, Typeflag: tar.TypeSymlink, Linkname: target}, "")
+	}
+}
+
+func hardlinkEntry(name, target string) func(*testing.T, *tar.Writer) {
+	return func(t *testing.T, tw *tar.Writer) {
+		writeTarEntry(t, tw, &tar.Header{Name: name, Typeflag: tar.TypeLink, Linkname: target}, "")
+	}
+}
+
+// writeLayerBlob writes a gzipped tar layer to a file and returns its path.
+func writeLayerBlob(t *testing.T, dir, name string, entries ...func(*testing.T, *tar.Writer)) string {
+	t.Helper()
+	data := tarGz(t, func(tw *tar.Writer) {
+		for _, entry := range entries {
+			entry(t, tw)
+		}
+	})
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, data, 0644))
+	return path
+}
+
+func writeRawTarLayer(t *testing.T, dir, name string, entries ...func(*testing.T, *tar.Writer)) string {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, entry := range entries {
+		entry(t, tw)
+	}
+	require.NoError(t, tw.Close())
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0644))
+	return path
+}
+
+func writeZstdTarLayer(t *testing.T, dir, name string, entries ...func(*testing.T, *tar.Writer)) string {
+	t.Helper()
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	for _, entry := range entries {
+		entry(t, tw)
+	}
+	require.NoError(t, tw.Close())
+	var zstBuf bytes.Buffer
+	zw, err := zstd.NewWriter(&zstBuf)
+	require.NoError(t, err)
+	_, err = zw.Write(tarBuf.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, zstBuf.Bytes(), 0644))
+	return path
+}
+
+// unpackInto applies a layer blob onto dest with compose semantics.
+func unpackInto(t *testing.T, blobPath, dest string) *unpackStats {
+	t.Helper()
+	stats, err := unpackLayerBlob(context.Background(), blobPath, testTarGzMediaType, dest, composeOnDiskFormat())
+	require.NoError(t, err)
+	return stats
+}
+
+func requireNoWhiteoutMarkers(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		require.NoError(t, err)
+		require.NotContains(t, entry.Name(), whiteoutPrefix, "whiteout marker leaked into tree")
+		return nil
+	}))
+}
+
+// layerArtifactFixture builds a manager over a temp data dir holding one layer
+// in the shared OCI cache, with DefaultImageFormat set to format. It skips
+// unless the host has the formatter for that format.
+func layerArtifactFixture(t *testing.T, format ExportFormat) (*paths.Paths, *manager, layerDescriptor) {
+	t.Helper()
+	binary := "mkfs.erofs"
+	if format == FormatExt4 {
+		binary = "mkfs.ext4"
+	}
+	if _, err := exec.LookPath(binary); err != nil {
+		t.Skipf("%s not available", binary)
+	}
+	originalFormat := DefaultImageFormat
+	DefaultImageFormat = format
+	t.Cleanup(func() { DefaultImageFormat = originalFormat })
+
+	p := paths.New(t.TempDir())
+	img, err := mutate.AppendLayers(empty.Image, syntheticLayer(t, "base.txt", "base layer content"))
+	require.NoError(t, err)
+	writeLayerTestLayout(t, p, img)
+	return p, testLayerArtifactManager(p), layerDescFromImage(t, img, 0)
+}
+
+func TestMaterializeLayerArtifact(t *testing.T) {
+	p, m, desc := layerArtifactFixture(t, FormatErofs)
+
+	record, err := m.materializeLayerArtifact(context.Background(), desc)
+	require.NoError(t, err)
+	require.Equal(t, desc.Digest, record.Digest)
+	require.Equal(t, desc.DiffID, record.DiffID)
+	require.Equal(t, layerArtifactFormat(), record.Format)
+	require.Greater(t, record.SizeBytes, int64(0))
+	require.Greater(t, record.UnpackedBytes, int64(0))
+
+	layerHex := desc.Digest[len("sha256:"):]
+	artifactPath := p.ImageLayerArtifactForFormat(layerHex, layerArtifactFormat())
+	artifactInfo, err := os.Stat(artifactPath)
+	require.NoError(t, err, "layer.erofs must be installed")
+
+	// A second materialization reuses the existing artifact.
+	reused, err := m.materializeLayerArtifact(context.Background(), desc)
+	require.NoError(t, err)
+	require.True(t, record.CreatedAt.Equal(reused.CreatedAt), "reuse must return the stored record")
+	artifactInfoAfter, err := os.Stat(p.ImageLayerArtifactForFormat(layerHex, layerArtifactFormat()))
+	require.NoError(t, err)
+	require.Equal(t, artifactInfo.ModTime(), artifactInfoAfter.ModTime(), "reuse must not rebuild")
+
+	// A truncated artifact must not be reused just because its record is valid.
+	require.NoError(t, os.Truncate(artifactPath, 0))
+	rebuilt, err := m.materializeLayerArtifact(context.Background(), desc)
+	require.NoError(t, err)
+	require.NotEqual(t, reused.CreatedAt, rebuilt.CreatedAt, "invalid artifact must rebuild")
+	rebuiltInfo, err := os.Stat(artifactPath)
+	require.NoError(t, err)
+	require.Equal(t, rebuilt.SizeBytes, rebuiltInfo.Size())
+
+	// A same-size mutation must not be reused.
+	file, err := os.OpenFile(artifactPath, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	_, err = file.WriteAt([]byte{0}, 0)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	rebuiltAgain, err := m.materializeLayerArtifact(context.Background(), desc)
+	require.NoError(t, err)
+	// A missing artifact must be rebuilt even though its record is intact.
+	require.NoError(t, os.Remove(artifactPath))
+	restored, err := m.materializeLayerArtifact(context.Background(), desc)
+	require.NoError(t, err)
+	require.NotEqual(t, rebuiltAgain.CreatedAt, restored.CreatedAt, "missing artifact must rebuild")
+	require.FileExists(t, artifactPath)
+}
+
+func TestMaterializeLayerArtifactRecoversCorruptRecord(t *testing.T) {
+	p, m, desc := layerArtifactFixture(t, FormatExt4)
+
+	first, err := m.materializeLayerArtifact(context.Background(), desc)
+	require.NoError(t, err)
+
+	layerHex := desc.Digest[len("sha256:"):]
+	require.NoError(t, os.WriteFile(
+		p.ImageLayerRecordForFormat(layerHex, layerArtifactFormat()),
+		[]byte("{not valid json"),
+		0600,
+	))
+
+	second, err := m.materializeLayerArtifact(context.Background(), desc)
+	require.NoError(t, err)
+	require.NotEqual(t, first.CreatedAt, second.CreatedAt, "corrupt record must trigger a rebuild")
+	require.FileExists(t, p.ImageLayerArtifactForFormat(layerHex, layerArtifactFormat()))
+
+	data, err := os.ReadFile(p.ImageLayerRecordForFormat(layerHex, layerArtifactFormat()))
+	require.NoError(t, err)
+	var record layerArtifact
+	require.NoError(t, json.Unmarshal(data, &record))
+	require.NoError(t, record.validate())
+}
+
+// TestMaterializeLayerArtifactOutlivesCancelledCaller checks that a caller
+// abandoning a shared build does not abort the build for everyone else: the
+// artifact still lands even though the initiating context was cancelled.
+func TestMaterializeLayerArtifactOutlivesCancelledCaller(t *testing.T) {
+	p, m, desc := layerArtifactFixture(t, FormatExt4)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// The build usually loses the race against the cancelled context, but a
+	// fast build can finish first; either outcome is valid when detached.
+	if _, buildErr := m.materializeLayerArtifact(ctx, desc); buildErr != nil {
+		require.ErrorIs(t, buildErr, context.Canceled)
+	}
+
+	layerHex := desc.Digest[len("sha256:"):]
+	require.Eventually(t, func() bool {
+		record, err := readLayerRecord(p, layerHex)
+		return err == nil && record != nil
+	}, 30*time.Second, 50*time.Millisecond, "detached build must still install the artifact")
+	require.FileExists(t, p.ImageLayerArtifactForFormat(layerHex, layerArtifactFormat()))
+}
+
+func TestMaterializeLayerArtifactRejectsUnsupportedHost(t *testing.T) {
+	p := paths.New(t.TempDir())
+	store := newLayerStore(p, 1)
+	store.artifactsSupported = false
+	m := &manager{paths: p, layers: store}
+	_, err := m.materializeLayerArtifact(context.Background(), layerDescriptor{
+		Digest:    "sha256:" + strings.Repeat("ab", 32),
+		MediaType: testTarGzMediaType,
+	})
+	require.ErrorContains(t, err, "unsupported on this host")
+}
+
+func TestMaterializeLayerArtifactMissingBlob(t *testing.T) {
+	_, m, _ := layerArtifactFixture(t, FormatErofs)
+
+	_, err := m.materializeLayerArtifact(context.Background(), layerDescriptor{
+		Digest:    "sha256:abababababababababababababababababababababababababababababababab",
+		MediaType: testTarGzMediaType,
+	})
+	require.ErrorContains(t, err, "missing from oci cache")
+}
+
+// TestUnpackLayerBlobArtifactFormatKeepsWhiteouts checks that the artifact
+// extraction format records deletions in overlayfs form: a 0:0 character
+// device for a whiteout and the opaque xattr for an opaque directory.
+func TestUnpackLayerBlobArtifactFormatKeepsWhiteouts(t *testing.T) {
+	if !probeLayerArtifactSupport(t.TempDir()) {
+		t.Skip("overlayfs whiteouts need mknod and trusted xattrs")
+	}
+	root := t.TempDir()
+	blob := writeLayerBlob(t, root, "layer.tar.gz",
+		fileEntry("keep.txt", "keep"),
+		dirEntry("gone/"),
+		fileEntry("gone/.wh.deleted.txt", ""),
+		dirEntry("opq/"),
+		fileEntry("opq/.wh..wh..opq", ""),
+		fileEntry("opq/fresh.txt", "fresh"),
+	)
+	dest := filepath.Join(root, "dest")
+	_, err := unpackLayerBlob(context.Background(), blob, testTarGzMediaType, dest, layerArtifactOnDiskFormat())
+	require.NoError(t, err)
+
+	var stat unix.Stat_t
+	require.NoError(t, unix.Lstat(filepath.Join(dest, "gone", "deleted.txt"), &stat))
+	require.Equal(t, uint32(unix.S_IFCHR), stat.Mode&unix.S_IFMT, "whiteout must be a character device")
+	require.Equal(t, uint64(0), uint64(stat.Rdev), "whiteout device must be 0:0")
+
+	value := make([]byte, 8)
+	n, err := unix.Lgetxattr(filepath.Join(dest, "opq"), "trusted.overlay.opaque", value)
+	require.NoError(t, err)
+	require.Equal(t, "y", string(value[:n]))
+	requireNoWhiteoutMarkers(t, dest)
+}
+
+func TestUnpackLayerBlobAppliesWhiteoutsAcrossLayers(t *testing.T) {
+	root := t.TempDir()
+	base := writeLayerBlob(t, root, "base.tar.gz",
+		dirEntry("etc/"),
+		fileEntry("etc/config.txt", "original"),
+		dirEntry("data/"),
+		fileEntry("data/old.txt", "stale"),
+		dirEntry("replacedir/"),
+		fileEntry("replacedir/inner.txt", "inner"),
+		fileEntry("added/foo", "old"),
+	)
+	top := writeLayerBlob(t, root, "top.tar.gz",
+		fileEntry("etc/.wh.config.txt", ""),
+		fileEntry("data/.wh..wh..opq", ""),
+		fileEntry("data/new.txt", "new"),
+		fileEntry("replacedir", "now a file"),
+		fileEntry("added/.wh.foo", ""),
+		fileEntry("added/foo", "new"),
+	)
+	dest := filepath.Join(root, "dest")
+	unpackInto(t, base, dest)
+	unpackInto(t, top, dest)
+
+	_, err := os.Lstat(filepath.Join(dest, "etc", "config.txt"))
+	require.True(t, os.IsNotExist(err), "whiteout must delete the lower entry")
+	_, err = os.Lstat(filepath.Join(dest, "data", "old.txt"))
+	require.True(t, os.IsNotExist(err), "opaque marker must mask lower contents")
+	data, err := os.ReadFile(filepath.Join(dest, "data", "new.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "new", string(data))
+	info, err := os.Lstat(filepath.Join(dest, "replacedir"))
+	require.NoError(t, err)
+	require.False(t, info.IsDir(), "file must replace lower directory")
+	data, err = os.ReadFile(filepath.Join(dest, "added", "foo"))
+	require.NoError(t, err)
+	require.Equal(t, "new", string(data), "whiteout then recreate in one layer keeps the new file")
+	requireNoWhiteoutMarkers(t, dest)
+}
+
+// TestUnpackLayerBlobReplacesDirectorySymlink checks the standard runtime
+// behavior: a directory in an upper layer replaces a symlink from a lower one
+// rather than writing through it.
+func TestUnpackLayerBlobReplacesDirectorySymlink(t *testing.T) {
+	root := t.TempDir()
+	base := writeLayerBlob(t, root, "base.tar.gz",
+		dirEntry("usr/"),
+		dirEntry("usr/bin/"),
+		fileEntry("usr/bin/sh", "sh"),
+		symlinkEntry("bin", "usr/bin"),
+	)
+	top := writeLayerBlob(t, root, "top.tar.gz",
+		dirEntry("bin/"),
+		fileEntry("bin/tool", "tool"),
+	)
+	dest := filepath.Join(root, "dest")
+	unpackInto(t, base, dest)
+	unpackInto(t, top, dest)
+
+	info, err := os.Lstat(filepath.Join(dest, "bin"))
+	require.NoError(t, err)
+	require.True(t, info.IsDir(), "upper directory must replace the lower symlink")
+	require.FileExists(t, filepath.Join(dest, "bin", "tool"))
+	require.FileExists(t, filepath.Join(dest, "usr", "bin", "sh"))
+	require.NoFileExists(t, filepath.Join(dest, "usr", "bin", "tool"))
+}
+
+func TestUnpackLayerBlobConfinesSymlinkTraversal(t *testing.T) {
+	root := t.TempDir()
+	blob := writeLayerBlob(t, root, "layer.tar.gz",
+		symlinkEntry("link", "../../escape"),
+		fileEntry("link/pwned", "x"),
+	)
+	dest := filepath.Join(root, "dest")
+	unpackInto(t, blob, dest)
+
+	require.NoFileExists(t, filepath.Join(root, "escape", "pwned"))
+	require.FileExists(t, filepath.Join(dest, "escape", "pwned"), "escaping link must be resolved inside the root")
+}
+
+func TestUnpackLayerBlobPreservesHardlinks(t *testing.T) {
+	root := t.TempDir()
+	blob := writeLayerBlob(t, root, "layer.tar.gz",
+		fileEntry("a", "shared"),
+		hardlinkEntry("b", "a"),
+	)
+	dest := filepath.Join(root, "dest")
+	unpackInto(t, blob, dest)
+
+	a, err := os.Stat(filepath.Join(dest, "a"))
+	require.NoError(t, err)
+	b, err := os.Stat(filepath.Join(dest, "b"))
+	require.NoError(t, err)
+	require.True(t, os.SameFile(a, b))
+}
+
+func TestUnpackLayerBlobContextHonorsCancellation(t *testing.T) {
+	root := t.TempDir()
+	blob := writeLayerBlob(t, root, "layer.tar.gz", fileEntry("file", "x"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := unpackLayerBlob(ctx, blob, testTarGzMediaType, filepath.Join(root, "dest"), composeOnDiskFormat())
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestUnpackLayerBlobIncludesTrailingTarPaddingInDiffID(t *testing.T) {
+	root := t.TempDir()
+	var tarData bytes.Buffer
+	tw := tar.NewWriter(&tarData)
+	writeTarEntry(t, tw, &tar.Header{Name: "file", Typeflag: tar.TypeReg, Mode: 0644}, "x")
+	require.NoError(t, tw.Close())
+	_, err := tarData.Write(make([]byte, 512))
+	require.NoError(t, err)
+
+	var compressed bytes.Buffer
+	gzw := gzip.NewWriter(&compressed)
+	_, err = gzw.Write(tarData.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, gzw.Close())
+	blob := filepath.Join(root, "layer.tar.gz")
+	require.NoError(t, os.WriteFile(blob, compressed.Bytes(), 0644))
+
+	stats := unpackInto(t, blob, filepath.Join(root, "dest"))
+	want := sha256.Sum256(tarData.Bytes())
+	require.Equal(t, "sha256:"+fmt.Sprintf("%x", want), stats.diffID)
+	require.Equal(t, int64(tarData.Len()), stats.unpackedBytes)
+}

--- a/lib/images/layer_store.go
+++ b/lib/images/layer_store.go
@@ -1,0 +1,35 @@
+package images
+
+import (
+	"sync"
+
+	"github.com/kernel/hypeman/lib/paths"
+	"golang.org/x/sync/singleflight"
+)
+
+// layerStore owns the state shared by layer materialization and accounting.
+// Keeping it separate from manager makes the layer-specific concurrency and
+// cache lifecycle explicit.
+type layerStore struct {
+	paths               *paths.Paths
+	flights             singleflight.Group
+	builds              chan struct{}
+	artifactsSupported  bool
+	diskUsageMu         sync.RWMutex
+	diskUsageGeneration uint64
+	activeBuilds        int
+	diskUsageLoaded     bool
+	readyImageBytes     int64
+	ociCacheBytes       int64
+}
+
+func newLayerStore(p *paths.Paths, maxConcurrentBuilds int) *layerStore {
+	if maxConcurrentBuilds < 1 {
+		maxConcurrentBuilds = 1
+	}
+	return &layerStore{
+		paths:              p,
+		builds:             make(chan struct{}, maxConcurrentBuilds),
+		artifactsSupported: probeLayerArtifactSupport(p.ImageLayersDir()),
+	}
+}

--- a/lib/images/manager.go
+++ b/lib/images/manager.go
@@ -55,7 +55,7 @@ type Manager interface {
 	// TotalImageBytes returns the total size of all ready images on disk.
 	// Used by the resource manager for disk capacity tracking.
 	TotalImageBytes(ctx context.Context) (int64, error)
-	// TotalOCICacheBytes returns the total size of the OCI layer cache.
+	// TotalOCICacheBytes returns the total size of the OCI and materialized layer caches.
 	// Used by the resource manager for disk capacity tracking.
 	TotalOCICacheBytes(ctx context.Context) (int64, error)
 	// WaitForReady blocks until the image identified by name reaches a terminal
@@ -75,12 +75,9 @@ type manager struct {
 	ociClient                  *ociClient
 	queue                      *queue.Queue
 	createMu                   sync.Mutex
-	diskUsageMu                sync.RWMutex
+	layers                     *layerStore
 	tagGenerations             map[string]uint64
 	requestedTags              map[string]string // newest pull's digest per requested tag
-	diskUsageLoaded            bool
-	readyImageBytes            int64
-	ociCacheBytes              int64
 	metrics                    *Metrics
 	inflightPulls              map[string]*inflightImagePull // keyed by digest
 	borrowedCredentialsTimeout time.Duration
@@ -98,8 +95,13 @@ func NewManager(p *paths.Paths, maxConcurrentBuilds int, meter metric.Meter) (Ma
 		return nil, fmt.Errorf("create oci client: %w", err)
 	}
 
+	if maxConcurrentBuilds < 1 {
+		maxConcurrentBuilds = 1
+	}
+	layers := newLayerStore(p, maxConcurrentBuilds)
 	m := &manager{
 		paths:                      p,
+		layers:                     layers,
 		ociClient:                  ociClient,
 		queue:                      queue.New(maxConcurrentBuilds),
 		inflightPulls:              make(map[string]*inflightImagePull),
@@ -594,7 +596,7 @@ func (m *manager) finalizeImage(ref *ResolvedRef, result *pullResult, diskSize i
 	if !m.claimRequestedTags(ref, meta) {
 		m.cleanupUnclaimedImage(ref)
 	}
-	m.refreshDiskUsageTotals()
+	m.layers.refreshDiskUsageTotals()
 	return nil
 }
 
@@ -807,7 +809,7 @@ func (m *manager) deleteDigestImage(repository, digestHex string) error {
 		return err
 	}
 	m.clearRequestedDigest(digestHex)
-	m.refreshDiskUsageTotals()
+	m.layers.refreshDiskUsageTotals()
 	return nil
 }
 
@@ -841,22 +843,22 @@ func (m *manager) deleteTaggedImage(repository, tag string) error {
 	if err := removeDigestIfUnreferenced(m.paths, repository, digestHex, true); err != nil {
 		return fmt.Errorf("delete orphaned digest %s: %w", digestHex, err)
 	}
-	m.refreshDiskUsageTotals()
+	m.layers.refreshDiskUsageTotals()
 	return nil
 }
 
 // TotalImageBytes returns the total size of all ready images on disk.
 func (m *manager) TotalImageBytes(ctx context.Context) (int64, error) {
-	readyImageBytes, _, err := m.getDiskUsageTotals()
+	readyImageBytes, _, err := m.layers.getDiskUsageTotals(ctx)
 	if err != nil {
 		return 0, err
 	}
 	return readyImageBytes, nil
 }
 
-// TotalOCICacheBytes returns the total size of the OCI layer cache.
+// TotalOCICacheBytes returns the total size of the OCI and materialized layer caches.
 func (m *manager) TotalOCICacheBytes(ctx context.Context) (int64, error) {
-	_, ociCacheBytes, err := m.getDiskUsageTotals()
+	_, ociCacheBytes, err := m.layers.getDiskUsageTotals(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/lib/images/oci.go
+++ b/lib/images/oci.go
@@ -641,6 +641,8 @@ func convertToOCIMediaType(mediaType string) string {
 		return v1.MediaTypeImageConfig
 	case "application/vnd.docker.image.rootfs.diff.tar.gzip":
 		return v1.MediaTypeImageLayerGzip
+	case "application/vnd.docker.image.rootfs.diff.tar.zstd":
+		return v1.MediaTypeImageLayerZstd
 	case "application/vnd.docker.image.rootfs.diff.tar":
 		return v1.MediaTypeImageLayer
 	default:

--- a/lib/images/tag.go
+++ b/lib/images/tag.go
@@ -92,7 +92,7 @@ func (m *manager) cleanupReplacedTag(ref *NormalizedRef, previousDigest, digestH
 	if err := removeDigestIfUnreferenced(m.paths, ref.Repository(), previousDigest, true); err != nil {
 		slog.Warn("failed to collect replaced image content", "repository", ref.Repository(), "digest", previousDigest, "error", err)
 	}
-	m.refreshDiskUsageTotals()
+	m.layers.refreshDiskUsageTotals()
 }
 
 func parseTagReferences(source, target string) (*NormalizedRef, *NormalizedRef, error) {

--- a/lib/images/tag_test.go
+++ b/lib/images/tag_test.go
@@ -54,7 +54,12 @@ func seedImage(t *testing.T, p *paths.Paths, repository, tag, digestHex string, 
 func newTagTestCase(t *testing.T) (*paths.Paths, *manager, string) {
 	t.Helper()
 	p := paths.New(t.TempDir())
-	return p, &manager{paths: p, tagGenerations: make(map[string]uint64), requestedTags: make(map[string]string)}, "docker.io/library/alpine"
+	return p, &manager{
+		paths:          p,
+		layers:         newLayerStore(p, 1),
+		tagGenerations: make(map[string]uint64),
+		requestedTags:  make(map[string]string),
+	}, "docker.io/library/alpine"
 }
 
 func requireTagResolvesTo(t *testing.T, p *paths.Paths, repository, tag, digest string) {

--- a/lib/paths/paths.go
+++ b/lib/paths/paths.go
@@ -177,6 +177,28 @@ func (p *Paths) ImageRepositoryTagSymlink(repository, tag string) string {
 	return filepath.Join(p.ImageRepositoriesDir(), repository, tag)
 }
 
+// ImageLayersDir returns the root directory of the per-layer artifact store.
+// Layer artifacts are content-addressed by the compressed layer blob digest.
+func (p *Paths) ImageLayersDir() string {
+	return filepath.Join(p.dataDir, "images", "layers")
+}
+
+// ImageLayerDir returns the artifact directory for one layer digest.
+func (p *Paths) ImageLayerDir(layerHex string) string {
+	return filepath.Join(p.ImageLayersDir(), layerHex)
+}
+
+// ImageLayerArtifactForFormat returns the path to a materialized layer artifact.
+func (p *Paths) ImageLayerArtifactForFormat(layerHex, format string) string {
+	return filepath.Join(p.ImageLayerDir(layerHex), "layer."+format)
+}
+
+// ImageLayerRecordForFormat returns the path to the artifact record for one
+// materialized layer and format.
+func (p *Paths) ImageLayerRecordForFormat(layerHex, format string) string {
+	return filepath.Join(p.ImageLayerDir(layerHex), "artifact."+format+".json")
+}
+
 // ImageDigestDir returns the directory for a specific image digest.
 func (p *Paths) ImageDigestDir(repository, digestHex string) string {
 	return filepath.Join(p.dataDir, "images", repository, digestHex)

--- a/lib/resources/disk.go
+++ b/lib/resources/disk.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/c2h5oh/datasize"
@@ -75,31 +76,35 @@ func (d *DiskResource) GetBreakdown(ctx context.Context) (*DiskBreakdown, error)
 	// Get image sizes
 	if d.imageLister != nil {
 		imageBytes, err := d.imageLister.TotalImageBytes(ctx)
-		if err == nil {
-			breakdown.Images = imageBytes
+		if err != nil {
+			return nil, fmt.Errorf("get image disk usage: %w", err)
 		}
+		breakdown.Images = imageBytes
 		ociCacheBytes, err := d.imageLister.TotalOCICacheBytes(ctx)
-		if err == nil {
-			breakdown.OCICache = ociCacheBytes
+		if err != nil {
+			return nil, fmt.Errorf("get OCI cache disk usage: %w", err)
 		}
+		breakdown.OCICache = ociCacheBytes
 	}
 
 	// Get volume sizes
 	if d.volumeLister != nil {
 		volumeBytes, err := d.volumeLister.TotalVolumeBytes(ctx)
-		if err == nil {
-			breakdown.Volumes = volumeBytes
+		if err != nil {
+			return nil, fmt.Errorf("get volume disk usage: %w", err)
 		}
+		breakdown.Volumes = volumeBytes
 	}
 
 	// Get overlay sizes from instances
 	if d.instanceLister != nil {
 		instances, err := d.instanceLister.ListInstanceAllocations(ctx)
-		if err == nil {
-			for _, inst := range instances {
-				if isActiveState(inst.State) {
-					breakdown.Overlays += inst.OverlayBytes + inst.VolumeOverlayBytes
-				}
+		if err != nil {
+			return nil, fmt.Errorf("get instance disk usage: %w", err)
+		}
+		for _, inst := range instances {
+			if isActiveState(inst.State) {
+				breakdown.Overlays += inst.OverlayBytes + inst.VolumeOverlayBytes
 			}
 		}
 	}

--- a/lib/resources/resource.go
+++ b/lib/resources/resource.go
@@ -90,7 +90,7 @@ type AllocationBreakdown struct {
 // DiskBreakdown shows disk usage by category.
 type DiskBreakdown struct {
 	Images   int64 `json:"images_bytes"`    // Exported rootfs disk files
-	OCICache int64 `json:"oci_cache_bytes"` // OCI layer cache (shared blobs)
+	OCICache int64 `json:"oci_cache_bytes"` // OCI blobs and materialized shared layers
 	Volumes  int64 `json:"volumes_bytes"`
 	Overlays int64 `json:"overlays_bytes"` // Rootfs overlays + volume overlays
 }
@@ -132,7 +132,7 @@ type InstanceAllocation struct {
 type ImageLister interface {
 	// TotalImageBytes returns the total size of all images on disk.
 	TotalImageBytes(ctx context.Context) (int64, error)
-	// TotalOCICacheBytes returns the total size of the OCI layer cache.
+	// TotalOCICacheBytes returns the total size of the OCI and materialized layer caches.
 	TotalOCICacheBytes(ctx context.Context) (int64, error)
 }
 

--- a/lib/resources/resource_test.go
+++ b/lib/resources/resource_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"testing"
 
@@ -14,10 +15,11 @@ import (
 // mockInstanceLister implements InstanceLister for testing
 type mockInstanceLister struct {
 	allocations []InstanceAllocation
+	err         error
 }
 
 func (m *mockInstanceLister) ListInstanceAllocations(ctx context.Context) ([]InstanceAllocation, error) {
-	return m.allocations, nil
+	return m.allocations, m.err
 }
 
 // mockImageLister implements ImageLister for testing
@@ -37,10 +39,11 @@ func (m *mockImageLister) TotalOCICacheBytes(ctx context.Context) (int64, error)
 // mockVolumeLister implements VolumeLister for testing
 type mockVolumeLister struct {
 	totalBytes int64
+	err        error
 }
 
 func (m *mockVolumeLister) TotalVolumeBytes(ctx context.Context) (int64, error) {
-	return m.totalBytes, nil
+	return m.totalBytes, m.err
 }
 
 func TestNewManager(t *testing.T) {
@@ -485,6 +488,23 @@ func TestDiskBreakdown_IncludesOCICacheAndVolumeOverlays(t *testing.T) {
 	assert.Equal(t, int64(100*1024*1024*1024), status.DiskDetail.Volumes)
 	// Overlays should be (10+5) + (8+2) = 25GB
 	assert.Equal(t, int64(25*1024*1024*1024), status.DiskDetail.Overlays)
+}
+
+func TestDiskBreakdownPropagatesVolumeAndInstanceErrors(t *testing.T) {
+	cfg := &config.Config{DataDir: t.TempDir(), Capacity: config.CapacityConfig{Disk: "100GB"}}
+	p := paths.New(cfg.DataDir)
+
+	volumeErr := errors.New("volume lookup failed")
+	disk, err := NewDiskResource(cfg, p, nil, nil, &mockVolumeLister{err: volumeErr})
+	require.NoError(t, err)
+	_, err = disk.GetBreakdown(context.Background())
+	require.ErrorIs(t, err, volumeErr)
+
+	instanceErr := errors.New("instance lookup failed")
+	disk, err = NewDiskResource(cfg, p, &mockInstanceLister{err: instanceErr}, nil, nil)
+	require.NoError(t, err)
+	_, err = disk.GetBreakdown(context.Background())
+	require.ErrorIs(t, err, instanceErr)
 }
 
 func TestValidateAllocation_Disk(t *testing.T) {


### PR DESCRIPTION
## tldr

Content-addressed per-layer artifact store at `images/layers/<layer-blob-digest>/`. Pulls and composition (next PR in the stack) share it. Native layer artifacts are Linux-root-only; rootless Linux and macOS use the merged-rootfs path instead, with no image-content change.

## what this adds

1. **Materialization** (`materializeLayerArtifact`) — unpacks a layer blob from the existing shared OCI cache with umoci, converts to erofs, installs `layer.erofs` + an `artifact.json` record atomically. Same layer shared across images materializes once; concurrent callers share one build (singleflight), with a manager-level concurrency bound.
2. **Whiteouts as overlayfs** — on supported Linux hosts, `.wh.<name>` becomes a `0:0` char device and `.wh..wh..opq` becomes a `trusted.overlay.opaque` xattr. This is the standard representation required by later overlayfs stacking; it is not attempted where the host cannot create it.
3. **Platform fallback contract** — a startup probe verifies Linux `mknod` and trusted overlay xattr support on the layer-store filesystem. Rootless Linux, macOS, and unsupported filesystems skip per-layer artifact materialization and compose OCI layers into one rootfs with `DirRootfs`, which applies whiteouts in userspace. This preserves image semantics while giving up per-layer sharing on those hosts.
4. **Hardened extraction** — umoci confines entries, blob digest + diff ID verified, stream capped at 100 GiB, detached builds bounded by a 1h deadline.
5. **Disk accounting** — the layer store, including records and in-progress extraction/install trees, is counted in `TotalOCICacheBytes` (conservative: blob + artifact of the same layer may transiently coexist). Active builds keep totals uncached, and disk-usage scans retry if invalidated while a scan is in progress.

## review status: done

Two independent review passes (correctness + code-quality). Findings and how they are handled:

- Hung blob read could wedge the singleflight key forever → 1h deadline on detached builds
- Cache blob integrity was never verified → unpack now checks the compressed digest
- Rootless/macOS whiteout extraction could not produce valid overlayfs artifacts → unsupported hosts now use the merged-rootfs fallback
- Disk-usage invalidation could return stale totals → scans retry after a concurrent invalidation
- Same-size artifact corruption was reusable → records now include and verify an artifact checksum
- Detached layer builds were unbounded across distinct digests → a manager-level semaphore limits them
- Compressed blob verification could miss decoder-unconsumed suffixes → the raw blob is hashed independently
- Layer-build cleanup could race disk accounting → cleanup completes before the build is marked inactive
- Conflicting descriptor encodings could share one artifact path → records store the normalized encoding and reject mismatches
- Dead/simplification cleanup: `composeOnDiskFormat` + `whiteoutPrefix` moved to tests, `multiCloser` deleted, blob path via `paths.OCICacheBlob`

Verified empirically on a dev host: `mkfs.erofs` 1.8.10 and `mkfs.ext4` both preserve whiteout char devices and opaque xattrs through `ExportRootfs` on the supported Linux-root path. Depends on host erofs-utils version; check it in the pull-integration PR.

## reviewer focus (3 things)

1. `layerBuildTimeout` = 1h is a judgment call — flag if hypeman has a convention for bounding background work
2. Unpack now hard-fails on blob digest mismatch — new error if any path intentionally writes unverified blobs
3. PR `#458` wires the store into production. It skips layer materialization on unsupported hosts and retains blob-based merged-rootfs composition as the fallback.

## validation

Full `lib/images` + `lib/paths` green on a rootless host; capability-gated whiteout/device tests pass or skip based on an actual `mknod` + trusted-xattr probe. Tests cover: materialize/reuse/rebuild, corrupt-record recovery, same-size artifact corruption, invalid digest rejection (`sha256:..`, `sha256:a/b`), whiteout/opaque output and cross-layer semantics, symlink confinement and replacement, hardlinks, cancellation, zstd + docker media types, concurrent singleflight (8 callers, one build), trailing-padding diff IDs. The exported erofs whiteout round trip moves to the composition PR, which is where the host erofs-utils version gets checked.

CI note: the `test` workflow is flaky on this branch — failures are unrelated integration tests (`TestEgressProxyRewritesHTTPSHeaders` timeout, docker/network tests needing `nginx:alpine`), failing before the latest commits too. Layer-artifact tests pass consistently.

## next step

Review the focus items above, then approve. PR `#458` is the production caller and lifecycle follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New layer unpack and filesystem materialization touches tar extraction and external mkfs tools; incorrect whiteout or path handling could affect future image composition, though pull behavior is unchanged until wired in.
> 
> **Overview**
> Introduces a **content-addressed per-layer artifact store** under `images/layers/<blob-digest>/`, keyed by compressed layer digest plus format (erofs/ext4). **`materializeLayerArtifact`** reads blobs from the existing OCI cache, unpacks with umoci into a temp dir, converts to the default disk format, and installs `layer.*` plus an `artifact.*.json` record atomically; duplicate work is deduped with **singleflight** and valid on-disk records are reused.
> 
> **Whiteouts** are modeled explicitly: artifact extraction uses umoci **`OverlayfsRootfs`** (character-device whiteouts and opaque xattrs) so stacked layers can be mounted later; compose-oriented unpacking uses **`DirRootfs`**. Layer unpack supports gzip/zstd, verifies diff IDs, caps unpacked size at 100 GiB, and honors **context cancellation** via a `contextReader` and **`CommandContext`** for `mkfs.erofs`.
> 
> **Disk accounting** now walks `layer.*` files (skipping `.unpack-*` temps) and folds that into **`TotalOCICacheBytes`** / resource admission alongside OCI blobs. New path helpers live in `lib/paths`. The materialization API is implemented and tested; production wiring is in follow-up PR `#458`, which skips it on unsupported hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ed10542efd0080115dac657b639703fc029953. Configure [here](https://cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



