### PR TITLE
Hide consoles for desktop exec

### DIFF
--- a/lib/system/guest_agent/exec_desktop_windows.go
+++ b/lib/system/guest_agent/exec_desktop_windows.go
@@ -186,7 +186,7 @@ func startDesktopProcess(
 		ProcThreadAttributeList: attributes.List(),
 	}
 	processInfo := windows.ProcessInformation{}
-	flags := uint32(windows.CREATE_SUSPENDED | windows.CREATE_UNICODE_ENVIRONMENT | windows.EXTENDED_STARTUPINFO_PRESENT)
+	flags := uint32(windows.CREATE_SUSPENDED | windows.CREATE_UNICODE_ENVIRONMENT | windows.CREATE_NO_WINDOW | windows.EXTENDED_STARTUPINFO_PRESENT)
 	if err := windows.CreateProcessAsUser(
 		token,
 		nil,


### PR DESCRIPTION
## summary

- prevent non-interactive desktop exec commands from opening visible console windows
- retain redirected standard handles, process-tree cleanup, and active-desktop execution semantics

## why

Desktop exec already redirects standard input and output through the guest agent. Console-subsystem commands should therefore run without creating a window in the interactive session. GUI applications are unaffected by `CREATE_NO_WINDOW`.

## tests

- `make build-windows-guest-agent`
- `go test ./lib/system/guest_agent`
- full Linux, Darwin, Windows lifecycle, and install CI suites