### PR TITLE
Harden guest TAP bridge ports against cross-guest frame leakage

### DIFF
--- a/lib/network/allocate.go
+++ b/lib/network/allocate.go
@@ -59,7 +59,7 @@ func (m *manager) CreateAllocation(ctx context.Context, req AllocateRequest) (*N
 		attribute.Bool("download_rate_limit", req.DownloadBps > 0),
 		attribute.Bool("upload_rate_limit", req.UploadBps > 0),
 	)
-	err = m.createTAPDevice(tapCtx, netConfig.TAPDevice, network.Bridge, network.Isolated)
+	err = m.createTAPDevice(tapCtx, netConfig.TAPDevice, network.Bridge, netConfig.MAC, network.Isolated)
 	tapSpanEnd(err)
 	if err != nil {
 		cleanupErr := m.deleteTAPDeviceForInstanceSerialized(ctx, req.InstanceID, netConfig.TAPDevice)
@@ -143,7 +143,7 @@ func (m *manager) RecreateAllocation(ctx context.Context, instanceID string, dow
 		attribute.Bool("download_rate_limit", downloadBps > 0),
 		attribute.Bool("upload_rate_limit", uploadBps > 0),
 	)
-	err = m.createTAPDevice(tapCtx, alloc.TAPDevice, network.Bridge, network.Isolated)
+	err = m.createTAPDevice(tapCtx, alloc.TAPDevice, network.Bridge, alloc.MAC, network.Isolated)
 	tapSpanEnd(err)
 	if err != nil {
 		_ = m.deleteTAPDeviceForInstanceSerialized(ctx, instanceID, alloc.TAPDevice)

--- a/lib/network/bridge_darwin.go
+++ b/lib/network/bridge_darwin.go
@@ -36,7 +36,7 @@ func (m *manager) setupBridgeHTB(ctx context.Context, bridgeName string, capacit
 
 // createTAPDevice is a no-op on macOS as we use NAT networking.
 // Virtualization.framework creates virtual network interfaces internally.
-func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName string, isolated bool) error {
+func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName, mac string, isolated bool) error {
 	// On macOS with vz, network devices are created by the VMM itself
 	return nil
 }

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -613,55 +613,65 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName, mac 
 			return fmt.Errorf("set isolation mode: %w", err)
 		}
 
-		// Isolation only stops guest-to-guest forwarding. Frames arriving from
-		// the uplink for a MAC the bridge has forgotten (aged out, or a guest
-		// that was just torn down) are still flooded to every port, so one
-		// guest can sniff traffic addressed to another. Pin the guest MAC to
-		// its port and turn off flooding and learning on the port so delivery
-		// never depends on flooding and a guest can't move FDB entries by
-		// spoofing a source MAC.
-		_, floodEnd := startNetworkStep(ctx, "network.create_tap.set_flood_off",
-			attribute.String("operation", "set_flood_off"),
-			attribute.String("tap", tapName),
-		)
-		err = netlink.LinkSetFlood(tapLink, false)
-		floodEnd(err)
-		if err != nil {
-			return fmt.Errorf("disable unicast flooding: %w", err)
-		}
-
-		_, learningEnd := startNetworkStep(ctx, "network.create_tap.set_learning_off",
-			attribute.String("operation", "set_learning_off"),
-			attribute.String("tap", tapName),
-		)
-		err = netlink.LinkSetLearning(tapLink, false)
-		learningEnd(err)
-		if err != nil {
-			return fmt.Errorf("disable MAC learning: %w", err)
-		}
-
-		var fdbEntry *netlink.Neigh
-		fdbEntry, err = guestFDBEntry(tapLink.Attrs().Index, mac)
-		if err != nil {
+		if err := hardenIsolatedPort(ctx, tapLink, tapName, mac); err != nil {
 			return err
-		}
-		_, fdbEnd := startNetworkStep(ctx, "network.create_tap.add_fdb_entry",
-			attribute.String("operation", "add_fdb_entry"),
-			attribute.String("tap", tapName),
-			attribute.String("mac", mac),
-		)
-		err = netlink.NeighAppend(fdbEntry)
-		fdbEnd(err)
-		if err != nil {
-			return fmt.Errorf("add static FDB entry: %w", err)
 		}
 	}
 
 	return nil
 }
 
