### PR TITLE
Fix flaky netlink and overlay cleanup tests

### DIFF
--- a/lib/instances/volumes_test.go
+++ b/lib/instances/volumes_test.go
@@ -299,9 +299,9 @@ func TestOverlayDiskCleanupOnDelete(t *testing.T) {
 	_, err = os.Stat(overlayDisk)
 	require.NoError(t, err, "overlay disk file should exist after instance creation")
 
-	// Delete the instance
-	err = manager.DeleteInstance(ctx, inst.Id)
-	require.NoError(t, err)
+	// Delete the instance. Hypervisor teardown can outlast the first delete
+	// attempt on a busy CI host.
+	deleteInstanceEventually(t, ctx, manager, inst.Id)
 
 	// Verify instance directory is removed (which includes vol-overlays/)
 	instanceDir := p.InstanceDir(inst.Id)

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -51,6 +51,22 @@ func listBridgeAddrsWithRetry(link netlink.Link) ([]netlink.Addr, error) {
 	return nil, err
 }
 
+func listLinksWithRetry() ([]netlink.Link, error) {
+	var err error
+	for i := 0; i < netlinkDumpRetryCount; i++ {
+		links, listErr := netlink.LinkList()
+		if listErr == nil {
+			return links, nil
+		}
+		if !errors.Is(listErr, netlink.ErrDumpInterrupted) {
+			return nil, listErr
+		}
+		err = listErr
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil, err
+}
+
 // checkSubnetConflicts checks if the configured subnet conflicts with existing routes.
 // Returns an error if a conflict is detected, with guidance on how to resolve it.
 func (m *manager) checkSubnetConflicts(ctx context.Context, subnet string) error {
@@ -1170,7 +1186,7 @@ func (m *manager) CleanupOrphanedTAPs(ctx context.Context, preserveInstanceIDs [
 	}
 
 	// List all network interfaces
-	links, err := netlink.LinkList()
+	links, err := listLinksWithRetry()
 	if err != nil {
 		log.WarnContext(ctx, "failed to list network links for TAP cleanup", "error", err)
 		return 0
@@ -1259,7 +1275,7 @@ func (m *manager) CleanupOrphanedClasses(ctx context.Context) int {
 	}
 
 	liveTapIndexes := make(map[int]bool)
-	links, err := netlink.LinkList()
+	links, err := listLinksWithRetry()
 	if err != nil {
 		log.WarnContext(ctx, "skipping orphaned tc cleanup: failed to list links", "error", err)
 		return 0

--- a/skills/test-agent/agents/test-agent/NOTES.md
+++ b/skills/test-agent/agents/test-agent/NOTES.md
@@ -528,3 +528,23 @@
   - Run 1: `356s`
   - Run 2: `423s`
   - Run 3: `458s`
+
+## 2026-09-02 - Overlay disk cleanup deletion flake
+
+### Flake signature
+- PR CI failed `TestOverlayDiskCleanupOnDelete` during `manager.DeleteInstance`.
+- The delete path returned `kill hypervisor: hypervisor pid ... did not exit after SIGKILL` after the process teardown budget elapsed, leaving the instance metadata in place for a retry.
+
+### Root cause
+- The test made one direct delete call even though the delete contract intentionally retains metadata when hypervisor death cannot be confirmed and supports a safe retry.
+
+### Fix
+- Changed the test to use the existing `deleteInstanceEventually` helper, which retries deletion until the retained instance metadata can be removed.
+
+### Validation
+- Targeted `TestOverlayDiskCleanupOnDelete` passed 5 times on the Linux KVM runner.
+- Full no-cache Linux suite passed three consecutive times after the change:
+  - Run 4: `269s`
+  - Run 5: `488s`
+  - Run 6: `421s`
+- An earlier post-change full run failed on the separate, reproducible `TestSocketCacheKeyChangesWhenSocketIsRecreated` test; that issue is outside this change.

--- a/skills/test-agent/agents/test-agent/NOTES.md
+++ b/skills/test-agent/agents/test-agent/NOTES.md
@@ -506,3 +506,25 @@
   - Run 2: `443s`
   - Run 3: `369s`
 - Full command used `go test -count=1 -tags containers_image_openpgp -timeout=20m ./...` with the CI prewarm directory, registry mirror, reflink strict mode, and `/ci` scratch path.
+
+## 2026-09-02 - Current main network cleanup flake
+
+### Flake signature
+- Main Linux CI failed `TestCreateInstanceWithNetwork` while validating orphaned bridge tc cleanup.
+- The test created a live and stale tc class/filter pair, then observed `CleanupOrphanedClasses` return `0` instead of at least `2`.
+- The surrounding CI log reported `skipping orphaned tc cleanup: failed to list links error="results may be incomplete or inconsistent"`.
+
+### Root cause
+- `netlink.LinkList` can return `netlink.ErrDumpInterrupted` while parallel tests are creating and deleting TAP devices. `CleanupOrphanedClasses` treated that transient, incomplete dump as a permanent cleanup skip, making the test assertion fail.
+
+### Fix
+- Added bounded retry handling for interrupted netlink link dumps.
+- Applied it to both orphaned tc-class cleanup and orphaned TAP cleanup.
+
+### Validation
+- `go test ./lib/network` passed locally after the change.
+- Targeted `TestCreateInstanceWithNetwork` passed 5 times on the Linux KVM runner.
+- Full no-cache Linux suite passed three consecutive times after the change:
+  - Run 1: `356s`
+  - Run 2: `423s`
+  - Run 3: `458s`


### PR DESCRIPTION
## summary

Fixes two flaky Linux cleanup tests found by the test-agent:

- retry interrupted netlink link dumps during orphaned TAP and traffic-control cleanup
- use the existing bounded deletion helper in `TestOverlayDiskCleanupOnDelete` so the test tolerates hypervisor teardown completing after the first delete attempt

## testing

- `go test ./lib/network`
- `TestCreateInstanceWithNetwork` passed 5 times
- `TestOverlayDiskCleanupOnDelete` passed 5 times
- full no-cache Linux suite passed 3 consecutive times (269s, 488s, 421s)
