### PR TITLE
feat(metrics): expose orphaned vGPU mdev gauge

### DIFF
--- a/lib/instances/metrics.go
+++ b/lib/instances/metrics.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kernel/hypeman/lib/devices"
 	"github.com/kernel/hypeman/lib/hypervisor"
 	mw "github.com/kernel/hypeman/lib/middleware"
 	hypotel "github.com/kernel/hypeman/lib/otel"
@@ -288,6 +289,14 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 		return nil, err
 	}
 
+	gpuMdevsTotal, err := meter.Int64ObservableGauge(
+		"hypeman_gpu_mdevs_total",
+		metric.WithDescription("Host vGPU mdev devices by whether an instance references them"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	snapshotCompressionActiveTotal, err := meter.Int64ObservableGauge(
 		"hypeman_snapshot_compression_active_total",
 		metric.WithDescription("Total number of actively running snapshot compression jobs"),
@@ -359,10 +368,19 @@ func newInstanceMetrics(meter metric.Meter, tracer trace.Tracer, m *manager) (*M
 				o.ObserveInt64(instancesTotal, count, metric.WithAttributes(attrs...))
 				o.ObserveFloat64(oldestInStateSeconds, oldestAgeSeconds[key], metric.WithAttributes(attrs...))
 			}
+
+			mdevs, err := devices.ListMdevDevices()
+			if err != nil || len(mdevs) == 0 {
+				return nil
+			}
+			claimed, orphaned := countGPUMdevs(mdevs, instances)
+			o.ObserveInt64(gpuMdevsTotal, claimed, metric.WithAttributes(attribute.String("state", "claimed")))
+			o.ObserveInt64(gpuMdevsTotal, orphaned, metric.WithAttributes(attribute.String("state", "orphaned")))
 			return nil
 		},
 		instancesTotal,
 		oldestInStateSeconds,
+		gpuMdevsTotal,
 	)
 	if err != nil {
 		return nil, err
@@ -682,4 +700,24 @@ func (m *manager) recordLifecycleEventDropped(ctx context.Context, consumer Life
 		attribute.String("consumer", string(consumer)),
 		attribute.String("reason", string(reason)),
 	))
+}
+
+// countGPUMdevs splits host mdevs into those referenced by an instance and
+// those no instance references. An unreferenced mdev holds a vGPU slot that
+// nothing will release until the next startup reconciliation.
+func countGPUMdevs(mdevs []devices.MdevDevice, instances []Instance) (claimed, orphaned int64) {
+	referenced := make(map[string]struct{}, len(instances))
+	for _, inst := range instances {
+		if inst.GPUMdevUUID != "" {
+			referenced[inst.GPUMdevUUID] = struct{}{}
+		}
+	}
+	for _, mdev := range mdevs {
+		if _, ok := referenced[mdev.UUID]; ok {
+			claimed++
+		} else {
+			orphaned++
+		}
+	}
+	return claimed, orphaned
 }

--- a/lib/instances/metrics_gpu_test.go
+++ b/lib/instances/metrics_gpu_test.go
@@ -1,0 +1,37 @@
+package instances
+
+import (
+	"testing"
+
+	"github.com/kernel/hypeman/lib/devices"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountGPUMdevs(t *testing.T) {
+	t.Parallel()
+
+	mdevs := []devices.MdevDevice{
+		{UUID: "claimed-running"},
+		{UUID: "claimed-stopped"},
+		{UUID: "orphaned-a"},
+		{UUID: "orphaned-b"},
+	}
+	instances := []Instance{
+		{StoredMetadata: StoredMetadata{GPUMdevUUID: "claimed-running"}, State: StateRunning},
+		{StoredMetadata: StoredMetadata{GPUMdevUUID: "claimed-stopped"}, State: StateStopped},
+		{StoredMetadata: StoredMetadata{GPUMdevUUID: "no-longer-on-host"}, State: StateStopped},
+		{State: StateRunning},
+	}
+
+	claimed, orphaned := countGPUMdevs(mdevs, instances)
+	assert.Equal(t, int64(2), claimed)
+	assert.Equal(t, int64(2), orphaned)
+
+	claimed, orphaned = countGPUMdevs(nil, instances)
+	assert.Equal(t, int64(0), claimed)
+	assert.Equal(t, int64(0), orphaned)
+
+	claimed, orphaned = countGPUMdevs(mdevs, nil)
+	assert.Equal(t, int64(0), claimed)
+	assert.Equal(t, int64(4), orphaned)
+}

--- a/lib/otel/README.md
+++ b/lib/otel/README.md
@@ -100,6 +100,7 @@ This keeps pull and push views aligned because both are sourced from the same OT
 | `hypeman_resources_image_storage_bytes` | gauge | kind | Current and maximum image storage bytes |
 | `hypeman_resources_gpu_slots` | gauge | kind | Total and used GPU slots |
 | `hypeman_resources_gpu_profile_slots` | gauge | profile, kind | Available GPU slots by profile |
+| `hypeman_gpu_mdevs_total` | gauge | state | Host vGPU mdevs that an instance references (`claimed`) or that nothing references (`orphaned`) |
 
 ### Volumes
 | Metric | Type | Description |


### PR DESCRIPTION
## Summary

Adds a `hypeman_gpu_mdevs_total` gauge with `state="claimed"` and `state="orphaned"`, emitted from the existing instance metrics callback on hosts that have mdevs present.

- `claimed`: mdevs under `/sys/bus/mdev/devices` whose UUID matches the `GPUMdevUUID` stored on some instance.
- `orphaned`: mdevs no instance references. Each one holds a vGPU slot that nothing will release until `ReconcileMdevs` runs at the next API startup.

## Why

Leaked mdevs are currently only visible by subtracting used GPU slots from a count of running instances on a dashboard. That derivation has to guess which instances are GPU-backed (there is no `gpu` label on `hypeman_instances_total`), hardcodes host capacity, and mixes two gauges that are scraped at different instants, so it jitters and can't be alerted on. This gauge answers the question directly from one snapshot, using the same definition the startup reconciliation applies.

## Notes

- The series is only emitted when the host has at least one mdev, matching how `hypeman_resources_gpu_slots` is gated on GPU presence. Dashboards should use `or vector(0)` if they want a flat line on idle GPU hosts; an alert on `> 0` works as-is.
- Instances in any state count as owners. A stopped instance that retained its assignment after a failed release is a tracked retry, not an orphan.
- `ListMdevDevices` is a directory read plus a couple of readlinks per mdev, bounded by the VF count, so per-collect cost is negligible.

## Testing

- `go vet ./lib/instances/` on linux and `GOOS=darwin` cross-vet.
- `go test ./lib/instances/ -run 'TestCountGPUMdevs|Metric'` passes, including the new unit test for the claimed/orphaned split.
- Not exercised on a live vGPU host from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)