### PR TITLE
Unify vGPU retention wrapping and dedupe test fixtures

### DIFF
--- a/lib/instances/create.go
+++ b/lib/instances/create.go
@@ -280,7 +280,8 @@ func (m *manager) createInstance(
 	var gpuAssignedAt *time.Time
 	retention := vgpuRetention{instanceID: id}
 
-	defer retention.deferWrapPending(&retErr)
+	// Deferred before cu.Clean so rollback records retention before this wraps the error.
+	defer func() { retErr = retention.wrapPending(retErr) }()
 	cu := cleanup.Make(func() {
 		log.DebugContext(ctx, "cleaning up instance on error", "instance_id", id)
 		m.persistVGPURetention(ctx, &retention)

--- a/lib/instances/start.go
+++ b/lib/instances/start.go
@@ -121,7 +121,8 @@ func (m *manager) startInstance(
 
 	// Setup cleanup stack for automatic rollback on errors
 	retention := vgpuRetention{instanceID: id}
-	defer retention.deferWrapPending(&retErr)
+	// Deferred before cu.Clean so rollback records retention before this wraps the error.
+	defer func() { retErr = retention.wrapPending(retErr) }()
 	cu := cleanup.Make(func() {})
 	defer cu.Clean()
 
@@ -177,20 +178,20 @@ func (m *manager) startInstance(
 		device, err := m.createVGPUDevice(ctx, stored.GPUProfile, id)
 		if err != nil {
 			log.ErrorContext(ctx, "failed to create vGPU", "instance_id", id, "profile", stored.GPUProfile, "error", err)
+			wrapped := fmt.Errorf("create vGPU for profile %s: %w", stored.GPUProfile, err)
 			if pendingDevice, ok := vgpuDevicePendingCleanup(err); ok {
-				assignedAt := m.nowUTC()
 				retentionMeta := rollbackMeta
-				setStoredVGPUDevice(&retentionMeta.StoredMetadata, pendingDevice, assignedAt)
-				wrapped := fmt.Errorf("create vGPU for profile %s: %w", stored.GPUProfile, err)
+				setStoredVGPUDevice(&retentionMeta.StoredMetadata, pendingDevice, m.nowUTC())
+				persisted := true
 				if saveErr := m.saveMetadata(&retentionMeta); saveErr != nil {
-					m.recordVGPURetainedAssignment(ctx, vgpuRetentionOperationStart, false)
 					log.ErrorContext(ctx, "failed to retain vGPU assignment after create rollback failure", "instance_id", id, "error", saveErr)
-					return nil, &VGPUCleanupPendingError{InstanceID: id, Err: fmt.Errorf("%w; retain assignment: %v", wrapped, saveErr)}
+					wrapped = fmt.Errorf("%w; retain assignment: %v", wrapped, saveErr)
+					persisted = false
 				}
-				m.recordVGPURetainedAssignment(ctx, vgpuRetentionOperationStart, true)
-				return nil, &VGPUCleanupPendingError{InstanceID: id, Retained: true, Err: wrapped}
+				retention.markRetained(persisted)
+				m.recordVGPURetainedAssignment(ctx, vgpuRetentionOperationStart, persisted)
 			}
-			return nil, fmt.Errorf("create vGPU for profile %s: %w", stored.GPUProfile, err)
+			return nil, wrapped
 		}
 		assignedAt := m.nowUTC()
 		setStoredVGPUDevice(stored, device, assignedAt)

--- a/lib/instances/vgpu_retention.go
+++ b/lib/instances/vgpu_retention.go
@@ -42,11 +42,6 @@ func (r *vgpuRetention) wrapPending(err error) error {
 	return &VGPUCleanupPendingError{InstanceID: r.instanceID, Retained: r.persisted, Err: err}
 }
 
-// Defer before cleanup so rollback records retention before this wraps the error.
-func (r *vgpuRetention) deferWrapPending(retErr *error) {
-	*retErr = r.wrapPending(*retErr)
-}
-
 func (m *manager) persistVGPURetention(ctx context.Context, retention *vgpuRetention) {
 	if retention.stub == nil {
 		m.deleteInstanceData(retention.instanceID)

--- a/lib/instances/vgpu_test.go
+++ b/lib/instances/vgpu_test.go
@@ -18,6 +18,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testVendorVFIODevice(profileName string) devices.VGPUDevice {
+	return devices.VGPUDevice{
+		Framework:   devices.VGPUFrameworkVendorVFIO,
+		VFAddress:   "0000:82:00.4",
+		ProfileType: "1148",
+		ProfileName: profileName,
+		SysfsPath:   "/sys/bus/pci/devices/0000:82:00.4",
+	}
+}
+
 func persistTestVGPURetention(m *manager, ctx context.Context, id string, stub *StoredMetadata) bool {
 	retention := vgpuRetention{instanceID: id, stub: stub, retained: stub != nil}
 	m.persistVGPURetention(ctx, &retention)
@@ -131,13 +141,8 @@ func newStartRollbackVGPUManager(t *testing.T, destroy func(context.Context, dev
 		instanceLocks:   sync.Map{},
 		bootMarkerScans: sync.Map{},
 		createVGPU: func(_ context.Context, profileName, _ string) (*devices.VGPUDevice, error) {
-			return &devices.VGPUDevice{
-				Framework:   devices.VGPUFrameworkVendorVFIO,
-				VFAddress:   "0000:82:00.4",
-				ProfileType: "1148",
-				ProfileName: profileName,
-				SysfsPath:   "/sys/bus/pci/devices/0000:82:00.4",
-			}, nil
+			device := testVendorVFIODevice(profileName)
+			return &device, nil
 		},
 		destroyVGPU: destroy,
 	}
@@ -180,13 +185,7 @@ func TestStartRetainsVGPUWhenCreateRollbackFails(t *testing.T) {
 	meta.ExitMessage = "previous exit"
 	require.NoError(t, m.saveMetadata(meta))
 
-	device := devices.VGPUDevice{
-		Framework:   devices.VGPUFrameworkVendorVFIO,
-		VFAddress:   "0000:82:00.4",
-		ProfileType: "1148",
-		ProfileName: "NVIDIA L40S-2Q",
-		SysfsPath:   "/sys/bus/pci/devices/0000:82:00.4",
-	}
+	device := testVendorVFIODevice("NVIDIA L40S-2Q")
 	cause := errors.New("create verification and rollback failed")
 	m.createVGPU = func(context.Context, string, string) (*devices.VGPUDevice, error) {
 		return nil, &devices.VGPUCreateCleanupPendingError{Device: device, Err: cause}
@@ -225,13 +224,7 @@ func TestStartReportsUnretainedVGPUWhenRetentionSaveFails(t *testing.T) {
 	m, id := newStartRollbackVGPUManager(t, func(context.Context, devices.VGPUAssignment) error {
 		return nil
 	})
-	device := devices.VGPUDevice{
-		Framework:   devices.VGPUFrameworkVendorVFIO,
-		VFAddress:   "0000:82:00.4",
-		ProfileType: "1148",
-		ProfileName: "NVIDIA L40S-2Q",
-		SysfsPath:   "/sys/bus/pci/devices/0000:82:00.4",
-	}
+	device := testVendorVFIODevice("NVIDIA L40S-2Q")
 	cause := errors.New("create verification and rollback failed")
 	m.createVGPU = func(context.Context, string, string) (*devices.VGPUDevice, error) {
 		instanceDir := filepath.Dir(m.paths.InstanceMetadata(id))


### PR DESCRIPTION
## Summary

Cleanup pass on the vendor VFIO vGPU lifecycle layer (#321), no behavior change:

- **One retention mechanism in start.** The start-path rollback for a failed vGPU create previously hand-built `VGPUCleanupPendingError` in two places instead of going through `vgpuRetention` like create does. The branch now records retention via `markRetained` and lets the existing deferred `wrapPending` produce the error, so the pending-error construction and the retained/unretained metric each live in one place. Error text, `Retained` flag, metric values, and wrapping order are unchanged.
- **Inlined `deferWrapPending`.** It was a one-line adapter around `wrapPending`; the ordering constraint it documented belongs at the two call sites, which now carry it.
- **Deduped test fixtures.** The identical 5-field vendor VFIO `VGPUDevice` literal appeared three times in `vgpu_test.go`; extracted `testVendorVFIODevice`.

Reviewed the rest of the diff for dead branches and redundant tests and deliberately left it alone: the per-callsite retention-stub rejection tests match the four independent guards, the reconcile tests each cover a distinct fail-closed path, and the `interface{ StartVGPUReconciler }` assertion in `cmd/api/main.go` follows the file's existing idiom for optional manager methods.

## Testing

- `go build ./...`, `go vet ./...` clean
- `go test -race` passes for `lib/devices`, `lib/hypervisor/qemu`, and the `lib/instances` vGPU/retention/reconcile/lifecycle suites
- `cmd/api/api` and `lib/instances` integration failures in this environment are identical on the unmodified base branch (network/hypervisor privileges), per-test diff verified