### PR TITLE
Wait for the dpkg lock before installing test dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
              ! command -v swtpm &> /dev/null || \
              ! test -d /usr/share/OVMF; then
             apt_update_with_retry
-            timeout 300s sudo apt-get install -y erofs-utils e2fsprogs iptables ovmf qemu-system-x86 qemu-utils swtpm
+            timeout 600s sudo apt-get -o DPkg::Lock::Timeout=300 install -y erofs-utils e2fsprogs iptables ovmf qemu-system-x86 qemu-utils swtpm
           fi
           if test -f /usr/share/OVMF/OVMF_CODE_4M.secboot.fd && test -f /usr/share/OVMF/OVMF_VARS_4M.ms.fd; then
             ovmf_code=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd


### PR DESCRIPTION
## summary

The `Install dependencies` step in the test workflow runs `apt-get install` on a shared self-hosted runner. When another job holds the dpkg frontend lock at that moment, apt fails immediately with exit 100 and the whole job is lost.

Pass `-o DPkg::Lock::Timeout=300` so apt waits for the lock instead of failing, and widen the surrounding `timeout` so the wait cannot be cut off.

## validation

Workflow-only change; no code affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only tweak to apt install behavior on shared runners; no product code or secrets handling affected.
> 
> **Overview**
> The Linux **Install dependencies** step on self-hosted runners no longer fails immediately when another job holds the dpkg frontend lock.
> 
> `apt-get install` now passes **`-o DPkg::Lock::Timeout=300`** so apt waits up to five minutes for the lock instead of exiting with code 100. The outer **`timeout`** on that install was raised from **300s to 600s** so a full lock wait plus install is not cut off early.
> 
> No application code changes—CI reliability only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec372804e96e3ab3400d8f7469a5a8f319533cd2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->