### PR TITLE
Pass the staging deploy owner downstream

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,4 +31,5 @@ jobs:
             --ref main \
             --field env=staging \
             --field ref="$HYPEMAN_REF" \
-            --field cli-version=latest
+            --field cli-version=latest \
+            --field triggered_by="${{ github.actor }}"


### PR DESCRIPTION
## Summary

- pass the actor from the Hypeman main-branch workflow to the infra deploy dispatch
- preserve the originating human when the downstream workflow runs through the GitHub App

Depends on kernel/infra#1163, which adds the `triggered_by` workflow input. Merge that PR first so the dispatch accepts the new field.

## Testing

- `actionlint .github/workflows/deploy-staging.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds an optional dispatch field; no application runtime or secrets handling changes.
> 
> **Overview**
> Staging deploys dispatched to **kernel/infra** now include **`triggered_by`** set to **`github.actor`**, so the downstream Ansible deploy run can record who kicked off the Hypeman main-branch deploy instead of only seeing the GitHub App identity.
> 
> The `gh workflow run` invocation gains one `--field` and a line-continuation fix on `cli-version=latest`. This pairs with **kernel/infra#1163**, which must accept the new input before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42ff81f899c691abb8f298ae3362e8107f63de48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->