### PR TITLE
Cancel superseded Test runs per branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,17 @@ on:
         required: false
         type: string
 
+# Every branch push triggers a full run and superseded runs used to keep
+# running, holding self-hosted slots that every repo on the shared pool
+# queues behind. Group by ref so a newer push cancels the older run for
+# that branch. main and workflow_dispatch runs get run_id, a unique group
+# each, because sharing a group is unsafe even with cancellation off:
+# GitHub cancels an existing pending run when a newer one enters the
+# group, which would drop a commit's only test signal.
+concurrency:
+  group: test-${{ (github.event_name == 'push' && github.ref != 'refs/heads/main') && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+
 # A slash-command dispatch supplies a fork repository and immutable commit SHA.
 # Normal push runs use the upstream repository and pushed ref.
 env:


### PR DESCRIPTION
Test runs on every push to every branch, and superseded runs kept running: pushing a stack of branches repeatedly can put dozens of full runs in flight at once, with only the newest per branch mattering. Since the linux test job runs on the shared self-hosted pool, the stale runs starve every other repo's CI (kernel/kernel jobs were queuing 30+ minutes behind one such burst).

This adds workflow-level concurrency grouped by ref with cancel-in-progress, so a newer push cancels the older run for that branch. Two deliberate exclusions:

- main pushes and workflow_dispatch (slash-command) runs get run_id as their group, one group per run. They are never cancelled, and never coalesced either: sharing a group is unsafe even with cancellation off, because GitHub cancels an existing pending run when a newer one enters the group, which would drop a commit's only test signal.
- The existing job-level concurrency on the macOS jobs is untouched; it still serializes access to the small mac runner pool across runs.

Note on rollout: push-event runs read the workflow file from the pushed commit, so this takes effect for a branch once it contains this change (i.e. after rebasing onto main). Runs already queued are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; no application code or runtime behavior is affected.
> 
> **Overview**
> Adds **workflow-level concurrency** to the Test workflow so rapid pushes on feature branches do not pile up full Linux self-hosted runs that block the shared runner pool.
> 
> For **push events on non-`main` refs**, runs share a concurrency group keyed by `github.ref`, with **`cancel-in-progress: true`**, so only the latest push per branch keeps testing. **`main` pushes** and **`workflow_dispatch`** (slash-command) runs use **`github.run_id`** as the group and are **not** cancelled—avoiding GitHub’s behavior where a new run in the same group can drop a pending run even when cancellation is disabled.
> 
> Existing **job-level concurrency** on the macOS jobs is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897e7b7d5fa98391b5766811f6b80237da34ae77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->