### PR TITLE
Harden vGPU sentinel polling

### DIFF
--- a/lib/devices/GPU.md
+++ b/lib/devices/GPU.md
@@ -315,9 +315,12 @@ can overlap `quarantined_slots`; use `allocatable_slots` for admission.
 Below-threshold failures log at warn and increment
 `hypeman_instances_vgpu_sentinel_init_failures_total`; quarantines log at
 error and increment `hypeman_instances_vgpu_sentinel_quarantines_total`.
-`hypeman_instances_vgpu_quarantined_vfs` gauges the current count. A systemic
-guest/host driver mismatch can still quarantine every VF, so validate driver
-changes on a test host and alert on the failure counter.
+`hypeman_instances_vgpu_sentinel_checks_total` records checks by result
+(`ok`, `failed`, `unknown`, `rpc_error`, or `list_error`) so hosts that lose
+sentinel coverage are visible. `hypeman_instances_vgpu_quarantined_vfs`
+gauges the current count. A systemic guest/host driver mismatch can still
+quarantine every VF, so validate driver changes on a test host and alert on
+the failure counter.
 
 Detection requires the hypeman guest agent and a running instance: the state
 lives in the agent, so a wedge whose instance stops before the next poll (5s)

--- a/lib/instances/vgpu_sentinel.go
+++ b/lib/instances/vgpu_sentinel.go
@@ -11,12 +11,15 @@ import (
 	"github.com/kernel/hypeman/lib/devices"
 	"github.com/kernel/hypeman/lib/guest"
 	"github.com/kernel/hypeman/lib/logger"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
-	vgpuSentinelPollInterval = 5 * time.Second
-	vgpuSentinelPollTimeout  = 5 * time.Second
+	vgpuSentinelPollInterval       = 5 * time.Second
+	vgpuSentinelPollTimeout        = 5 * time.Second
+	vgpuSentinelMaxConcurrentPolls = 64
 )
 
 type vgpuSentinelTarget struct {
@@ -46,6 +49,7 @@ type VGPUSentinelController struct {
 	guestGPUInitStatus func(ctx context.Context, instanceID string) (guest.GPUInitState, string, error)
 	initFailures       metric.Int64Counter
 	quarantines        metric.Int64Counter
+	checks             metric.Int64Counter
 	discoverFramework  func() (devices.VGPUFramework, []devices.VirtualFunction, error)
 	probeErrLoggedAt   time.Time
 }
@@ -72,6 +76,13 @@ func NewVGPUSentinelController(manager Manager, meter metric.Meter, log *slog.Lo
 	quarantines, err := meter.Int64Counter(
 		"hypeman_instances_vgpu_sentinel_quarantines_total",
 		metric.WithDescription("Total VFs quarantined by the vGPU sentinel"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	checks, err := meter.Int64Counter(
+		"hypeman_instances_vgpu_sentinel_checks_total",
+		metric.WithDescription("Total vGPU sentinel checks by result"),
 	)
 	if err != nil {
 		return nil, err
@@ -119,6 +130,7 @@ func NewVGPUSentinelController(manager Manager, meter metric.Meter, log *slog.Lo
 		discoverFramework: devices.DiscoverVGPU,
 		initFailures:      initFailures,
 		quarantines:       quarantines,
+		checks:            checks,
 	}, nil
 }
 
@@ -169,12 +181,19 @@ func (c *VGPUSentinelController) probeVendorVFIO() (bool, error) {
 func (c *VGPUSentinelController) pollOnce(ctx context.Context) {
 	targets, err := c.store.listVGPUSentinelTargets(ctx)
 	if err != nil {
+		c.recordCheck(ctx, "list_error")
 		c.log.WarnContext(ctx, "vGPU sentinel failed to list instances", "error", err)
 		return
 	}
+	var group errgroup.Group
+	group.SetLimit(vgpuSentinelMaxConcurrentPolls)
 	for _, target := range targets {
-		c.pollTarget(ctx, target)
+		group.Go(func() error {
+			c.pollTarget(ctx, target)
+			return nil
+		})
 	}
+	_ = group.Wait()
 }
 
 func (c *VGPUSentinelController) pollTarget(ctx context.Context, target vgpuSentinelTarget) {
@@ -182,6 +201,7 @@ func (c *VGPUSentinelController) pollTarget(ctx context.Context, target vgpuSent
 	state, nvrm, err := c.guestGPUInitStatus(pollCtx, target.instanceID)
 	cancel()
 	if err != nil {
+		c.recordCheck(ctx, "rpc_error")
 		// The agent is unreachable whenever the instance is not running or
 		// still booting; the next tick polls again.
 		c.log.DebugContext(ctx, "vGPU sentinel cannot reach the guest agent",
@@ -190,10 +210,18 @@ func (c *VGPUSentinelController) pollTarget(ctx context.Context, target vgpuSent
 	}
 	switch state {
 	case guest.GPUInitState_GPU_INIT_STATE_FAILED:
+		c.recordCheck(ctx, "failed")
 		c.handleFailure(ctx, target, nvrm)
 	case guest.GPUInitState_GPU_INIT_STATE_OK:
+		c.recordCheck(ctx, "ok")
 		c.handleSuccess(ctx, target)
+	default:
+		c.recordCheck(ctx, "unknown")
 	}
+}
+
+func (c *VGPUSentinelController) recordCheck(ctx context.Context, result string) {
+	c.checks.Add(ctx, 1, metric.WithAttributes(attribute.String("result", result)))
 }
 
 // confirmAssignment rejects a report only when the instance now holds a

--- a/lib/instances/vgpu_sentinel_test.go
+++ b/lib/instances/vgpu_sentinel_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
+	otelmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 const testNVRMMessage = "NVRM: GPU 0000:e3:00.4: RmInitAdapter failed! (0x22:0x65:884)"
@@ -79,6 +81,7 @@ func newTestSentinelController(t *testing.T, store *fakeSentinelStore) (*VGPUSen
 		guestGPUInitStatus: guestReportsFailed,
 		initFailures:       counter,
 		quarantines:        counter,
+		checks:             counter,
 	}
 	return c, &reported
 }
@@ -131,6 +134,87 @@ func TestVGPUSentinelControllerSkipsUnreachableGuest(t *testing.T) {
 	c.pollOnce(context.Background())
 	assert.Empty(t, *reported)
 	assert.Empty(t, successes)
+}
+
+func TestVGPUSentinelControllerPollsTargetsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeSentinelStore{targets: []vgpuSentinelTarget{
+		{instanceID: "instance-1"},
+		{instanceID: "instance-2"},
+	}}
+	c, _ := newTestSentinelController(t, store)
+	started := make(chan struct{}, len(store.targets))
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	c.guestGPUInitStatus = func(context.Context, string) (guest.GPUInitState, string, error) {
+		started <- struct{}{}
+		<-release
+		return guest.GPUInitState_GPU_INIT_STATE_UNKNOWN, "", nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		c.pollOnce(context.Background())
+		close(done)
+	}()
+	for range store.targets {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("targets were not polled concurrently")
+		}
+	}
+	close(release)
+	released = true
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("poll did not finish")
+	}
+}
+
+func TestVGPUSentinelControllerRecordsCheckResults(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeSentinelStore{targets: []vgpuSentinelTarget{
+		{instanceID: "ok"},
+		{instanceID: "unknown"},
+		{instanceID: "unreachable"},
+	}}
+	c, _ := newTestSentinelController(t, store)
+	reader := otelmetric.NewManualReader()
+	provider := otelmetric.NewMeterProvider(otelmetric.WithReader(reader))
+	checks, err := provider.Meter("test").Int64Counter("hypeman_instances_vgpu_sentinel_checks_total")
+	require.NoError(t, err)
+	c.checks = checks
+	c.guestGPUInitStatus = func(_ context.Context, instanceID string) (guest.GPUInitState, string, error) {
+		switch instanceID {
+		case "ok":
+			return guest.GPUInitState_GPU_INIT_STATE_OK, "", nil
+		case "unknown":
+			return guest.GPUInitState_GPU_INIT_STATE_UNKNOWN, "", nil
+		default:
+			return guest.GPUInitState_GPU_INIT_STATE_UNKNOWN, "", errors.New("vsock dial failed")
+		}
+	}
+
+	c.pollOnce(context.Background())
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	metric := findMetric(t, rm, "hypeman_instances_vgpu_sentinel_checks_total")
+	checksTotal, ok := metric.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	got := make(map[string]int64)
+	for _, point := range checksTotal.DataPoints {
+		got[metricLabel(t, point.Attributes, "result")] = point.Value
+	}
+	assert.Equal(t, map[string]int64{"ok": 1, "unknown": 1, "rpc_error": 1}, got)
 }
 
 func TestVGPUSentinelControllerProcessesSuccessAfterFailure(t *testing.T) {

--- a/lib/system/guest_agent/gpu_watch.go
+++ b/lib/system/guest_agent/gpu_watch.go
@@ -22,11 +22,11 @@ const (
 	kmsgPath          = "/dev/kmsg"
 	nvidiaPCIVendorID = "0x10de"
 
-	gpuProbeInterval = 15 * time.Second
-	gpuProbeTimeout  = 10 * time.Minute
-	// nvidia-smi can hang indefinitely on a wedged VF; without a per-attempt
-	// bound the overall probe deadline is never reached.
-	gpuProbeAttemptTimeout = 30 * time.Second
+	gpuProbeInterval    = 15 * time.Second
+	gpuProbeRetryWindow = 10 * time.Minute
+	// A slow attempt is killed after this delay. If it is stuck in
+	// uninterruptible I/O, the probe waits for it instead of starting another.
+	gpuProbeAttemptKillAfter = 30 * time.Second
 
 	kmsgReopenDelay = 5 * time.Second
 
@@ -139,12 +139,12 @@ func probeGPUInit(reporter *gpuInitReporter) {
 	if err != nil {
 		return
 	}
-	probeGPUInitUntil(reporter, time.Now().Add(gpuProbeTimeout), gpuProbeAttemptTimeout, gpuProbeInterval, func() error {
-		return runGPUProbeAttempt(nvidiaSMI, gpuProbeAttemptTimeout)
+	probeGPUInitUntil(reporter, time.Now().Add(gpuProbeRetryWindow), gpuProbeAttemptKillAfter, gpuProbeInterval, func() error {
+		return runGPUProbeAttempt(nvidiaSMI, gpuProbeAttemptKillAfter)
 	})
 }
 
-func probeGPUInitUntil(reporter *gpuInitReporter, deadline time.Time, attemptTimeout, interval time.Duration, attempt func() error) {
+func probeGPUInitUntil(reporter *gpuInitReporter, deadline time.Time, attemptKillAfter, interval time.Duration, attempt func() error) {
 	for {
 		err := attempt()
 		if err == nil {
@@ -152,17 +152,17 @@ func probeGPUInitUntil(reporter *gpuInitReporter, deadline time.Time, attemptTim
 			return
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
-			log.Printf("[guest-agent] GPU init probe attempt timed out after %s", attemptTimeout)
+			log.Printf("[guest-agent] GPU init probe attempt exceeded %s and was killed", attemptKillAfter)
 		}
 		if time.Now().After(deadline) {
-			log.Printf("[guest-agent] GPU init probe gave up after %s", gpuProbeTimeout)
+			log.Printf("[guest-agent] GPU init probe gave up after %s", gpuProbeRetryWindow)
 			return
 		}
 		time.Sleep(interval)
 	}
 }
 
-func runGPUProbeAttempt(nvidiaSMI string, timeout time.Duration) error {
+func runGPUProbeAttempt(nvidiaSMI string, killAfter time.Duration) error {
 	cmd := exec.Command(nvidiaSMI, "-L")
 	if err := cmd.Start(); err != nil {
 		return err
@@ -170,7 +170,7 @@ func runGPUProbeAttempt(nvidiaSMI string, timeout time.Duration) error {
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 
-	timer := time.NewTimer(timeout)
+	timer := time.NewTimer(killAfter)
 	defer timer.Stop()
 	select {
 	case err := <-done:

--- a/lib/system/guest_agent/gpu_watch_test.go
+++ b/lib/system/guest_agent/gpu_watch_test.go
@@ -138,7 +138,7 @@ func TestGPUInitReporterState(t *testing.T) {
 	assert.Empty(t, resp.FailureMessage)
 }
 
-func TestRunGPUProbeAttemptReturnsOnTimeout(t *testing.T) {
+func TestRunGPUProbeAttemptKillsAndReapsAfterDeadline(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nvidia-smi")
 	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexec sleep 10\n"), 0o755))
 


### PR DESCRIPTION
## Summary

- poll vGPU sentinel targets concurrently with a fixed limit so unreachable guests do not serialize the scan
- record low-cardinality sentinel check outcomes for coverage monitoring
- describe the GPU probe kill-and-reap behavior accurately

## Testing

Passed:

```bash
go test -race ./lib/system/guest_agent ./lib/guest ./lib/instances -run 'Test(VGPUSentinel|ListVGPUSentinel|ProbeGPUInit|RunGPUProbeAttempt|GPUInitReporter)' -count=1
go vet ./lib/system/guest_agent ./lib/guest ./lib/instances ./lib/devices ./lib/providers ./lib/resources
go test ./lib/devices ./lib/providers ./lib/resources
```

The full `lib/instances` race suite did not complete cleanly locally because its integration tests require additional host networking and image tooling and surfaced unrelated dependency races.