+// hardenIsolatedPort keeps an isolated guest from seeing its neighbours'
+// traffic. Isolation only stops guest-to-guest forwarding: frames arriving
+// from the uplink for a MAC the bridge has forgotten (aged out, or a guest
+// that was just torn down) are still flooded to every port. Pinning the guest
+// MAC to its own port makes inbound delivery independent of flooding, so
+// flooding can be turned off; turning learning off then stops a guest from
+// relocating FDB entries by spoofing a source MAC.
+func hardenIsolatedPort(ctx context.Context, tapLink netlink.Link, tapName, mac string) error {
+	// Built before the port is touched so a malformed MAC can't leave the port
+	// with flooding off and nothing pinned to it.
+	fdbEntry, err := guestFDBEntry(tapLink.Attrs().Index, mac)
+	if err != nil {
+		return err
+	}
+
+	_, fdbEnd := startNetworkStep(ctx, "network.create_tap.add_fdb_entry",
+		attribute.String("operation", "add_fdb_entry"),
+		attribute.String("tap", tapName),
+		attribute.String("mac", mac),
+	)
+	err = netlink.NeighSet(fdbEntry)
+	fdbEnd(err)
+	if err != nil {
+		return fmt.Errorf("add static FDB entry: %w", err)
+	}
+
+	_, floodEnd := startNetworkStep(ctx, "network.create_tap.set_flood_off",
+		attribute.String("operation", "set_flood_off"),
+		attribute.String("tap", tapName),
+	)
+	err = netlink.LinkSetFlood(tapLink, false)
+	floodEnd(err)
+	if err != nil {
+		return fmt.Errorf("disable unicast flooding: %w", err)
+	}
+
+	_, learningEnd := startNetworkStep(ctx, "network.create_tap.set_learning_off",
+		attribute.String("operation", "set_learning_off"),
+		attribute.String("tap", tapName),
+	)
+	err = netlink.LinkSetLearning(tapLink, false)
+	learningEnd(err)
+	if err != nil {
+		return fmt.Errorf("disable MAC learning: %w", err)
+	}
+
+	return nil
+}
+
 // guestFDBEntry builds the permanent bridge FDB entry that pins a guest MAC to
-// its TAP port. Equivalent to `bridge fdb add <mac> dev <tap> master permanent`.
+// its TAP port. Equivalent to `bridge fdb replace <mac> dev <tap> master permanent`.
 func guestFDBEntry(tapIndex int, mac string) (*netlink.Neigh, error) {
 	hwAddr, err := net.ParseMAC(mac)
 	if err != nil {

--- a/lib/network/bridge_linux.go
+++ b/lib/network/bridge_linux.go
@@ -521,7 +521,7 @@ func (m *manager) lastHypemanForwardRulePosition() int {
 }
 
 // createTAPDevice creates TAP device and attaches it to the bridge.
-func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName string, isolated bool) error {
+func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName, mac string, isolated bool) error {
 	// 1. Check if TAP already exists
 	_, linkLookupEnd := startNetworkStep(ctx, "network.create_tap.link_lookup_existing",
 		attribute.String("operation", "link_lookup_existing"),
@@ -612,9 +612,68 @@ func (m *manager) createTAPDevice(ctx context.Context, tapName, bridgeName strin
 		if err != nil {
 			return fmt.Errorf("set isolation mode: %w", err)
 		}
+
+		// Isolation only stops guest-to-guest forwarding. Frames arriving from
+		// the uplink for a MAC the bridge has forgotten (aged out, or a guest
+		// that was just torn down) are still flooded to every port, so one
+		// guest can sniff traffic addressed to another. Pin the guest MAC to
+		// its port and turn off flooding and learning on the port so delivery
+		// never depends on flooding and a guest can't move FDB entries by
+		// spoofing a source MAC.
+		_, floodEnd := startNetworkStep(ctx, "network.create_tap.set_flood_off",
+			attribute.String("operation", "set_flood_off"),
+			attribute.String("tap", tapName),
+		)
+		err = netlink.LinkSetFlood(tapLink, false)
+		floodEnd(err)
+		if err != nil {
+			return fmt.Errorf("disable unicast flooding: %w", err)
+		}
+
+		_, learningEnd := startNetworkStep(ctx, "network.create_tap.set_learning_off",
+			attribute.String("operation", "set_learning_off"),
+			attribute.String("tap", tapName),
+		)
+		err = netlink.LinkSetLearning(tapLink, false)
+		learningEnd(err)
+		if err != nil {
+			return fmt.Errorf("disable MAC learning: %w", err)
+		}
+
+		var fdbEntry *netlink.Neigh
+		fdbEntry, err = guestFDBEntry(tapLink.Attrs().Index, mac)
+		if err != nil {
+			return err
+		}
+		_, fdbEnd := startNetworkStep(ctx, "network.create_tap.add_fdb_entry",
+			attribute.String("operation", "add_fdb_entry"),
+			attribute.String("tap", tapName),
+			attribute.String("mac", mac),
+		)
+		err = netlink.NeighAppend(fdbEntry)
+		fdbEnd(err)
+		if err != nil {
+			return fmt.Errorf("add static FDB entry: %w", err)
+		}
 	}
 
 	return nil
+}
+
+// guestFDBEntry builds the permanent bridge FDB entry that pins a guest MAC to
+// its TAP port. Equivalent to `bridge fdb add <mac> dev <tap> master permanent`.
+func guestFDBEntry(tapIndex int, mac string) (*netlink.Neigh, error) {
+	hwAddr, err := net.ParseMAC(mac)
+	if err != nil {
+		return nil, fmt.Errorf("parse guest MAC %q: %w", mac, err)
+	}
+	return &netlink.Neigh{
+		LinkIndex:    tapIndex,
+		Family:       unix.AF_BRIDGE,
+		State:        netlink.NUD_PERMANENT,
+		Flags:        netlink.NTF_MASTER,
+		HardwareAddr: hwAddr,
+	}, nil
 }
 
 // applyDownloadRateLimit applies download (external→VM) rate limiting using TBF on TAP egress.

--- a/lib/network/bridge_linux_test.go
+++ b/lib/network/bridge_linux_test.go
@@ -3,6 +3,9 @@
 package network
 
 import (
+	"context"
+	"os"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,4 +88,63 @@ func TestGuestFDBEntry(t *testing.T) {
 func TestGuestFDBEntryRejectsBadMAC(t *testing.T) {
 	_, err := guestFDBEntry(42, "not-a-mac")
 	assert.Error(t, err)
+}
+
+// TestHardenIsolatedPortOnRealBridge exercises the netlink calls against a real
+// bridge, which is the only way to catch a request the kernel rejects.
+func TestHardenIsolatedPortOnRealBridge(t *testing.T) {
+	const mac = "02:00:00:aa:bb:cc"
+	tap := bridgedTAPForTest(t, "brhardn0", "taphardn0")
+
+	require.NoError(t, hardenIsolatedPort(context.Background(), tap, tap.Name, mac))
+
+	protinfo, err := netlink.LinkGetProtinfo(tap)
+	require.NoError(t, err)
+	assert.False(t, protinfo.Flood, "unicast flooding should be off")
+	assert.False(t, protinfo.Learning, "MAC learning should be off")
+
+	entries, err := netlink.NeighList(tap.Attrs().Index, unix.AF_BRIDGE)
+	require.NoError(t, err)
+	pinned := slices.IndexFunc(entries, func(n netlink.Neigh) bool {
+		return n.HardwareAddr.String() == mac
+	})
+	require.NotEqual(t, -1, pinned, "guest MAC should be pinned to the TAP port")
+	assert.Equal(t, netlink.NUD_PERMANENT, entries[pinned].State)
+}
+
+// TestHardenIsolatedPortLeavesPortAloneOnBadMAC covers the case where the
+// allocation carries a MAC we can't parse: the port keeps its defaults rather
+// than ending up with flooding off and nothing pinned to it.
+func TestHardenIsolatedPortLeavesPortAloneOnBadMAC(t *testing.T) {
+	tap := bridgedTAPForTest(t, "brhardn1", "taphardn1")
+
+	require.Error(t, hardenIsolatedPort(context.Background(), tap, tap.Name, ""))
+
+	protinfo, err := netlink.LinkGetProtinfo(tap)
+	require.NoError(t, err)
+	assert.True(t, protinfo.Flood, "flooding should be untouched")
+	assert.True(t, protinfo.Learning, "learning should be untouched")
+}
+
+// bridgedTAPForTest creates a throwaway bridge with one TAP enslaved to it, and
+// skips the test when it can't (creating links needs root).
+func bridgedTAPForTest(t *testing.T, bridgeName, tapName string) *netlink.Tuntap {
+	t.Helper()
+	if os.Getuid() != 0 {
+		t.Skip("Skipping test that requires root")
+	}
+
+	bridge := &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: bridgeName}}
+	require.NoError(t, netlink.LinkAdd(bridge))
+	t.Cleanup(func() { _ = netlink.LinkDel(bridge) })
+
+	tap := &netlink.Tuntap{
+		LinkAttrs: netlink.LinkAttrs{Name: tapName},
+		Mode:      netlink.TUNTAP_MODE_TAP,
+	}
+	require.NoError(t, netlink.LinkAdd(tap))
+	t.Cleanup(func() { _ = netlink.LinkDel(tap) })
+	require.NoError(t, netlink.LinkSetMaster(tap, bridge))
+
+	return tap
 }

--- a/lib/network/bridge_linux_test.go
+++ b/lib/network/bridge_linux_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 func TestParseBridgeFilters(t *testing.T) {
@@ -65,4 +68,21 @@ func TestPlanOrphanedBridgeTCBailsWhenNoRTIIFParses(t *testing.T) {
 	assert.False(t, safe)
 	assert.Nil(t, staleFilters)
 	assert.Nil(t, staleClasses)
+}
+
+func TestGuestFDBEntry(t *testing.T) {
+	entry, err := guestFDBEntry(42, "02:00:00:aa:bb:cc")
+	require.NoError(t, err)
+
+	assert.Equal(t, 42, entry.LinkIndex)
+	assert.Equal(t, unix.AF_BRIDGE, entry.Family)
+	assert.Equal(t, netlink.NUD_PERMANENT, entry.State)
+	assert.Equal(t, netlink.NTF_MASTER, entry.Flags)
+	assert.Equal(t, "02:00:00:aa:bb:cc", entry.HardwareAddr.String())
+	assert.Nil(t, entry.IP)
+}
+
+func TestGuestFDBEntryRejectsBadMAC(t *testing.T) {
+	_, err := guestFDBEntry(42, "not-a-mac")
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Guest VMs on a shared bridge can passively capture unicast frames addressed to other guests. Port isolation is already enabled on isolated networks, but it only blocks guest-to-guest forwarding: when the bridge has no FDB entry for a destination MAC (aged out, or a guest that was just deleted while upstream packets were still in flight), it floods the frame to **every** port, including other guests' TAPs. A guest with a raw socket sees those frames.

This applies the standard multi-tenant bridge-port hardening to each guest TAP on isolated networks, right after isolation is set:

| step | effect |
|---|---|
| permanent FDB entry (`bridge fdb replace <mac> dev <tap> master permanent`) | inbound delivery to the guest never depends on flooding, and learning cannot relocate the entry |
| `LinkSetFlood(tap, false)` | unknown-unicast frames are never flooded to the guest port |
| `LinkSetLearning(tap, false)` | a guest cannot poison the FDB by spoofing a source MAC (which could blackhole or misdirect neighbours' traffic) |

The three steps live in `hardenIsolatedPort`. The FDB entry is built (and the MAC parsed) before the port is touched, so an unparseable MAC leaves the port at its defaults rather than flooding-off with nothing pinned to it.

`createTAPDevice` now takes the allocated guest MAC; both call sites (`CreateAllocation`, `RecreateAllocation`) already had it. Only isolated networks are affected — non-isolated networks keep their current behaviour.

## Notes for review

- **Learning-off is the one step with blast radius.** With every guest MAC pinned statically it is safe, but it means a guest that changes its own MAC in-guest loses inbound until it changes back. That is an unsupported configuration, and it is what closes the FDB-poisoning vector, so I kept it — happy to drop it to a follow-up if you'd rather land flood-off + static FDB first.
- Failures in the new steps fail TAP creation, matching how the existing isolation step behaves.
- FDB entries are per-port and are removed by the kernel when the TAP is deleted, so no cleanup path was needed; TAP GC is unaffected.
- The entry is installed with `NeighSet` (`NLM_F_REPLACE`) rather than `NeighAppend`: `NLM_F_APPEND` carries multi-destination semantics, and replace is the idempotent primitive for pinning a single unicast MAC. `NeighAdd` (`NLM_F_EXCL`) is wrong here — it returns `EEXIST` if the MAC is still pinned to a stale port.
- Broadcast and multicast flooding are deliberately left on (`bcast_flood` / `mcast_flood`), so DHCP and ND still work. Guests can therefore still observe broadcast ARP from the uplink; suppressing that (`neigh_suppress`) is a separate change.

## Testing

- `go vet ./lib/network/` on linux, and `GOOS=darwin go vet ./lib/network/` for the stub — both clean.
- `go test ./lib/network/` passes.
- **Exercised against a real bridge.** `TestHardenIsolatedPortOnRealBridge` and `TestHardenIsolatedPortLeavesPortAloneOnBadMAC` create an actual bridge and enslaved TAP and assert the resulting port state, so the netlink requests themselves are covered rather than just the entry builder. They skip when not root, following the existing convention for privileged tests in this repo. Run as root on kernel 6.12:
  - `flood off` / `learning off` read back via `LinkGetProtinfo`
  - the guest MAC present in `NeighList(tap, AF_BRIDGE)` as `NUD_PERMANENT`
  - on an unparseable MAC, `flood on` / `learning on` — the port is untouched
  - both tests clean up their links, verified with `ip -br link` afterwards
- `TestGuestFDBEntry` / `TestGuestFDBEntryRejectsBadMAC` still cover the pure entry builder.
- `go build ./...` reports three `//go:embed` errors for downloaded binaries; identical on `main` (pre-existing, unrelated).
